### PR TITLE
Add anchor links to headings, tidy up HTML and Sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+*.iml
+.idea/

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -1,0 +1,8 @@
+<script type="text/javascript">
+    $('h1, h2, h3, h4, h5, h6').filter('[id]').each(function () {
+        var el = document.createElement('a')
+        el.className = 'anchor'
+        el.href = '#' + this.id;
+        this.prepend(el)
+    });
+</script>

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -63,8 +63,14 @@
           </a>  
         </div>
         </section>
-
     </div>
+
+    <footer>
+      <div>
+        <span class="credits left">Project maintained by <a href="{{ site.url }}">{{ site.github_username }}</a></span>
+        <span class="credits right">Theme: modified version of <a href="https://github.com/pages-themes/midnight/">midnight</a></span>
+      </div>
+    </footer>
 
     {% if site.google_analytics %}
       <script>
@@ -77,11 +83,6 @@
       </script>
     {% endif %}
 
-    <footer>
-      <div>
-        <span class="credits left">Project maintained by <a href="{{ site.url }}">{{ site.github_username }}</a></span>
-        <span class="credits right">Theme: modified version of <a href="https://github.com/pages-themes/midnight/">midnight</a></span>
-      </div>
-    </footer>
+    {% include script.html %}
   </body>
 </html>

--- a/_layouts/command.html
+++ b/_layouts/command.html
@@ -36,6 +36,12 @@
 
     </div>
 
+    <footer>
+      <div class="centered">
+        If you found an error in this command documentation or want to adapt it <a href="https://github.com/nushell/nushell/blob/master/docs/commands/{{page.title}}.md">please go here</a>
+      </div>
+    </footer>
+
     {% if site.google_analytics %}
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -46,12 +52,7 @@
         ga('send', 'pageview');
       </script>
     {% endif %}
+    
+    {% include script.html %}
   </body>
-
-  <footer>
-    <div class="centered">
-      If you found an error in this command documentation or want to adapt it <a href="https://github.com/nushell/nushell/blob/master/docs/commands/{{page.title}}.md">please go here</a>
-    </div>
-</footer>
-  
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,9 +19,9 @@
 
   </head>
   <body>
-      <div id="header">
-            {% include navigation.html current="index" %}
-      </div><!-- end header -->
+    <div id="header">
+      {% include navigation.html current="index" %}
+    </div><!-- end header -->
 
     <div class="wrapper">
 
@@ -32,10 +32,15 @@
         </div>
 
         {{ content }}
-
       </section>
 
     </div>
+
+    <footer>
+      <div class="centered">
+        If you have suggestions or want to change something please give us <a href="https://github.com/nushell/nushell.github.io">feedback</a>
+      </div>
+    </footer>
 
     {% if site.google_analytics %}
       <script>
@@ -48,11 +53,7 @@
       </script>
     {% endif %}
 
-    <footer>
-      <div class="centered">
-        If you have suggestions or want to change something please give us <a href="https://github.com/nushell/nushell.github.io">feedback</a>
-      </div>
-  </footer>
+    {% include script.html %}
 
   </body>
 </html>

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -36,6 +36,12 @@
 
     </div>
 
+    <footer>
+      <div class="centered">
+        If you have suggestions or want to change something please give us <a href="https://github.com/nushell/nushell.github.io">feedback</a>
+      </div>
+    </footer>
+
     {% if site.google_analytics %}
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -46,12 +52,7 @@
         ga('send', 'pageview');
       </script>
     {% endif %}
-  </body>
 
-  <footer>
-    <div class="centered">
-      If you have suggestions or want to change something please give us <a href="https://github.com/nushell/nushell.github.io">feedback</a>
-    </div>
-</footer>
-  
+    {% include script.html %}
+  </body>
 </html>

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -18,17 +18,18 @@ body {
 h1, h2, h3, h4, h5, h6 {
   //color:#e8e8e8;
   color: #242424;
-  margin: 0 0 10px;
+  margin: -60px 0 10px;
+  padding-top: 60px;
   font-weight: normal;
 }
 
-p, ul, ol, table, pre, dl {
-  margin:0 0 20px;
+p, ul, ol, table, pre, dl, blockquote {
+  margin: 0 0 20px;
 }
 
 h1, h2, h3 {
   line-height: 1.3em;
-  margin: 1em 0 0.5em 0;
+  margin: -50px 0 0.5em 0;
 }
 
 h1 {
@@ -47,6 +48,7 @@ h3 {
 h4, h5, h6 {
   color: #242424;
   font-weight: bold;
+  margin: -55px 0 0.5em 0;
 }
 
 a {

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -2,22 +2,32 @@
 @import "fonts";
 @import "rouge-base16-dark.scss";
 
+$text-dark: #242424;
+$text-light: #585858;
+
+$green-dark: #418305;
+$green-medium: #5bb006;
+
+$green-bright: #51cd28;
+$green-brighter: #69ff33;
+
+
 body {
-  padding:0px 0 20px 0px;
-  margin: 0px;
+  padding: 0 0 20px 0;
+  margin: 0;
   font:18px/1.5 "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   //color: #f0e7d5
-  color:#585858;
+  color: $text-light;
   font-weight: normal;
   //background: #252525;
   background: #ffffff;
-  background-attachment: fixed !important;
+  //background-attachment: fixed !important;
   //background: linear-gradient(#2a2a29, #1c1c1c);
 }
 
 h1, h2, h3, h4, h5, h6 {
   //color:#e8e8e8;
-  color: #242424;
+  color: $text-dark;
   margin: -60px 0 10px;
   padding-top: 60px;
   font-weight: normal;
@@ -42,27 +52,25 @@ h2 {
 
 h3 {
   font-size: 1.45em;
-  color: #535353;
+  color: $text-light;
 }
 
 h4, h5, h6 {
-  color: #242424;
+  color: $text-dark;
   font-weight: bold;
   margin: -55px 0 0.5em 0;
 }
 
 a {
-  color:#418305;
-  font-weight:400;
+  color: $green-dark;
   text-decoration:none;
   font-weight: bold;
 
   &:hover {
-    color: #60c007;
+    color: $green-medium;
   }
-
   &:focus {
-    color: #60c007;
+    color: $green-medium;
     outline: none;
   }
 }
@@ -70,8 +78,8 @@ a {
 a.anchor {
   display: none;
   position: absolute;
-  margin: -70px 0 -10px -40px;
-  padding: 70px 0 10px 0;
+  margin: -10px 0 -10px -40px;
+  padding: 10px 0 10px 0;
   width: 40px;
   opacity: 0.6;
 
@@ -81,7 +89,7 @@ a.anchor {
 
   &::before {
     content: '🔗';
-    color: #bbb;
+    color: #999;
     font-size: 19px;
     vertical-align: bottom;
   }
@@ -100,17 +108,15 @@ a small {
   display:block;
 }
 
-ul{
+ul {
   list-style-type: square;
-  color: #555;
 }
 
 .wrapper {
   max-width: 900px;
-  margin:0 auto;
-  position:relative;
+  margin: 70px auto 0;
+  position: relative;
   padding: 0 20px;
-  margin-top: 70px;
 }
 
 section img {
@@ -119,15 +125,14 @@ section img {
 }
 
 blockquote {
-  border-left:3px solid #4e9a06;
-  margin:0;
+  border-left:3px solid $green-medium;
   padding:0 0 0 20px;
   font-style:italic;
 }
 
 code {
   font-family: Monaco, 'Source Code Pro', 'Bitstream Vera Sans Mono', 'Lucida Console', Terminal, monospace;
-  color:#282828;
+  color: $text-dark;
   font-size: 80%;
   margin: 0 4px;
   padding: 2px 4px;
@@ -141,7 +146,7 @@ pre {
   background: #333;
   border-radius: 5px;
   border: 1px solid #121212;
-  box-shadow: inset 0 1px 3px rgba(0,0,0,.3);
+  box-shadow: inset 0 1px 3px rgba(black, .3);
   overflow: auto;
   overflow-y: hidden;
   font-size: 80%;
@@ -151,7 +156,7 @@ pre {
     color: #efefef;
     font-size: inherit;
     background: transparent;
-    text-shadow: 0px 1px 0px #000;
+    text-shadow: 0 1px 0 black;
     margin: 0;
     padding: 0;
   }
@@ -171,7 +176,7 @@ table {
   width: 100%;
   position: fixed;
   background: url(../images/nav-bg.gif) #353535;
-  box-shadow: 0px 1px 3px rgba(0,0,0,.25);
+  box-shadow: 0 1px 3px rgba(0,0,0,.25);
 
   nav {
     max-width: 900px;
@@ -189,16 +194,17 @@ table {
       margin-right: 15px;
       line-height: 55px;
       vertical-align: middle;
-      color: #4ec526;
+      color: $green-bright;
+      text-shadow: 0 1px 0 rgba(black, 0.4);
       font-weight: normal;
 
       &.active {
-        color: #40ff00;
-        box-shadow: inset 0 -3px 0 #40ff00;
+        color: $green-brighter;
+        box-shadow: inset 0 -3px 0 $green-brighter;
       }
 
       &:hover, &:focus {
-        color: #40ff00;
+        color: $green-brighter;
       }
 
       &.nu {
@@ -223,20 +229,20 @@ table {
 
       a.button {
         color: white;
-        text-shadow: 0px 1px 0px rgba(#000, .2);
+        text-shadow: 0 1px 0 rgba(black, .2);
         border-radius: 5px;
-        box-shadow: inset 0px 1px 0px rgba(255,255,255,.3), 0px 3px 7px rgba(0,0,0,.7);
+        box-shadow: inset 0 1px 0 rgba(white, .3), 0 3px 7px rgba(black, .7);
         word-spacing: 2px;
-        background-color: #418305;
+        background-color: $green-dark;
         padding: 4px 10px;
         margin-top: 10px;
         font-size: 80%;
         line-height: 1.5em;
+        transition: background-color .15s;
   
         &:hover, &:focus {
           color: #fff;
-          background-color: #529c0d;
-          border: 1px solid none;
+          background-color: $green-medium;
           border-radius: 5px;
         }
 
@@ -253,8 +259,7 @@ footer {
   font-weight: 400;
   color: #3e3e3e;
   max-width: 900px;
-  margin: 2px auto;
-  padding: 0 0px;
+  padding: 0;
   background: none;
   margin: 10px auto;
 
@@ -280,9 +285,8 @@ footer {
 
 section {
   max-width: 900px;
-  padding: 30px 0px 50px 0px;
-  margin: 20px 0;
-  margin-top: 70px;
+  padding: 30px 0 50px 0;
+  margin: 70px 0 20px 0;
 
   #title {
     border-bottom: 1px solid #aaa;
@@ -295,15 +299,17 @@ section {
       text-align: center;
       line-height: 1em;
       margin: 0.25em 0;
+      padding: 0;
     }
 
     .subheading {
       text-align: center;
+      color: #242424;
     }
 
     hr {
-      border: 1px solid #aaa;
-      border-width: 1px 0 0 0;
+      border: 0 solid #aaa;
+      border-bottom-width: 1px;
     }
 
     p {

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -65,6 +65,32 @@ a {
   }
 }
 
+a.anchor {
+  display: none;
+  position: absolute;
+  margin: -70px 0 -10px -40px;
+  padding: 70px 0 10px 0;
+  width: 40px;
+  opacity: 0.6;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &::before {
+    content: '🔗';
+    color: #bbb;
+    font-size: 19px;
+    vertical-align: bottom;
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  &:hover a.anchor {
+    display: inline-block;
+  }
+}
+
 a small {
   font-size:11px;
   color:#555;

--- a/contribute.md
+++ b/contribute.md
@@ -5,6 +5,6 @@ layout: doc
 
 If you are a developer who would like to contribute to Nu, feel free to start working with us on our [GitHub page](https://github.com/nushell/nushell).
 
-We are also currently writing a [contributers book](https://github.com/nushell/contributer-book). It attempts to cover the basics of how Nu works internally, to better enable you to have a solid understanding of Nu and how best to contribute.
+We are also currently writing a [contributors book](https://github.com/nushell/contributor-book). It attempts to cover the basics of how Nu works internally, to better enable you to have a solid understanding of Nu and how best to contribute.
 
 We also have active discussions on [Discord](https://discord.gg/NtAbbGn) and [Twitter](https://twitter.com/nu_shell). Here you can get help, bring in your own ideas and visions for evolving Nu and discuss suggestions from other developers.


### PR DESCRIPTION
- When a heading is hovered, a 🔗 symbol appears. Click on it to link to the heading
- When an internal link (e.g. https://www.nushell.sh/installation.html#docker-containers) is clicked, the browser now scrolls to the correct position (previously it scrolled ~60px too far)
- Fix a few HTML issues
- Refactor CSS, convert some colors into Sass variables
- Fix broken link