### PR TITLE
Fix variable width characters in `pre`

### DIFF
--- a/_includes/script.html
+++ b/_includes/script.html
@@ -1,8 +1,13 @@
 <script type="text/javascript">
     $('h1, h2, h3, h4, h5, h6').filter('[id]').each(function () {
-        var el = document.createElement('a')
-        el.className = 'anchor'
+        var el = document.createElement('a');
+        el.className = 'anchor';
         el.href = '#' + this.id;
         this.prepend(el)
     });
+    $('pre code').each(function () {
+        this.innerHTML = this.innerHTML
+            .split('').map(c => c === '━' || c === '─' ? `<span>${c}</span>` : c)
+            .join('');
+    })
 </script>

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -6,7 +6,7 @@
         this.prepend(el)
     });
     $('pre code').each(function () {
-        this.innerHTML = this.innerHTML.replace(/\u2501+|\u2500+|\u252f|\u253c|\u2537|\u2502/g, function (s) {
+        this.innerHTML = this.innerHTML.replace(/\u2501{1,8}|\u2500{1,8}|\u252f|\u253c|\u2537|\u2502/g, function (s) {
             return '<u style="width:' + s.length + 'ch">' + s + '</u>'
         });
     })

--- a/_sass/fonts.scss
+++ b/_sass/fonts.scss
@@ -8,7 +8,6 @@
          url('../fonts/OpenSans-Light-webfont.svg#OpenSansLight') format('svg');
     font-weight: 300;
     font-style: normal;
-
 }
 
 @font-face {
@@ -21,7 +20,6 @@
          url('../fonts/OpenSans-LightItalic-webfont.svg#OpenSansLightItalic') format('svg');
     font-weight: 300;
     font-style: italic;
-
 }
 
 @font-face {
@@ -34,7 +32,6 @@
          url('../fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg');
     font-weight: normal;
     font-style: normal;
-    -webkit-font-smoothing:antialiased;
 }
 
 @font-face {
@@ -47,7 +44,6 @@
          url('../fonts/OpenSans-Italic-webfont.svg#OpenSansItalic') format('svg');
     font-weight: normal;
     font-style: italic;
-    -webkit-font-smoothing:antialiased;
 }
 
 @font-face {
@@ -60,7 +56,6 @@
          url('../fonts/OpenSans-Bold-webfont.svg#OpenSansBold') format('svg');
     font-weight: bold;
     font-style: normal;
-    -webkit-font-smoothing:antialiased;
 }
 
 @font-face {
@@ -73,5 +68,4 @@
          url('../fonts/OpenSans-BoldItalic-webfont.svg#OpenSansBoldItalic') format('svg');
     font-weight: bold;
     font-style: italic;
-    -webkit-font-smoothing:antialiased;
 }

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -150,7 +150,7 @@ pre {
   overflow: auto;
   overflow-y: hidden;
   font-size: 80%;
-  line-height: 1.35em;
+  line-height: 1.3em;
 
   code {
     color: #efefef;
@@ -161,9 +161,12 @@ pre {
     padding: 0;
   }
 
+  // table borders:
   u {
     text-decoration: none;
     width: 1ch;
+    height: 1em;
+    color: white;
     overflow: visible;
     display: inline-block;
   }

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -167,6 +167,7 @@ pre {
     width: 1ch;
     height: 1em;
     color: white;
+    font-weight: normal;
     overflow: visible;
     display: inline-block;
   }

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -160,6 +160,13 @@ pre {
     margin: 0;
     padding: 0;
   }
+
+  u {
+    text-decoration: none;
+    width: 1ch;
+    overflow: visible;
+    display: inline-block;
+  }
 }
 
 table {

--- a/_sass/rouge-base16-dark.scss
+++ b/_sass/rouge-base16-dark.scss
@@ -8,20 +8,29 @@
 .highlight, .highlight .w {
   color: #d0d0d0;
 }
+
+.highlight .c, .highlight .o {
+  color: #95ff5d;
+  font-weight: bold;
+}
+.highlight .s1 {
+  color: #7be9b4;
+}
+
 .highlight .err {
   color: #151515;
   background-color: #ac4142;
 }
-.highlight .c, .highlight .cd, .highlight .cm, .highlight .c1, .highlight .cs {
+.highlight .cd, .highlight .cm, .highlight .c1, .highlight .cs {
   color: #888;
 }
 .highlight .cp {
   color: #f4bf75;
 }
 .highlight .nt {
-  color: #f4bf75;
+  color: #f0bc73;
 }
-.highlight .o, .highlight .ow {
+.highlight .ow {
   color: #d0d0d0;
 }
 .highlight .p, .highlight .pi {
@@ -49,7 +58,7 @@
 .highlight .kd {
   color: #d28445;
 }
-.highlight .s, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx, .highlight .s1 {
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx {
   color: #90a959;
 }
 .highlight .sr {


### PR DESCRIPTION
This PR adds some JS which iterates over `<code>` blocks within a `<pre>` and replaces all horizontal line characters (`━`, `─`) with a `<u>` elment containing the character.

This element has a CSS rule `width: 1ch` which gives it the width of the `0` character. Unfortunately, this only works in browsers with JS enabled. Furthermore, the `ch` unit is not supported in IE <= 8, Safari <= 6.1, Android Browser <= 4.3 and Opera Mini. In these browsers, this fix has no effect. However, I think this is acceptable, since these browsers are rarely used.

Fixes #11 