### PR TITLE
Fix logo font

### DIFF
--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -219,7 +219,7 @@ table {
         font-size: 1.35em;
         line-height: 1.6em;
         vertical-align: -2px;
-        font-family: 'Source Code Pro', monospace;
+        font-family: Consolas, Menlo, Monaco, Hack, Roboto Mono, Droid Sans Mono, Liberation Mono, DejaVu Sans Mono, monospace;
       }
       &.nu::after {
         content: '>';


### PR DESCRIPTION
Same change as what was done in 076d63e2d for the `<code>` elements, now applied for the logo as well.

Here's what the website looks for me on Firefox 72.0 on macOS 10.15.2 (Catalina):

Before:

![Screenshot 2020-01-17 at 17 51 06](https://user-images.githubusercontent.com/478237/72634233-0f98e000-3952-11ea-9d79-3184132bb8a3.png)

After:

> ![Screenshot 2020-01-17 at 17 51 24](https://user-images.githubusercontent.com/478237/72634249-13c4fd80-3952-11ea-9259-ffe1647baa46.png)
