### PR TITLE
Improve installation instructions

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -118,7 +118,7 @@ You can also install Nu with all the bells and whistles (be sure to have install
 [dependencies](https://book.nushell.sh/en/installation#dependencies) for your platform):
 
 ```
-cargo install nu --features=stable
+cargo install nu --all --features=stable
 ```
 
 ## Building from source
@@ -135,7 +135,7 @@ From there, we can build and run Nu if we are using `rustup` with:
 
 ```
 > cd nushell
-nushell> cargo build --features=stable && cargo run --features=stable
+nushell> cargo build --all --features=stable && cargo run --all --features=stable
 ```
 
 You can also build and run Nu in release mode:

--- a/installation.md
+++ b/installation.md
@@ -118,7 +118,7 @@ You can also install Nu with all the bells and whistles (be sure to have install
 [dependencies](https://book.nushell.sh/en/installation#dependencies) for your platform):
 
 ```
-cargo install nu --all-features
+cargo install nu --features=stable
 ```
 
 ## Building from source
@@ -135,7 +135,7 @@ From there, we can build and run Nu if we are using `rustup` with:
 
 ```
 > cd nushell
-nushell> cargo build --all-features && cargo run --all-features
+nushell> cargo build --features=stable && cargo run --features=stable
 ```
 
 You can also build and run Nu in release mode:

--- a/installation.md
+++ b/installation.md
@@ -3,7 +3,13 @@ layout: doc
 title: Installation
 ---
 
-This is just a short description of how you can install Nu. There is a more detailed documentation on how to install Nu. It offers the installation guide in different languages: [English](https://book.nushell.sh/en/installation), [Español](https://book.nushell.sh/es/instalacion), [Português do Brasil](https://book.nushell.sh/pt-br/instalacao) and [日本語](https://book.nushell.sh/ja/installation).
+This is just a short description of how you can install Nu.
+There is an installation guide offering more detailed documentation on how to install Nu.
+It is available in different languages:
+[English](https://book.nushell.sh/en/installation),
+[Español](https://book.nushell.sh/es/instalacion),
+[Português do Brasil](https://book.nushell.sh/pt-br/instalacao) and
+[日本語](https://book.nushell.sh/ja/installation).
 
 # Pre-built binaries
 
@@ -11,13 +17,15 @@ This is just a short description of how you can install Nu. There is a more deta
 
 **Please Note:** Nu works on Windows 10 and does not currently have Windows 7/8.1 support.
 
-Download the current released `.zip`-file from the [release page](https://github.com/nushell/nushell/releases) and extract it for example to:
+Download the current released `.zip`-file from the [release page](https://github.com/nushell/nushell/releases)
+and extract it, for example, to:
 
 ```
 C:\Program Files
 ```
 
-And then add the folder of `nu` to your PATH. Once we have done that, we can run Nu using the `nu` command:
+And then add the folder of `nu` to your `PATH`.
+Once we have done that, we can run Nu using the `nu` command:
 
 ```
 > nu
@@ -26,7 +34,11 @@ C:\Users\user>
 
 ## macOS
 
-You can download Nu pre-built from the [release page](https://github.com/nushell/nushell/releases) or if you are using [Homebrew](https://brew.sh/) you can install the binary by running
+You can download Nu pre-built from the [release page](https://github.com/nushell/nushell/releases).
+
+## Homebrew
+
+If you use [Homebrew](https://brew.sh/) on macOS or Linux, you can install the binary by running
 
 ```shell
 > brew install nushell
@@ -34,9 +46,9 @@ You can download Nu pre-built from the [release page](https://github.com/nushell
 
 ## Docker containers
 
-
-If you want to pull a pre-built container, you can browse tags for the [nushell organization](https://quay.io/organization/nushell)
-on Quay.io. Pulling a container would come down to:
+If you want to pull a pre-built container, you can browse tags for the
+[nushell organization](https://quay.io/organization/nushell) on Quay.io.
+Pulling a container would come down to:
 
 ```bash
 $ docker pull quay.io/nushell/nu
@@ -46,7 +58,8 @@ $ docker pull quay.io/nushell/nu-base
 Both "nu-base" and "nu" provide the `nu` binary, however nu-base also includes the source code at `/code`
 in the container and all dependencies.
 
-Optionally, you can also build the containers locally using the [dockerfiles provided](https://github.com/nushell/nushell/tree/master/docker):
+Optionally, you can also build the containers locally using the
+[dockerfiles provided](https://github.com/nushell/nushell/tree/master/docker).
 To build the base image:
 
 ```bash
@@ -69,16 +82,17 @@ $ docker run -it nushell/nu
 
 The second container is a bit smaller, if size is important to you.
 
-# Building it Local
+# Building it locally
 
 To build Nu, you will need to use the **latest stable (1.39 or later)** version of the compiler.
 
-For Rust to work properly, you'll need to have a compatible compiler suite installed on your system. These are the recommended compiler suites:
+For Rust to work properly, you'll need to have a compatible compiler suite installed on your system.
+These are the recommended compiler suites:
 
 * Linux: GCC or Clang
 * macOS: Clang (install Xcode)
-* Windows: [Visual Studio Community Edition](https://visualstudio.microsoft.com/vs/community/) (make sure to install the "C++ build tools")
-
+* Windows: [Visual Studio Community Edition](https://visualstudio.microsoft.com/vs/community/)
+  (make sure to install the "C++ build tools")
 
 ### Required dependencies:
 
@@ -91,16 +105,17 @@ For Rust to work properly, you'll need to have a compatible compiler suite insta
 * To use Nu with all possible optional features enabled, you'll also need the following:  
   ➜ on Linux (on Debian/Ubuntu): `apt install libxcb-composite0-dev libx11-dev`
 
-
 ## Installing from crates.io
 
-To install Nu via cargo (make sure you have installed [rustup](https://rustup.rs/) and the latest stable compiler via `rustup install stable`):
+To install Nu via cargo (make sure you have installed [rustup](https://rustup.rs/)
+and the latest stable compiler via `rustup install stable`):
 
 ```
 cargo install nu
 ```
 
-You can also install Nu with all the bells and whistles (be sure to have installed the [dependencies](https://book.nushell.sh/en/installation#dependencies) for your platform):
+You can also install Nu with all the bells and whistles (be sure to have installed the
+[dependencies](https://book.nushell.sh/en/installation#dependencies) for your platform):
 
 ```
 cargo install nu --all-features
@@ -108,13 +123,15 @@ cargo install nu --all-features
 
 ## Building from source
 
-We can also build our own Nu from source directly from github. This gives us immediate access to the latest Nu features and bug fixes.
+We can also build our own Nu from source directly from GitHub.
+This gives us immediate access to the latest Nu features and bug fixes.
 
 ```
 > git clone https://github.com/nushell/nushell.git
 ```
 
-Git will clone the main nushell repo for us. From there, we can build and run Nu if we are using `rustup` with:
+Git will clone the main nushell repo for us.
+From there, we can build and run Nu if we are using `rustup` with:
 
 ```
 > cd nushell
@@ -127,4 +144,6 @@ You can also build and run Nu in release mode:
 nushell> cargo build --release && cargo run --release
 ```
 
-People familiar with Rust may wonder why we do both a "build" and a "run" step if "run" does a build by default. This is to get around a shortcoming of the new `default-run` option in Cargo, and ensure that all plugins are built, though this may not be required in the future.
+People familiar with Rust may wonder why we do both a "build" and a "run" step if "run" does a build by default.
+This is to get around a shortcoming of the new `default-run` option in Cargo,
+and ensure that all plugins are built, though this may not be required in the future.


### PR DESCRIPTION
- Various wording, punctuation and formatting tweaks
- Add a separate section for Homebrew, since it works for both macOS and Linux
- Break some long lines, especially those with links, to allow for cleaner diffs