### PR TITLE
add os-specific installation instructions to front page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,4 +254,4 @@ DEPENDENCIES
   wdm
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -129,14 +129,18 @@
             </div>
           </div>
           <h3>Building Nu locally</h3>
-          <p>You can of course build Nu locally. To do this please look over <a
-              href="{{ '/installation.html#building-it-locally' | relative_url }}">here</a></p>
+          <p>For instructions on how to build Nu locally please look over <a
+              href="{{ '/installation.html#building-it-locally' | relative_url }}">here</a>.</p>
         </div>
 
 
         <div id="Linux" class="tabcontent">
+          <h3>Packaging status</h3>
+          <p>Packages are available in the following repos:</p>
+          <p><a href="https://repology.org/project/nushell/versions" style="text-align: center;"><img
+                src="https://repology.org/badge/vertical-allrepos/nushell.svg" alt="Packaging status" /></a></p>
           <h3>Homebrew</h3>
-          <p>If you use <a href="https://brew.sh/">Homebrew</a> on macOS or Linux, you can install the binary by running
+          <p>If you use <a href="https://brew.sh/">Homebrew</a> on Linux, you can install the binary by running
           </p>
 
           <div class="language-shell highlighter-rouge">
@@ -146,8 +150,8 @@
             </div>
           </div>
           <h3>Building Nu locally</h3>
-          <p>You can of course build Nu locally. To do this please look over <a
-              href="{{ '/installation.html#building-it-locally' | relative_url }}">here</a></p>
+          <p>For instructions on how to build Nu locally please look over <a
+              href="{{ '/installation.html#building-it-locally' | relative_url }}">here</a>.</p>
         </div>
 
 
@@ -158,7 +162,7 @@
           </p>
           <h3 id="homebrew">Homebrew</h3>
 
-          <p>If you use <a href="https://brew.sh/">Homebrew</a> on macOS or Linux, you can install the binary by running
+          <p>If you use <a href="https://brew.sh/">Homebrew</a> on macOS, you can install the binary by running
           </p>
 
           <div class="language-shell highlighter-rouge">
@@ -168,8 +172,8 @@
             </div>
           </div>
           <h3>Building Nu locally</h3>
-          <p>You can of course build Nu locally. To do this please look over <a
-              href="{{ '/installation.html#building-it-locally' | relative_url }}">here</a></p>
+          <p>For instructions on how to build Nu locally please look over <a
+              href="{{ '/installation.html#building-it-locally' | relative_url }}">here</a>.</p>
         </div>
       </div>
       <br>
@@ -275,70 +279,35 @@
         tablinks[i].className = tablinks[i].className.replace(" active", "");
       }
 
-      document.getElementById("Windows").style.display = "none";
-      document.getElementById("macOS").style.display = "none";
-      document.getElementById("Linux").style.display = "none";
-
-      document.getElementById("winbutton").style.backgroundColor = "#fff";
-      document.getElementById("macbutton").style.backgroundColor = "#fff";
-      document.getElementById("linuxbutton").style.backgroundColor = "#fff";
-
       document.getElementById(osName).style.display = "block";
       evt.currentTarget.className += " active";
-      document.getElementById(btnname).style.backgroundColor = "#16c60c";
     }
 
     var OSName = "Unknown";
-    if (window.navigator.userAgent.indexOf("Windows NT 10.0") != -1) {
+    if (window.navigator.userAgent.indexOf("Windows NT") != -1) {
       OSName = "Windows";
       document.getElementById("Windows").style.display = "block";
-      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
-    }
-    if (window.navigator.userAgent.indexOf("Windows NT 6.2") != -1) {
-      OSName = "Windows";
-      document.getElementById("Windows").style.display = "block";
-      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
-    }
-    if (window.navigator.userAgent.indexOf("Windows NT 6.1") != -1) {
-      OSName = "Windows";
-      document.getElementById("Windows").style.display = "block";
-      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
-    }
-    if (window.navigator.userAgent.indexOf("Windows NT 6.0") != -1) {
-      OSName = "Windows";
-      document.getElementById("Windows").style.display = "block";
-      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
-    }
-    if (window.navigator.userAgent.indexOf("Windows NT 5.1") != -1) {
-      OSName = "Windows";
-      document.getElementById("Windows").style.display = "block";
-      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
-    }
-    if (window.navigator.userAgent.indexOf("Windows NT 5.0") != -1) {
-      OSName = "Windows";
-      document.getElementById("Windows").style.display = "block";
-      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
+      document.getElementById("winbutton").className += " active";
     }
     if (window.navigator.userAgent.indexOf("Mac") != -1) {
       OSName = "macOS";
       document.getElementById("macOS").style.display = "block";
-      document.getElementById("macbutton").style.backgroundColor = "#16c60c";
+      document.getElementById("macbutton").className += " active";
     }
     if (window.navigator.userAgent.indexOf("X11") != -1) {
       OSName = "Linux";
       document.getElementById("Linux").style.display = "block";
-      document.getElementById("linuxbutton").style.backgroundColor = "#16c60c";
+      document.getElementById("linuxbutton").className += " active";
     }
     if (window.navigator.userAgent.indexOf("Linux") != -1) {
       OSName = "Linux";
       document.getElementById("Linux").style.display = "block";
-      document.getElementById("linuxbutton").style.backgroundColor = "#16c60c";
+      document.getElementById("linuxbutton").className += " active";
     }
-
     if (OSName == "Unknown") {
       OSName = "Linux";
       document.getElementById("Linux").style.display = "block";
-      document.getElementById("linuxbutton").style.backgroundColor = "#16c60c";
+      document.getElementById("linuxbutton").className += " active";
     }
   </script>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -93,18 +93,84 @@
       <hr>
       <br>
       <br>
+
+      <h1>Installation Overview</h1>
       <div class="information">
-        <h1>Installation Overview</h1>
-        There are a many ways to get Nu:
-        <ul>
-          <li><a href="{{ '/installation.html#pre-built-binaries' | relative_url }}">Download
-              pre-built binaries</a>
-          </li>
-          <li><a href="{{ '/installation.html#building-from-source' | relative_url }}">Built it from source</a></li>
-          <li><a href="{{ '/installation.html#installing-from-cratesio' | relative_url }}">Install it from crates.io</a>
-          </li>
-          <li><a href="{{ '/installation.html' | relative_url }}">other</a></li>
-        </ul>
+        <div class="tab">
+          <button id="winbutton" class="tablinks" onclick="showOS(event,'Windows', 'winbutton')">Windows</button>
+          <button id="linuxbutton" class="tablinks" onclick="showOS(event,'Linux', 'linuxbutton')">Linux</button>
+          <button id="macbutton" class="tablinks" onclick="showOS(event,'macOS', 'macbutton')">macOS</button>
+        </div>
+        <div id="Windows" class="tabcontent">
+          <h3>Pre-built binaries</h3>
+          <p><strong>Please Note:</strong> Nu works on Windows 10 and does not currently have Windows 7/8.1 support.</p>
+
+          <p>Download the current released <code class="language-plaintext highlighter-rouge">.zip</code>-file from the
+            <a href="https://github.com/nushell/nushell/releases">release page</a>
+            and extract it, for example, to:</p>
+
+          <div class="language-plaintext highlighter-rouge">
+            <div class="highlight">
+              <pre class="highlight"><code>C:\Program Files
+  </code></pre>
+            </div>
+          </div>
+
+          <p>And then add the folder of <code class="language-plaintext highlighter-rouge">nu</code> to your <code
+              class="language-plaintext highlighter-rouge">PATH</code>.
+            Once we have done that, we can run Nu using the <code class="language-plaintext highlighter-rouge">nu</code>
+            command:</p>
+
+          <div class="language-plaintext highlighter-rouge">
+            <div class="highlight">
+              <pre class="highlight"><code>&gt; nu
+  C:\Users\user&gt;
+  </code></pre>
+            </div>
+          </div>
+          <h3>Building Nu locally</h3>
+          <p>You can of course build Nu locally. To do this please look over <a
+              href="{{ '/installation.html#building-it-locally' | relative_url }}">here</a></p>
+        </div>
+
+
+        <div id="Linux" class="tabcontent">
+          <h3>Homebrew</h3>
+          <p>If you use <a href="https://brew.sh/">Homebrew</a> on macOS or Linux, you can install the binary by running
+          </p>
+
+          <div class="language-shell highlighter-rouge">
+            <div class="highlight">
+              <pre class="highlight"><code><span class="o">&gt;</span> brew <span class="nb">install </span>nushell
+  </code></pre>
+            </div>
+          </div>
+          <h3>Building Nu locally</h3>
+          <p>You can of course build Nu locally. To do this please look over <a
+              href="{{ '/installation.html#building-it-locally' | relative_url }}">here</a></p>
+        </div>
+
+
+        <div id="macOS" class="tabcontent">
+          <h3>Pre-built binaries</h3>
+          <p>You can download Nu pre-built from the <a href="https://github.com/nushell/nushell/releases">release
+              page</a>.
+          </p>
+          <h3 id="homebrew">Homebrew</h3>
+
+          <p>If you use <a href="https://brew.sh/">Homebrew</a> on macOS or Linux, you can install the binary by running
+          </p>
+
+          <div class="language-shell highlighter-rouge">
+            <div class="highlight">
+              <pre class="highlight"><code><span class="o">&gt;</span> brew <span class="nb">install </span>nushell
+  </code></pre>
+            </div>
+          </div>
+          <h3>Building Nu locally</h3>
+          <p>You can of course build Nu locally. To do this please look over <a
+              href="{{ '/installation.html#building-it-locally' | relative_url }}">here</a></p>
+        </div>
       </div>
       <br>
       <div class="information">
@@ -195,6 +261,85 @@
       dots[slideIndex - 1].className += " current";
     }
 
+    function showOS(evt, osName, btnname) {
+      var i, tabcontent, tablinks;
+
+
+      tabcontent = document.getElementsByClassName("tabcontent");
+      for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+      }
+
+      tablinks = document.getElementsByClassName("tablinks");
+      for (i = 0; i < tablinks.length; i++) {
+        tablinks[i].className = tablinks[i].className.replace(" active", "");
+      }
+
+      document.getElementById("Windows").style.display = "none";
+      document.getElementById("macOS").style.display = "none";
+      document.getElementById("Linux").style.display = "none";
+
+      document.getElementById("winbutton").style.backgroundColor = "#fff";
+      document.getElementById("macbutton").style.backgroundColor = "#fff";
+      document.getElementById("linuxbutton").style.backgroundColor = "#fff";
+
+      document.getElementById(osName).style.display = "block";
+      evt.currentTarget.className += " active";
+      document.getElementById(btnname).style.backgroundColor = "#16c60c";
+    }
+
+    var OSName = "Unknown";
+    if (window.navigator.userAgent.indexOf("Windows NT 10.0") != -1) {
+      OSName = "Windows";
+      document.getElementById("Windows").style.display = "block";
+      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
+    }
+    if (window.navigator.userAgent.indexOf("Windows NT 6.2") != -1) {
+      OSName = "Windows";
+      document.getElementById("Windows").style.display = "block";
+      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
+    }
+    if (window.navigator.userAgent.indexOf("Windows NT 6.1") != -1) {
+      OSName = "Windows";
+      document.getElementById("Windows").style.display = "block";
+      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
+    }
+    if (window.navigator.userAgent.indexOf("Windows NT 6.0") != -1) {
+      OSName = "Windows";
+      document.getElementById("Windows").style.display = "block";
+      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
+    }
+    if (window.navigator.userAgent.indexOf("Windows NT 5.1") != -1) {
+      OSName = "Windows";
+      document.getElementById("Windows").style.display = "block";
+      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
+    }
+    if (window.navigator.userAgent.indexOf("Windows NT 5.0") != -1) {
+      OSName = "Windows";
+      document.getElementById("Windows").style.display = "block";
+      document.getElementById("winbutton").style.backgroundColor = "#16c60c";
+    }
+    if (window.navigator.userAgent.indexOf("Mac") != -1) {
+      OSName = "macOS";
+      document.getElementById("macOS").style.display = "block";
+      document.getElementById("macbutton").style.backgroundColor = "#16c60c";
+    }
+    if (window.navigator.userAgent.indexOf("X11") != -1) {
+      OSName = "Linux";
+      document.getElementById("Linux").style.display = "block";
+      document.getElementById("linuxbutton").style.backgroundColor = "#16c60c";
+    }
+    if (window.navigator.userAgent.indexOf("Linux") != -1) {
+      OSName = "Linux";
+      document.getElementById("Linux").style.display = "block";
+      document.getElementById("linuxbutton").style.backgroundColor = "#16c60c";
+    }
+
+    if (OSName == "Unknown") {
+      OSName = "Linux";
+      document.getElementById("Linux").style.display = "block";
+      document.getElementById("linuxbutton").style.backgroundColor = "#16c60c";
+    }
   </script>
 
   {% include script.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -111,8 +111,7 @@
 
           <div class="language-plaintext highlighter-rouge">
             <div class="highlight">
-              <pre class="highlight"><code>C:\Program Files
-  </code></pre>
+              <pre class="highlight"><code>C:\Program Files</code></pre>
             </div>
           </div>
 
@@ -124,8 +123,7 @@
           <div class="language-plaintext highlighter-rouge">
             <div class="highlight">
               <pre class="highlight"><code>&gt; nu
-  C:\Users\user&gt;
-  </code></pre>
+C:\Users\user&gt;</code></pre>
             </div>
           </div>
           <h3>Building Nu locally</h3>
@@ -145,8 +143,8 @@
 
           <div class="language-shell highlighter-rouge">
             <div class="highlight">
-              <pre class="highlight"><code><span class="o">&gt;</span> brew <span class="nb">install </span>nushell
-  </code></pre>
+              <pre
+                class="highlight"><code><span class="o">&gt;</span> brew <span class="nb">install </span>nushell</code></pre>
             </div>
           </div>
           <h3>Building Nu locally</h3>
@@ -167,8 +165,8 @@
 
           <div class="language-shell highlighter-rouge">
             <div class="highlight">
-              <pre class="highlight"><code><span class="o">&gt;</span> brew <span class="nb">install </span>nushell
-  </code></pre>
+              <pre
+                class="highlight"><code><span class="o">&gt;</span> brew <span class="nb">install </span>nushell</code></pre>
             </div>
           </div>
           <h3>Building Nu locally</h3>
@@ -208,7 +206,6 @@
           <span>Twitter</span>
         </a>
       </div>
-
     </section>
 
   </div>

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -446,8 +446,8 @@ section {
 .tab button {
   background-color: inherit;
   float: left;
-  border: none;
   border: 1px solid #ccc;
+  border-bottom: none;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
   outline: none;
@@ -463,6 +463,7 @@ section {
 .tab button.active {
   // has currently now effect because the colors are set with javascript
   background-color: #16c60c;
+  color: #fff;
 }
 
 .tabcontent {

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -436,6 +436,44 @@ section {
   animation-duration: 1.5s;
 }
 
+.tab {
+  overflow: hidden;
+  background-color: #fff;
+  border-bottom: 1px inset #ccc;
+  bottom: -1px;
+}
+
+.tab button {
+  background-color: inherit;
+  float: left;
+  border: none;
+  border: 1px solid #ccc;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  outline: none;
+  cursor: pointer;
+  padding: 14px 16px;
+  transition: 0.3s;
+}
+
+.tab button:hover {
+  background-color: #15c60c57;
+}
+
+.tab button.active {
+  // has currently now effect because the colors are set with javascript
+  background-color: #16c60c;
+}
+
+.tabcontent {
+  display: none;
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+  border-top: none;
+}
+
 .information {
   margin-top: 20px;
   margin-bottom: 20px;
@@ -445,7 +483,8 @@ section {
     padding-top: 8px;
   }
   //background: #d2e9d0;
-  background: #eafae9;
+  //background: #eafae9;
+  background: #ffffff;
   padding-bottom: 8px;
 }
 


### PR DESCRIPTION
PR adds os detection to determine which installation instructions to display on the front page. #37 