### PR TITLE
Fix typos and EOL whitespace

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 #
-# If you need help with YAML syntax, here are some quick references for you: 
+# If you need help with YAML syntax, here are some quick references for you:
 # https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
 # https://learnxinyminutes.com/docs/yaml/
 #

--- a/_layouts/command.html
+++ b/_layouts/command.html
@@ -52,7 +52,7 @@
         ga('send', 'pageview');
       </script>
     {% endif %}
-    
+
     {% include script.html %}
   </body>
 </html>

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -247,7 +247,7 @@ table {
         font-size: 80%;
         line-height: 1.5em;
         transition: background-color .15s;
-  
+
         &:hover, &:focus {
           color: #fff;
           background-color: $green-medium;

--- a/_sass/normalize.scss
+++ b/_sass/normalize.scss
@@ -359,7 +359,7 @@ fieldset {
 
 /*
  * 1. Corrects color not being inherited in IE6/7/8/9
- * 2. Corrects text not wrapping in FF3 
+ * 2. Corrects text not wrapping in FF3
  * 3. Corrects alignment displayed oddly in IE6/7
  */
 

--- a/commands/00_newtable.txt
+++ b/commands/00_newtable.txt
@@ -8,4 +8,4 @@
 [edit](/commands/edit.html) | [last](/commands/last.html) | [sort-by](/commands/sort-by.html) | [trim](/commands/trim.html)
 [enter](/commands/enter.html) | [lines](/commands/lines.html) | [str](/commands/str.html) | [version](/commands/version.html)
 [env](/commands/env.html) | [nth](/commands/nth.html) | [sum](/commands/sum.html) | [where](/commands/where.html)
-[exit](/commands/exit.html) | [open](/commands/open.html) | [sys](/commands/sys.html) | 
+[exit](/commands/exit.html) | [open](/commands/open.html) | [sys](/commands/sys.html) |

--- a/commands/update_commands.py
+++ b/commands/update_commands.py
@@ -1,5 +1,5 @@
 # this script needs to be run in the /commands folder and the documentation.md file should be in /
-# command references need to be at the bottom otherwise this script will overwrite everything thats coming after these references
+# command references need to be at the bottom otherwise this script will overwrite everything that's coming after these references
 # if the heading of the command references changes line 58 needs to be changed to the new heading
 
 import os

--- a/documentation.md
+++ b/documentation.md
@@ -10,11 +10,11 @@ At the bottom of this page you can also find quick references to the commands pr
 
 ## Nu Book
 
-You can read our [book](https://www.nushell.sh/book) to learn more about the core concepts behind Nu. It covers the basic and contains a lot of examples which will help you to have an easy start. 
+You can read our [book](https://www.nushell.sh/book) to learn more about the core concepts behind Nu. It covers the basic and contains a lot of examples which will help you to have an easy start.
 
 ## Contributor Book
 
-In the [contributers book](https://www.nushell.sh/contributor-book) you can find further information. It attempts to cover the basics of how Nu works internally, to get a solid understanding. You will learn how data is treated, what kind of data types Nu supports and how you can write plugins for it.
+In the [contributors book](https://www.nushell.sh/contributor-book) you can find further information. It attempts to cover the basics of how Nu works internally, to get a solid understanding. You will learn how data is treated, what kind of data types Nu supports and how you can write plugins for it.
 
 ## Cookbook
 

--- a/installation.md
+++ b/installation.md
@@ -64,13 +64,13 @@ To build the base image:
 
 ```bash
 $ docker build -f docker/Dockerfile.nu-base -t nushell/nu-base .
-``` 
+```
 
 And then to build the smaller container (using a Multistage build):
 
 ```bash
 $ docker build -f docker/Dockerfile -t nushell/nu .
-``` 
+```
 
 Either way, you can run either container as follows:
 
@@ -96,13 +96,13 @@ These are the recommended compiler suites:
 
 ### Required dependencies:
 
-* pkg-config and libssl (only needed on Linux)  
-  ➜ on Debian/Ubuntu: `apt install pkg-config libssl-dev`  
+* pkg-config and libssl (only needed on Linux)
+  ➜ on Debian/Ubuntu: `apt install pkg-config libssl-dev`
   ➜ on macOS: `brew install openssl cmake`
 
 ### Optional dependencies:
 
-* To use Nu with all possible optional features enabled, you'll also need the following:  
+* To use Nu with all possible optional features enabled, you'll also need the following:
   ➜ on Linux (on Debian/Ubuntu): `apt install libxcb-composite0-dev libx11-dev`
 
 ## Installing from crates.io


### PR DESCRIPTION
This PR was triggered by noticing one of the typos that was fixed in https://github.com/nushell/contributor-book/pull/16 (namely, "contributers" --> "contributors").