### PR TITLE
Remove leftover dash in the `from` and `to` subcommands

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -23,21 +23,21 @@ In the [contributors book](https://www.nushell.sh/contributor-book) you can find
 # Quick command references
 
 [alias](/commands/alias.html) | [format](/commands/format.html) | [last](/commands/last.html) | [sum](/commands/sum.html)
-[append](/commands/append.html) | [from-csv](/commands/from-csv.html) | [lines](/commands/lines.html) | [sys](/commands/sys.html)
-[average](/commands/average.html) | [from-ics](/commands/from-ics.html) | [nth](/commands/nth.html) | [tags](/commands/tags.html)
-[cal](/commands/cal.html) | [from-json](/commands/from-json.html) | [open](/commands/open.html) | [to-csv](/commands/to-csv.html)
-[calc](/commands/calc.html) | [from-ods](/commands/from-ods.html) | [pivot](/commands/pivot.html) | [to-json](/commands/to-json.html)
-[cd](/commands/cd.html) | [from-toml](/commands/from-toml.html) | [prepend](/commands/prepend.html) | [to-toml](/commands/to-toml.html)
-[compact](/commands/compact.html) | [from-tsv](/commands/from-tsv.html) | [ps](/commands/ps.html) | [to-tsv](/commands/to-tsv.html)
-[config](/commands/config.html) | [from-vcf](/commands/from-vcf.html) | [reject](/commands/reject.html) | [to-url](/commands/to-url.html)
-[count](/commands/count.html) | [from-xlsx](/commands/from-xlsx.html) | [reverse](/commands/reverse.html) | [to-yaml](/commands/to-yaml.html)
-[date](/commands/date.html) | [from-xml](/commands/from-xml.html) | [save](/commands/save.html) | [to](/commands/to.html)
-[debug](/commands/debug.html) | [from-yaml](/commands/from-yaml.html) | [select](/commands/select.html) | [trim](/commands/trim.html)
+[append](/commands/append.html) | [from csv](/commands/from-csv.html) | [lines](/commands/lines.html) | [sys](/commands/sys.html)
+[average](/commands/average.html) | [from ics](/commands/from-ics.html) | [nth](/commands/nth.html) | [tags](/commands/tags.html)
+[cal](/commands/cal.html) | [from json](/commands/from-json.html) | [open](/commands/open.html) | [to csv](/commands/to-csv.html)
+[calc](/commands/calc.html) | [from ods](/commands/from-ods.html) | [pivot](/commands/pivot.html) | [to json](/commands/to-json.html)
+[cd](/commands/cd.html) | [from toml](/commands/from-toml.html) | [prepend](/commands/prepend.html) | [to toml](/commands/to-toml.html)
+[compact](/commands/compact.html) | [from tsv](/commands/from-tsv.html) | [ps](/commands/ps.html) | [to tsv](/commands/to-tsv.html)
+[config](/commands/config.html) | [from vcf](/commands/from-vcf.html) | [reject](/commands/reject.html) | [to url](/commands/to-url.html)
+[count](/commands/count.html) | [from xlsx](/commands/from-xlsx.html) | [reverse](/commands/reverse.html) | [to yaml](/commands/to-yaml.html)
+[date](/commands/date.html) | [from xml](/commands/from-xml.html) | [save](/commands/save.html) | [to](/commands/to.html)
+[debug](/commands/debug.html) | [from yaml](/commands/from-yaml.html) | [select](/commands/select.html) | [trim](/commands/trim.html)
 [default](/commands/default.html) | [from](/commands/from.html) | [shells](/commands/shells.html) | [uniq](/commands/uniq.html)
 [du](/commands/du.html) | [get](/commands/get.html) | [size](/commands/size.html) | [version](/commands/version.html)
 [echo](/commands/echo.html) | [group-by](/commands/group-by.html) | [skip-while](/commands/skip-while.html) | [where](/commands/where.html)
 [edit](/commands/edit.html) | [help](/commands/help.html) | [skip](/commands/skip.html) | [which](/commands/which.html)
 [enter](/commands/enter.html) | [histogram](/commands/histogram.html) | [sort-by](/commands/sort-by.html) | [wrap](/commands/wrap.html)
-[exit](/commands/exit.html) | [history](/commands/history.html) | [split-column](/commands/split-column.html) | 
-[fetch](/commands/fetch.html) | [inc](/commands/inc.html) | [split-row](/commands/split-row.html) | 
-[first](/commands/first.html) | [insert](/commands/insert.html) | [str](/commands/str.html) | 
+[exit](/commands/exit.html) | [history](/commands/history.html) | [split-column](/commands/split-column.html) |
+[fetch](/commands/fetch.html) | [inc](/commands/inc.html) | [split-row](/commands/split-row.html) |
+[first](/commands/first.html) | [insert](/commands/insert.html) | [str](/commands/str.html) |


### PR DESCRIPTION
Simple removal of leftover dashes in the Documentation for `from` and `to` subcommands in order to address [issue #1864 from the main nushell repository](https://github.com/nushell/nushell/issues/1864).

This is the simplest solution. I think the preferred solution would be to remove the subcommands from the list completely and add * to `from` and `to` commands to indicate that these commands have subcommands.