### PR TITLE
copy and update CONTRIBUTING.md from the book repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+If you want to contribute to nushell itself, see [nushell/nushell/CONTRIBUTING.md](https://github.com/nushell/nushell/blob/master/CONTRIBUTING.md) and the [contributor-book](https://github.com/nushell/contributor-book).
+
+This website is based on Jekyll, which requires Ruby or Docker.
+
+## Running locally with Bundler
+
+To run this locally (without Docker, see below), you need the [dependencies as specified by Jekyll](https://jekyllrb.com/docs/installation/), then run these commands:
+
+```shell
+bundle install
+bundle exec jekyll serve
+```
+
+Then open http://localhost:4000/
+
+## Running locally with Docker
+
+To avoid installing dependencies locally, run with Docker:
+
+```
+docker-compose up
+```
+
+Runing that command will first download the `jekyll/jekyll` Docker image. That will install dependencies, which can take a while. Once its done, open http://localhost:4000/
+
+Changes in files will then show up after a reload and some delay (can be ~10 seconds).

--- a/README.md
+++ b/README.md
@@ -4,22 +4,7 @@ This repository contains the source for the [Nu website](https://www.nushell.sh)
 
 # Test it locally
 
-## Install jekyll
-
-You need to install `jekyll` and `bundler`. There is a detailed description on how to get them for different operating systems on the [jekyll website](https://jekyllrb.com/docs/installation/).
-
-## Build
-
-The easiest way to build the site is to run
-
-```shell
-> bundle exec jekyll  serve
-```
-
-in your local folder of the repo. This will run a local web server and you can view the website at [http://localhost:4000](http://localhost:4000).
-
-The website will also be automatically recompiled every time you make changes.
-
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 # License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "2.4"
+
+services:
+  jekyll:
+    image: jekyll/jekyll:4.0
+    command: jekyll serve
+    volumes:
+      - .:/srv/jekyll
+    ports:
+      - "4000:4000"


### PR DESCRIPTION
Updated jekyll from 3.8 to 4.0, to match the bundler version in use here (2.1.4; 3.8 ships with 2.0.2)

Removed the matching, Docker-less instructions from the README.