### PR TITLE
navigation: add link to demo, fix link to blog

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -3,7 +3,8 @@
     <a class="{% if include.current == 'Documentation' %} active {% endif %}" href="{{ '/documentation.html' | relative_url }}"><span class="no-mobile">Documentation</span><span class="mobile">Docs</span></a>
     <a class="{% if include.current == 'Contribute' %} active {% endif %}" href="{{ '/contribute.html' | relative_url }}">Contribute</a>
     <a class="{% if include.current == 'about' %} active {% endif %}" href="{{ '/about.html' | relative_url }}">About</a>
-    <a href="http://blog.nushell.sh">Blog</a>
+    <a href="https://www.nushell.sh/demo/">Demo</a>
+    <a href="https://www.nushell.sh/blog/">Blog</a>
     <div class="right">
         <a href="{{ '/installation.html' | relative_url }}" class="button">Install<span class="no-mobile"> Nushell</span></a>
     </div>


### PR DESCRIPTION
The old blog link takes a while to redirect, a direct link is better. Also use https links, not http. The Let's Encrypt certs are fine.