### PR TITLE
Update external echo example to work under 0.24.1

### DIFF
--- a/snippets/introduction/sys_get_external_echo_example.sh
+++ b/snippets/introduction/sys_get_external_echo_example.sh
@@ -1,2 +1,2 @@
-> sys | get host.sessions | ^echo $it
+> sys | get host.sessions | each { ^echo $it }
 jonathan


### PR DESCRIPTION
This example no longer works. Running in 0.24.1 I get:

```
❯ sys | get host.sessions | ^echo $it
error: Variable not in scope
  ┌─ shell:1:33
  │
1 │ sys | get host.sessions | ^echo $it
  │                                 ^^^ missing '$it' (note: $it is only available inside of a block)

thread 'main' panicked at 'failed printing to stdout: Broken pipe (os error 32)', library/std/src/io/stdio.rs:993:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I'm far from an expert on nushell but I'm hoping that I have intuited what the correct syntax should be.