### PR TITLE
clear up docker installation instructions

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -31,27 +31,26 @@ Now `nu` should load on startup of the Windows Terminal.
 ## Pre-built docker containers
 
 If you want to pull a pre-built container, you can browse tags for the [nushell organization](https://quay.io/organization/nushell)
-on Quay.io. Pulling a container would come down to:
+on [Quay.io](https://quay.io/). Pulling a container would come down to:
 
 <<< @/snippets/installation/pull_prebuilt_container.sh
 
 Both "nu-base" and "nu" provide the `nu` binary, however nu-base also includes the source code at `/code`
-in the container and all dependencies.
+in the container and all dependencies. The "nu" container is a bit smaller, if size is important to you.
 
-Optionally, you can also build the containers locally using the [dockerfiles provided](https://github.com/nushell/nushell/tree/master/docker):
-To build the base image:
+
+Optionally, you can also build the containers locally using the [provided dockerfiles](https://github.com/nushell/nushell/tree/master/docker):
+To build the base image ("nu-base"):
 
 <<< @/snippets/installation/build_containers_locally_base_image.sh
 
-And then to build the smaller container (using a Multistage build):
+And to build the smaller container("nu") using a multi-stage build:
 
 <<< @/snippets/installation/build_containers_locally_multistage_build.sh
 
-Either way, you can run either container as follows:
+You can run either the pre-built or locally built containers as follows:
 
 <<< @/snippets/installation/run_containers_built_locally.sh
-
-The second container is a bit smaller, if size is important to you.
 
 ## Getting Ready
 

--- a/snippets/installation/pull_prebuilt_container.sh
+++ b/snippets/installation/pull_prebuilt_container.sh
@@ -1,2 +1,2 @@
-$ docker pull quay.io/nushell/nu
 $ docker pull quay.io/nushell/nu-base
+$ docker pull quay.io/nushell/nu


### PR DESCRIPTION
I made the following changes to the Docker installation instructions.

- Link to Quay.io
- Move the difference of "nu" and "nu-base" to before the run commands
- "dockerfiles provided" -> "provided dockerfiles"
- Changed "Multistage build" to match capitalization I found in this blog post: https://www.docker.com/blog/multi-stage-builds/
- I changed the order of the `pull_prebuilt_container.sh` to match the other instructions on the paragraph (everything else first does an example for "nu-base", then "nu", and now that matches)


I realize a lot of documentation is just personal preferences / styles, so feel free to reject some / all of these changes! I just saw some things that I would have done differently.