### PR TITLE
Add list of accepted parameter types

### DIFF
--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -85,6 +85,11 @@ error: Type Error
 
 This can help you guide users of your definitions to call them with only the supported types.
 
+The currently accepted types are (as of version 0.28.0):
+```
+int, string, path, table, unit, number, pattern, range, block, any
+```
+
 ## Flags
 
 In addition to passing positional parameters, you can also pass named parameters by defining flags for your custom commands.


### PR DESCRIPTION
Currently, it seems this information is only available [in the source code](https://github.com/nushell/nushell/blob/56adc7c3c6c8c011c2db9cdcf780d9213a925a8b/crates/nu-parser/src/parse/def/primitives.rs#L162-L185).

The mentioned version 0.28.0 will get obsolete soon but I'd guess better than nothing, unless there is some mechanism to keep this up to date automatically.