### PR TITLE
update ls -f -> ls -la

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -7,7 +7,7 @@ Note: this table assumes Nu 0.14.1 or later.
 | `ls`     | `ls` | Lists the files in the current directory |
 | `ls <dir>`    | `ls <dir>`| Lists the files in the given directory |
 | `ls pattern*` | `ls pattern*` | Lists files that match a given pattern |
-| `ls -la` | `ls --full` or `ls -f` | List files with all available information |
+| `ls -la` | `ls --long --all` or `ls -la` | List files with all available information, including hidden files |
 | `ls -d */` | `ls | where type == Dir` | List directories |
 | `find . -name *.rs` | `ls **/*.rs` | Find recursively all files that match a given pattern |
 | `cd <directory>` | `cd <directory>` | Change to the given directory |

--- a/es/book/llegando_de_bash.md
+++ b/es/book/llegando_de_bash.md
@@ -7,7 +7,7 @@ Nota: Esta tabla asume Nushell 0.14.1 or posterior.
 | `ls`     | `ls` | Lists the files in the current directory |
 | `ls <dir>`    | `ls <dir>`| Lists the files in the given directory |
 | `ls pattern*` | `ls pattern*` | Lists files that match a given pattern |
-| `ls -la` | `ls --full` or `ls -f` | List files with all available information |
+| `ls -la` | `ls --long --all` or `ls -la` | List files with all available information, including hidden files |
 | `ls -d */` | `ls | where type == Dir` | List directories |
 | `cd <directory>` | `cd <directory>` | Change to the given directory |
 | `cd` | `cd` | Change to the home directory |

--- a/ja/book/coming_from_bash.md
+++ b/ja/book/coming_from_bash.md
@@ -7,7 +7,7 @@
 | `ls`     | `ls` | Lists the files in the current directory |
 | `ls <dir>`    | `ls <dir>`| Lists the files in the given directory |
 | `ls pattern*` | `ls pattern*` | Lists files that match a given pattern |
-| `ls -la` | `ls --full` or `ls -f` | List files with all available information |
+| `ls -la` | `ls --long --all` or `ls -la` | List files with all available information, including hidden files |
 | `ls -d */` | `ls | where type == Dir` | List directories |
 | `find . -name *.rs` | `ls **/*.rs` | Find recursively all files that match a given pattern |
 | `cd <directory>` | `cd <directory>` | Change to the given directory |


### PR DESCRIPTION
The "coming from bash" page for all three languages (en/es/ja) shows `ls -f` as the nu equivalent of the vanilla `la -la`. As of 0.29.0, `ls -f` doesn't seem to exist, but `ls -la` gets you both the long form and shows hidden files.