### PR TITLE
update update `sys_get_` examples

### DIFF
--- a/snippets/introduction/sys_get_external_echo_example.sh
+++ b/snippets/introduction/sys_get_external_echo_example.sh
@@ -1,2 +1,2 @@
-> sys | get host.sessions | each { ^echo $it }
+> sys | get host.sessions.name | each { ^echo $it }
 jonathan

--- a/snippets/introduction/sys_get_nested_example.sh
+++ b/snippets/introduction/sys_get_nested_example.sh
@@ -1,4 +1,4 @@
-> sys | get host.sessions
+> sys | get host.sessions.name
 ───┬─────────
  0 │ jonathan
 ───┴─────────


### PR DESCRIPTION
Hello! 

The type of sys.host.sessions was changed from a string to a table in this
PR: https://github.com/nushell/nushell/pull/2954, this PR updates the examples in the introduction to reflect that. :)