### PR TITLE
Adding config path argument to first paragraph of configuration.md file

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -2,7 +2,7 @@
 
 ## Nushell Configuration with `config.toml`
 
-Nushell uses a configuration system that loads a toml file at launch time. That configuration file is called the Nushell `config.toml` file. It contains the configuration points that nushell will use as default settings. Each setting follows a key value pattern. A value can be a number, a string, or an array. Below is a description of each setting.
+Nushell uses a configuration system that loads a toml file at launch time. That configuration file is called the Nushell `config.toml` file. The path to the configuration file can be found by calling `config path`. It contains the configuration points that nushell will use as default settings. Each setting follows a key value pattern. A value can be a number, a string, or an array. Below is a description of each setting.
 
 An example of the nushell `config.toml` can be found in our repo [here](https://github.com/nushell/nushell/tree/main/docs/sample_config).
 


### PR DESCRIPTION
It was brought up in this issue: https://github.com/nushell/nushell/issues/3911 that `config path` is not mentioned on the configuration page. This PR adds this info in the first paragraph to help new users. 