### PR TITLE
Remove grep from list of builtins, add str example

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -26,13 +26,16 @@ Note: this table assumes Nu 0.14.1 or later.
 | `rm -rf <path>` | `rm -r <path>` | Recursively removes the given path |
 | `chmod` | `<not yet possible>` | Changes the file attributes |
 | `date -d <date>` | `echo <date> | str to-datetime -f <format>` | Parse a date ([format documentation](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html)) |
+| `sed` | `str find-replace` | Find and replace a pattern in a string |
+| `grep <pattern>` | `where { ($it | str contains <substring>) }` | Filter strings that contain the substring |
 | `man <command>` | `help <command>` | Get the help for a given command |
 |  | `help commands` | List all available commands |
+|  | `help --find <string>` | Search for match in all available commands |
 | `command1 && command2` | `command1; command2` | Run a command, and if it's successful run a second |
 | `stat $(which git)` | `stat (which git).path` | Use command output as argument for other command |
 | `echo $PATH` | `echo $nu.path` | See the current path |
 | `<update ~/.bashrc>` | `config set path [<dir1> <dir2> ...]` | Update PATH permanently |
-| `export PATH = $PATH:/usr/other/bin` | `<not yet possible>` | Update PATH temporarily |
+| `export PATH = $PATH:/usr/other/bin` | `pathvar add <path>` | Update PATH temporarily |
 | `export` | `echo $nu.env` | List the current environment variables |
 | `<update ~/.bashrc>` | `echo $nu.env | insert var value | config set_into env` | Update environment variables permanently |
 | `FOO=BAR ./bin` | `FOO=BAR ./bin` | Update environment temporarily |
@@ -41,3 +44,4 @@ Note: this table assumes Nu 0.14.1 or later.
 | `bash -c <commands>` | `nu -c <commands>` | Run a pipeline of commands (requires 0.9.1 or later) |
 | `bash <script file>` | `nu <script file>` | Run a script file (requires 0.9.1 or later) |
 | `\` | `<not yet possible>` | Line continuation is not yet supported. |
+

--- a/book/nushell_map.md
+++ b/book/nushell_map.md
@@ -37,7 +37,6 @@ Note: this table assumes Nu 0.14.1 or later.
 | format                 |                               | String.Format                                        | String.Format                              |                                                 |
 | from                   | import flatfile, openjson, cast(variable as xml) |   -                               | Import/ConvertFrom-{Csv,Xml,Html,Json}     |                                                 |
 | get                    |                               | Select                                               | (cmd).column                               |                                                 |
-| grep                   | filter                        | filter                                               | filter                                     | filter                                          |
 | group_by               | group by                      | GroupBy, group                                       | Group-Object, group                        |                                                 |
 | headers                |                               |                                                      |                                            |                                                 |
 | help                   | sp_help                       |   -                                                  | Get-Help, help, man                        | man                                             |

--- a/book/nushell_map_functional.md
+++ b/book/nushell_map_functional.md
@@ -36,7 +36,6 @@ Note: this table assumes Nu 0.14.1 or later.
 | format                 | format                        |                                                      | Text.Printf.printf                         |                                                 |
 | from                   |                               |                                                      |                                            |                                                 |
 | get                    |                               |                                                      |                                            |                                                 |
-| grep                   | filter, filterv, select       | filter, filterMap                                    | filter                                     |                                                 |
 | group_by               | group-by                      |                                                      | group, groupBy                             |                                                 |
 | headers                |                               |                                                      |                                            |                                                 |
 | help                   | doc                           |                                                      |                                            |                                                 |

--- a/book/nushell_map_imperative.md
+++ b/book/nushell_map_imperative.md
@@ -36,7 +36,6 @@ Note: this table assumes Nu 0.14.1 or later.
 | format                 | format                        | format                                               | format                                     | format!                                         |
 | from                   | csv, json, sqlite3            |                                                      |                                            |                                                 |
 | get                    | dict[\"key\"]                 | Map[\"key\"]                                         | map[\"key\"]                               | HashMap["key"], get, entry                      |
-| grep                   | filter                        | filter                                               | filter                                     | filter                                          |
 | group_by               | itertools.groupby             | groupBy                                              |                                            | group_by                                        |
 | headers                |                               |                                                      |                                            |                                                 |
 | help                   | help                          |                                                      |                                            |                                                 |

--- a/es/book/llegando_de_bash.md
+++ b/es/book/llegando_de_bash.md
@@ -9,6 +9,7 @@ Nota: Esta tabla asume Nushell 0.14.1 or posterior.
 | `ls pattern*` | `ls pattern*` | Lists files that match a given pattern |
 | `ls -la` | `ls --long --all` or `ls -la` | List files with all available information, including hidden files |
 | `ls -d */` | `ls | where type == Dir` | List directories |
+| `find . -name *.rs` | `ls **/*.rs` | Find recursively all files that match a given pattern |
 | `cd <directory>` | `cd <directory>` | Change to the given directory |
 | `cd` | `cd` | Change to the home directory |
 | `mkdir <path>` | `mkdir <path>` | Creates the given path |
@@ -24,18 +25,21 @@ Nota: Esta tabla asume Nushell 0.14.1 or posterior.
 | | `rm -t <path>` | Move the given file to the system trash |
 | `rm -rf <path>` | `rm -r <path>` | Recursively removes the given path |
 | `chmod` | `<not yet possible>` | Changes the file attributes |
+| `date -d <date>` | `echo <date> | str to-datetime -f <format>` | Parse a date ([format documentation](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html)) |
+| `sed` | `str find-replace` | Find and replace a pattern in a string |
+| `grep <pattern>` | `where { ($it | str contains <substring>) }` | Filter strings that contain the substring |
 | `man <command>` | `help <command>` | Get the help for a given command |
 |  | `help commands` | List all available commands |
+|  | `help --find <string>` | Search for match in all available commands |
 | `command1 && command2` | `command1; command2` | Run a command, and if it's successful run a second |
+| `stat $(which git)` | `stat (which git).path` | Use command output as argument for other command |
 | `echo $PATH` | `echo $nu.path` | See the current path |
-| `<update ~/.bashrc>` | `config set [path [<dir1> <dir2> ...]]` | Update PATH permanently |
-| `export PATH = $PATH:/usr/other/bin` | `<not yet possible>` | Update PATH temporarily |
+| `<update ~/.bashrc>` | `config set path [<dir1> <dir2> ...]` | Update PATH permanently |
+| `export PATH = $PATH:/usr/other/bin` | `pathvar add <path>` | Update PATH temporarily |
 | `export` | `echo $nu.env` | List the current environment variables |
 | `<update ~/.bashrc>` | `echo $nu.env | insert var value | config set_into env` | Update environment variables permanently |
 | `FOO=BAR ./bin` | `FOO=BAR ./bin` | Update environment temporarily |
-| `alias s="git status -sb"` | `alias s [] { git status -sb }` | Define an alias temporarily |
-| `<update ~/.bashrc>` | `config set [startup ["alias myecho [msg] { echo Hello $msg }"]]` | Add a first alias permanently (for new shells) |
-| `<update ~/.bashrc>` | `config get startup | append "alias s [] { git status -sb }" | config set_into startup` | Add an additional alias permanently (for new shells) |
+| `alias s="git status -sb"` | `alias s = git status -sb` | Define an alias temporarily |
 | `<update ~/.bashrc>` | `<update nu/config.toml>` | Add and edit alias permanently (for new shells), find path for the file with `config path` |
 | `bash -c <commands>` | `nu -c <commands>` | Run a pipeline of commands (requires 0.9.1 or later) |
 | `bash <script file>` | `nu <script file>` | Run a script file (requires 0.9.1 or later) |

--- a/es/book/mapa_funcional_nushell.md
+++ b/es/book/mapa_funcional_nushell.md
@@ -51,7 +51,6 @@ Nota: Esta tabla asume Nu 0.14.1 o posterior.
 | from xml               |                               |                                                      |                                            |                                                 |
 | from yaml              |                               |                                                      |                                            |                                                 |
 | get                    |                               |                                                      |                                            |                                                 |
-| grep                   | filter                        |                                                      | filter                                     |                                                 |
 | group_by               | group-by                      |                                                      |                                            |                                                 |
 | headers                |                               |                                                      |                                            |                                                 |
 | help                   | doc                           |                                                      |                                            |                                                 |

--- a/es/book/mapa_imperativo_nushell.md
+++ b/es/book/mapa_imperativo_nushell.md
@@ -51,7 +51,6 @@ Nota: esta tabla asume Nu 0.14.1 o posterior.
 | from xml               |                               |                                                      |                                            |                                                 |
 | from yaml              |                               |                                                      |                                            |                                                 |
 | get                    | dict[\"key\"]                 | Map[\"key\"]                                         | map[\"key\"]                               |                                                 |
-| grep                   | filter                        | filter                                               | filter                                     | filter                                          |
 | group_by               | itertools.groupby             |                                                      |                                            |                                                 |
 | headers                |                               |                                                      |                                            |                                                 |
 | help                   | help                          |                                                      |                                            |                                                 |

--- a/es/book/mapa_nushell.md
+++ b/es/book/mapa_nushell.md
@@ -52,7 +52,6 @@ Nota: Esta tabla asume Nu 0.14.1 o posterior.
 | from xml               | cast(variable as xml)         | N/A                                                  | ConvertFrom-Xml                            |                                                 |
 | from yaml              | N/A                           | N/A                                                  | N/A                                        |                                                 |
 | get                    |                               | Select                                               | (cmd).column                               |                                                 |
-| grep                   | filter                        | filter                                               | filter                                     | filter                                          |
 | group_by               | group by                      | GroupBy, group                                       | Group-Object, group                        |                                                 |
 | headers                |                               |                                                      |                                            |                                                 |
 | help                   | sp_help                       | N/A                                                  | Get-Help, help, man                        | man                                             |

--- a/ja/book/coming_from_bash.md
+++ b/ja/book/coming_from_bash.md
@@ -26,18 +26,20 @@
 | `rm -rf <path>` | `rm -r <path>` | Recursively removes the given path |
 | `chmod` | `<not yet possible>` | Changes the file attributes |
 | `date -d <date>` | `echo <date> | str to-datetime -f <format>` | Parse a date ([format documentation](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html)) |
+| `sed` | `str find-replace` | Find and replace a pattern in a string |
+| `grep <pattern>` | `where { ($it | str contains <substring>) }` | Filter strings that contain the substring |
 | `man <command>` | `help <command>` | Get the help for a given command |
 |  | `help commands` | List all available commands |
+|  | `help --find <string>` | Search for match in all available commands |
 | `command1 && command2` | `command1; command2` | Run a command, and if it's successful run a second |
-| `stat $(which git)` | `stat $(which git).path` | Use command output as argument for other command |
+| `stat $(which git)` | `stat (which git).path` | Use command output as argument for other command |
 | `echo $PATH` | `echo $nu.path` | See the current path |
 | `<update ~/.bashrc>` | `config set path [<dir1> <dir2> ...]` | Update PATH permanently |
-| `export PATH = $PATH:/usr/other/bin` | `<not yet possible>` | Update PATH temporarily |
+| `export PATH = $PATH:/usr/other/bin` | `pathvar add <path>` | Update PATH temporarily |
 | `export` | `echo $nu.env` | List the current environment variables |
 | `<update ~/.bashrc>` | `echo $nu.env | insert var value | config set_into env` | Update environment variables permanently |
 | `FOO=BAR ./bin` | `FOO=BAR ./bin` | Update environment temporarily |
-| `alias s="git status -sb"` | `alias s [] { git status -sb }` | Define an alias temporarily |
-| `<update ~/.bashrc>` | `alias --save myecho [msg] { echo Hello $msg }` | Define an alias for all sessions (persist it in startup config) |
+| `alias s="git status -sb"` | `alias s = git status -sb` | Define an alias temporarily |
 | `<update ~/.bashrc>` | `<update nu/config.toml>` | Add and edit alias permanently (for new shells), find path for the file with `config path` |
 | `bash -c <commands>` | `nu -c <commands>` | Run a pipeline of commands (requires 0.9.1 or later) |
 | `bash <script file>` | `nu <script file>` | Run a script file (requires 0.9.1 or later) |

--- a/ja/book/nushell_map.md
+++ b/ja/book/nushell_map.md
@@ -36,7 +36,6 @@
 | format                 |                               | String.Format                                        | String.Format                              |                                                 |
 | from                   | import flatfile, openjson, cast(variable as xml) |   -                               | Import/ConvertFrom-{Csv,Xml,Html,Json}     |                                                 |
 | get                    |                               | Select                                               | (cmd).column                               |                                                 |
-| grep                   | filter                        | filter                                               | filter                                     | filter                                          |
 | group_by               | group by                      | GroupBy, group                                       | Group-Object, group                        |                                                 |
 | headers                |                               |                                                      |                                            |                                                 |
 | help                   | sp_help                       |   -                                                  | Get-Help, help, man                        | man                                             |

--- a/ja/book/nushell_map_functional.md
+++ b/ja/book/nushell_map_functional.md
@@ -35,7 +35,6 @@
 | format                 | format                        |                                                      | Text.Printf.printf                         |                                                 |
 | from                   |                               |                                                      |                                            |                                                 |
 | get                    |                               |                                                      |                                            |                                                 |
-| grep                   | filter, filterv, select       | filter, filterMap                                    | filter                                     |                                                 |
 | group_by               | group-by                      |                                                      | group, groupBy                             |                                                 |
 | headers                |                               |                                                      |                                            |                                                 |
 | help                   | doc                           |                                                      |                                            |                                                 |

--- a/ja/book/nushell_map_imperative.md
+++ b/ja/book/nushell_map_imperative.md
@@ -35,7 +35,6 @@
 | format                 | format                        | format                                               | format                                     | format!                                         |
 | from                   | csv, json, sqlite3            |                                                      |                                            |                                                 |
 | get                    | dict[\"key\"]                 | Map[\"key\"]                                         | map[\"key\"]                               | HashMap["key"], get, entry                      |
-| grep                   | filter                        | filter                                               | filter                                     | filter                                          |
 | group_by               | itertools.groupby             | groupBy                                              |                                            | group_by                                        |
 | headers                |                               |                                                      |                                            |                                                 |
 | help                   | help                          |                                                      |                                            |                                                 |


### PR DESCRIPTION
* Remove grep from tables where it's listed as a builtin.
* Add example of using `where` and `str contains` as a substitute for grep
* Add example of using `str find-replace` as a substitute for `sed`
* Add `pathvar` as a method of temporarily changing the PATH
* Update some tables to reflect usage in newer versions

Some tables listed `grep` alongside Nushell commands, which gives a false impression that it's also included as part of Nushell.

I removed all references of `grep` in those tables. In all of them, it was listed as a substitute for `filter`, which is `where` in Nushell and is already present in those tables.

I've added examples of using `where { ... | str contains } ` as a substitute for `grep`; `str find-replace` as a substitute for `sed`; `pathvar` as a method of changing the PATH. I've also updated some of the tables to reflect newer versions.