### PR TITLE
Document removing environment variables

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -39,6 +39,8 @@ Note: this table assumes Nu 0.14.1 or later.
 | `export` | `echo $nu.env` | List the current environment variables |
 | `<update ~/.bashrc>` | `echo $nu.env | insert var value | config set_into env` | Update environment variables permanently |
 | `FOO=BAR ./bin` | `FOO=BAR ./bin` | Update environment temporarily |
+| `export FOO=BAR` | `let-env FOO = BAR` | Set environment variable for current session |
+| `unset FOO` | `let-env FOO = $nothing` | Unset environment variable for current session |
 | `alias s="git status -sb"` | `alias s = git status -sb` | Define an alias temporarily |
 | `<update ~/.bashrc>` | `<update nu/config.toml>` | Add and edit alias permanently (for new shells), find path for the file with `config path` |
 | `bash -c <commands>` | `nu -c <commands>` | Run a pipeline of commands (requires 0.9.1 or later) |

--- a/book/environment.md
+++ b/book/environment.md
@@ -54,3 +54,74 @@ If you have more than one environment variable you'd like to set, you can create
 ## Permanent environment variables
 
 You can also set environment variables that are set at startup and are available for the duration of Nushell running. These can be set in the `env` section of the [config](configuration.md).
+
+## Removing environment variables
+
+You can remove an environment variable only if it was set in the current scope:
+
+```
+> let-env FOO = BAR
+...
+> unlet-env FOO
+```
+
+If you want to remove an environment variable stemming from a parent scope, you can do so by shadowing its value with `$nothing`:
+
+```
+> let-env FOO = BAR
+> do {
+    let-env FOO = $nothing
+    # $nu.env.FOO does not exist
+  }
+> $nu.env.FOO
+BAR
+```
+
+The same approach works with `load-env`. If you use `load-env`, you can simultaneously set some variables to a proper string value, while setting others to `$nothing`, and thus remove them.
+
+You can also use this approach in your `config.toml` to remove an environment variable from all future Nu sessions, but this is only possible by using `let-env` or `load-env` as part of the `startup` section. All values in the `env` section are literal strings:
+
+```
+# in config.toml
+startup = [
+    "let-env FOO = $nothing"
+]
+
+[env]
+BAZ="$nothing"
+```
+
+In the above example, any Nu session would start with no defined `FOO` environment variable, while `BAZ` would have a string value of `"$nothing"`.
+
+You can use the same approach with the long form of `with-env`:
+
+```
+> with-env [FOO $nothing] { echo $nu.env.FOO }
+error: Unknown column  # FOO is not seen in the block scope
+```
+
+Beware that the short form does not work with this feature, it treats the value as a string:
+
+```
+> FOO=$nothing echo $nu.env.FOO
+$nothing
+```
+
+Finally, be aware that environment variables set to `$nothing` can also be fully removed with `unlet-env` from the scope in which they are set. If a parent scope has an environment variable with the same name, this value will then be visible in the current scope.
+
+```
+> let-env FOO = BAR
+> do {
+    # FOO == BAR
+
+    let-env FOO = $nothing
+    # FOO does not exist
+
+    unlet-env FOO
+    # FOO == BAR (FOO from above this scope is seen again)
+
+    unlet-env FOO
+    # error: Not an environment variable
+    # the command finds FOO in the parent scope and can not remove it
+  }
+```

--- a/es/book/llegando_de_bash.md
+++ b/es/book/llegando_de_bash.md
@@ -39,7 +39,11 @@ Nota: Esta tabla asume Nushell 0.14.1 or posterior.
 | `export` | `echo $nu.env` | List the current environment variables |
 | `<update ~/.bashrc>` | `echo $nu.env | insert var value | config set_into env` | Update environment variables permanently |
 | `FOO=BAR ./bin` | `FOO=BAR ./bin` | Update environment temporarily |
+| `export FOO=BAR` | `let-env FOO = BAR` | Set environment variable for current session |
+| `unset FOO` | `let-env FOO = $nothing` | Unset environment variable for current session |
 | `alias s="git status -sb"` | `alias s = git status -sb` | Define an alias temporarily |
+| `<update ~/.bashrc>` | `config set [startup ["alias myecho [msg] { echo Hello $msg }"]]` | Add a first alias permanently (for new shells) |
+| `<update ~/.bashrc>` | `config get startup | append "alias s [] { git status -sb }" | config set_into startup` | Add an additional alias permanently (for new shells) |
 | `<update ~/.bashrc>` | `<update nu/config.toml>` | Add and edit alias permanently (for new shells), find path for the file with `config path` |
 | `bash -c <commands>` | `nu -c <commands>` | Run a pipeline of commands (requires 0.9.1 or later) |
 | `bash <script file>` | `nu <script file>` | Run a script file (requires 0.9.1 or later) |

--- a/ja/book/coming_from_bash.md
+++ b/ja/book/coming_from_bash.md
@@ -39,7 +39,10 @@
 | `export` | `echo $nu.env` | List the current environment variables |
 | `<update ~/.bashrc>` | `echo $nu.env | insert var value | config set_into env` | Update environment variables permanently |
 | `FOO=BAR ./bin` | `FOO=BAR ./bin` | Update environment temporarily |
+| `export FOO=BAR` | `let-env FOO = BAR` | Set environment variable for current session |
+| `unset FOO` | `let-env FOO = $nothing` | Unset environment variable for current session |
 | `alias s="git status -sb"` | `alias s = git status -sb` | Define an alias temporarily |
+| `<update ~/.bashrc>` | `alias --save myecho [msg] { echo Hello $msg }` | Define an alias for all sessions (persist it in startup config) |
 | `<update ~/.bashrc>` | `<update nu/config.toml>` | Add and edit alias permanently (for new shells), find path for the file with `config path` |
 | `bash -c <commands>` | `nu -c <commands>` | Run a pipeline of commands (requires 0.9.1 or later) |
 | `bash <script file>` | `nu <script file>` | Run a script file (requires 0.9.1 or later) |


### PR DESCRIPTION
* Describe `unlet-env`

* Describe `let-env ENVVAR = $nothing`

* Add `let-env` as example of `export` and `unset` in Bash table

I could only update the Bash tables in the translated books.