### PR TITLE
Add equivalent for `>>` in bash and fix a documentation issue in save

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -15,7 +15,8 @@ Note: this table assumes Nu 0.14.1 or later.
 | `mkdir <path>` | `mkdir <path>` | Creates the given path |
 | `mkdir -p <path>` | `mkdir <path>` | Creates the given path, creating parents as necessary |
 | `touch test.txt` | `touch test.txt` | Create a file |
-| `> <path>` | `| save --raw <path>` | Save string into a file |
+| `> <path>` | `\| save --raw <path>` | Save string into a file |
+| `>> <path>` | `\| save --raw --append <path>` | Append string to a file |
 | `cat <path>` | `open --raw <path>` | Display the contents of the given file |
 | | `open <path>` | Read a file as structured data |
 | `mv <source> <dest>` | `mv <source> <dest>` | Move file to new location |


### PR DESCRIPTION
Signed-off-by: Tw <tw19881113@gmail.com>