### PR TITLE
remove additional backslash

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -15,8 +15,8 @@ Note: this table assumes Nu 0.14.1 or later.
 | `mkdir <path>` | `mkdir <path>` | Creates the given path |
 | `mkdir -p <path>` | `mkdir <path>` | Creates the given path, creating parents as necessary |
 | `touch test.txt` | `touch test.txt` | Create a file |
-| `> <path>` | `\| save --raw <path>` | Save string into a file |
-| `>> <path>` | `\| save --raw --append <path>` | Append string to a file |
+| `> <path>` | `| save --raw <path>` | Save string into a file |
+| `>> <path>` | `| save --raw --append <path>` | Append string to a file |
 | `cat <path>` | `open --raw <path>` | Display the contents of the given file |
 | | `open <path>` | Read a file as structured data |
 | `mv <source> <dest>` | `mv <source> <dest>` | Move file to new location |


### PR DESCRIPTION
It seems github's markdown parser have different behavior for the backslash in code block than the website's:

github's default parser works fine:
![screenshot-20210908@152412](https://user-images.githubusercontent.com/587972/132464885-4312f052-6493-4167-a75a-6df2b32bcc72.png)


but the website shows the additional backslash in the table:

![screenshot-20210908@152056](https://user-images.githubusercontent.com/587972/132464769-854f77de-f916-4da3-bf73-a14398e76db8.png)


Because the website is our target eventually, so I remove the additional backslash.
