### PR TITLE
Fix typo in "config set" instructions

### DIFF
--- a/blog/2019-11-05-nushell-0_5_0.md
+++ b/blog/2019-11-05-nushell-0_5_0.md
@@ -29,8 +29,8 @@ To get started, you'll need to first copy the environment you're using into the 
 
 Version 0.7.2 and later (added: Dec 24, 2019) :
 ```shell
-> config --set [path $nu.path]
-> config --set [env $nu.env]
+> config set [path $nu.path]
+> config set [env $nu.env]
 ```
 
 Once these values are set, you'll be able to use Nu as your login shell.
@@ -104,7 +104,7 @@ We've added two new commands: `prepend` for adding items to the start of a table
 Version 0.7.2 and later:
 
 ```shell
-> echo $nu.path | prepend "/my/new/directory" | config --set_into path
+> echo $nu.path | prepend "/my/new/directory" | config set_into path
 ```
 
 ## Adding variables to your environment
@@ -118,7 +118,7 @@ You can use a similar set of steps to add new variables, or change existing vari
 Version 0.7.2 and later:
 
 ```shell
-> echo $nu.env | insert GREETING hello_world | config --set_into env
+> echo $nu.env | insert GREETING hello_world | config set_into env
 ```
 
 _Note: the previous `add` command of previous releases has been renamed `insert` to remove confusion with mathematical functions._


### PR DESCRIPTION
I was trying to set configs in nu 0.37 and noticed this error. I can't check, but I suspect (?) the instructions were meant to be as PRed for 0.7.2 (and that these changes haven't been introduced later)?