### PR TITLE
winget: Explicitly specify nu package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ brew install nushell
 With [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/):
 
 ```powershell
-$ winget install nu
+$ winget install -e nu
 ```
 
 #### Start the shell


### PR DESCRIPTION
`winget install nu` from the instructions yields an error.

`winget install -e nu` works by explicitly specifying the package name to install.

```
PS C:\Users\peter> winget install nu
Multiple packages found matching input criteria. Please refine the input.
Name                Id              Source
-------------------------------------------
NUCES CFD Timetable 9P607FB4K5FB    msstore
nu                  Nushell.Nushell winget
```

```
PS C:\Users\peter> winget install -e nu
Found nu [Nushell.Nushell] Version 0.38.0
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/nushell/nushell/releases/download/0.38.0/nu_0_38_0_windows.msi
  ██████████████████████████████  54.2 MB / 54.2 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```