### PR TITLE
Show link to Groups setion

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -48,7 +48,7 @@ a
 b; c | d
 ```
 
-When this script is run, Nushell will first run the `a` command to completion and view its results. Next, Nushell will run `b; c | d` following the rules in the "Command groups" section.
+When this script is run, Nushell will first run the `a` command to completion and view its results. Next, Nushell will run `b; c | d` following the rules in the ["Groups" section](https://www.nushell.sh/book/types_of_data.html#groups).
 
 ## Parameterizing Scripts
 


### PR DESCRIPTION
I was looking at this page and was confused by this line cause I couldn't search "Command groups" page neither by "Command" nor by "group".

After that I came across https://www.nushell.sh/book/types_of_data.html#groups, and thought it would be useful to show the link instead of the ambiguous expression.