### PR TITLE
fix: delete duplicate header text

### DIFF
--- a/book/commands/README.md
+++ b/book/commands/README.md
@@ -1,5 +1,7 @@
-# How do I get started?
-
+---
+title: How do I get started?
+layout: command
+---
 Pick any command from the checklist and write a comment acknowledging you started work.
 
 ## Instructions for documenting a Nu command of your choosing


### PR DESCRIPTION
Hi! There was duplicate header text while I was viewing Nushell Command Reference, so I open this PR.

Before:
![화면 캡처 2022-02-08 113315](https://user-images.githubusercontent.com/32578710/152907246-a48be922-2413-4ae9-9011-7e3ebbd5d148.png)

After:
![화면 캡처 2022-02-08 113335](https://user-images.githubusercontent.com/32578710/152907257-10309bc7-4ca7-4ea5-b984-d11f872ce5c4.png)

