### PR TITLE
Correct Winget installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ brew install nushell
 With [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/):
 
 ```powershell
-$ winget install nu
+$ winget install nushell
 ```
 
 For Windows users, you may also need to install the [Microsoft Visual C++ 2015 Redistributables](https://www.microsoft.com/en-us/download/details.aspx?id=52685).

--- a/book/installation.md
+++ b/book/installation.md
@@ -4,7 +4,7 @@ The best way currently to get Nu up and running is to install from [crates.io](h
 
 ## Pre-built binaries
 
-You can download Nu pre-built from the [release page](https://github.com/nushell/nushell/releases). Alternatively, if you use [Homebrew](https://brew.sh/) for macOS or Linux, you can install the binary by running `brew install nushell`, and if you use [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/) on Windows, you can install Nu by running `winget install nu`.
+You can download Nu pre-built from the [release page](https://github.com/nushell/nushell/releases). Alternatively, if you use [Homebrew](https://brew.sh/) for macOS or Linux, you can install the binary by running `brew install nushell`, and if you use [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/) on Windows, you can install Nu by running `winget install nushell`.
 
 ### Windows
 


### PR DESCRIPTION
The instructions to install nushell using Winget referenced an incorrect
package name nu.

Updates made to the website and book documentation to reflect the
correct package name nushell.

Resolves nushell/nushell.github.io#246