### PR TITLE
Add installation instructions using Chocolatey

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ With [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/):
 $ winget install nushell
 ```
 
+With [Chocolatey](https://chocolatey.org/):
+
+```powershell
+$ choco install nushell
+```
+
 For Windows users, you may also need to install the [Microsoft Visual C++ 2015 Redistributables](https://www.microsoft.com/en-us/download/details.aspx?id=52685).
 
 #### Start the shell

--- a/book/installation.md
+++ b/book/installation.md
@@ -4,7 +4,9 @@ The best way currently to get Nu up and running is to install from [crates.io](h
 
 ## Pre-built binaries
 
-You can download Nu pre-built from the [release page](https://github.com/nushell/nushell/releases). Alternatively, if you use [Homebrew](https://brew.sh/) for macOS or Linux, you can install the binary by running `brew install nushell`, and if you use [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/) on Windows, you can install Nu by running `winget install nushell`.
+You can download Nu pre-built from the [release page](https://github.com/nushell/nushell/releases).
+
+Alternatively, for macOS or Linux, you can install the binary using [Homebrew](https://brew.sh/) by running `brew install nushell`, and on Windows you can install Nu with [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/) by running `winget install nushell`, or with [Chocolatey](https://chocolatey.org/) by running `choco install nushell`.
 
 ### Windows
 


### PR DESCRIPTION
Add installation instructions for `Nushell` on Windows using the [Chocolatey](https://chocolatey.org/) package manager.

The project `README.md` and the installation section of the book have been updated to provide package installation instructions using the [Chocolatey](https://chocolatey.org/) package manager.

Resolves #247