### PR TITLE
Add case sensitivity section to operators page

### DIFF
--- a/book/operators.md
+++ b/book/operators.md
@@ -30,3 +30,17 @@ Commands that take a boolean expression, such as
 are automatically evaluated in shorthand math mode.
 
 For example, `let a = 2; let b = 3; $a * $b` outputs `6`.
+
+## Case Sensitivity
+
+Operators are always case-sensitive when operating on strings. In the future Nu may have simpler syntax for case-insensitive operations, but for now you can usually use the `str` subcommands (run `help str` for a full list). For example, this returns files whose names contain "foo" (case-sensitive):
+
+```nushell
+ls | where name =~ "foo"
+```
+
+And this will do the same but case-insensitive:
+
+```nushell
+ls | where ($it.name | str contains --insensitive "foo")
+```


### PR DESCRIPTION
Adding some info to cover the basics of case sensitivity. I think case-insensitive comparisons are a common thing to do and this is worth documenting on the operators page, just let me know if I should put this info elsewhere.