### PR TITLE
Nu book: grammar + spelling pass

### DIFF
--- a/book/3rdpartyprompts.md
+++ b/book/3rdpartyprompts.md
@@ -14,10 +14,10 @@ nerdfonts are not required but they make the presentation much better.
 
 [repo](https://github.com/JanDeDobbeleer/oh-my-posh)
 
-If you like [oh-my-posh](https://ohmyposh.dev/), you can use oh-my-posh with nushell with few steps. It's works great with nushell. There is how to setup oh-my-posh with nushell:
+If you like [oh-my-posh](https://ohmyposh.dev/), you can use oh-my-posh with Nushell with a few steps. It works great with Nushell. How to setup oh-my-posh with Nushell:
 
 1. Install Oh My Posh and download oh-my-posh's themes following [guide](https://ohmyposh.dev/docs/linux#installation).
-2. Download and Install a [nerd font](https://github.com/ryanoasis/nerd-fonts).
+2. Download and install a [nerd font](https://github.com/ryanoasis/nerd-fonts).
 3. Set the PROMPT_COMMAND in ~/.config/nushell/config.nu, change `M365Princess.omp.json` to whatever you like [Themes demo](https://ohmyposh.dev/docs/themes).
 
 ```shell
@@ -35,8 +35,8 @@ If you like [oh-my-posh](https://ohmyposh.dev/), you can use oh-my-posh with nus
 3. Set the starship shell environment variable to `nu` by running this commend `let-env STARSHIP_SHELL = "nu"`
 4. If you want the default ticking clock with date & time on the right prompt execut this command `hide PROMPT_COMMAND_RIGHT`
 5. If you don't want the default indicator, you can run this command `let-env PROMPT_INDICATOR = " "`
-6. Set starship as your left prompt with this command `let-env PROMPT_COMMAND = { starship prompt --cmd-duration $env.CMD_DURATION_MS --status $env.LAST_EXIT_CODE | str trim }`. Note that you may not have to use `str trim` in the nushell prompt if you disable starship's default newline setting with this entry in the starship.toml file `add_newline = false`. There have been reports that this might not play nice with nushell prompts. We're still testing.
-7. Since nushell supports a right prompt you can also play around with starship's ability to set a right prompt. Setting the right prompt in nushell is identical to setting the left prompt however you use `PROMPT_COMMAND_RIGHT`.
+6. Set starship as your left prompt with this command `let-env PROMPT_COMMAND = { starship prompt --cmd-duration $env.CMD_DURATION_MS --status $env.LAST_EXIT_CODE | str trim }`. Note that you may not have to use `str trim` in the Nushell prompt if you disable starship's default newline setting with this entry in the starship.toml file `add_newline = false`. There have been reports that this might not play nice with Nushell prompts. We're still testing.
+7. Since Nushell supports a right prompt you can also play around with starship's ability to set a right prompt. Setting the right prompt in Nushell is identical to setting the left prompt however you use `PROMPT_COMMAND_RIGHT`.
 
 ## Purs
 

--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -1,6 +1,6 @@
 # Coloring and Theming in Nushell
 
-There are a few main parts that nushell allows you to change the color. All of these can be set in the `config.nu` configuration file. If you see the hash/hashtag/pound mark `#` in the config file it means the text after it is commented out.
+Many parts of Nushell's interface can have their color customized. All of these can be set in the `config.nu` configuration file. If you see the hash/hashtag/pound mark `#` in the config file it means the text after it is commented out.
 
 1. table borders
 2. primitive values
@@ -12,7 +12,7 @@ There are a few main parts that nushell allows you to change the color. All of t
 
 ---
 
-Table borders are controlled by the `table_mode` setting in the `config.nu`. Here is an example:
+Table borders are controlled by the `table_mode` setting in `config.nu`. Here is an example:
 
 ```shell
 > let $config = {
@@ -200,11 +200,11 @@ Here are the current options for `table_mode`:
 
 ---
 
-The "#hex" format is one way you typically see colors represented. It's simply the `#` character followed by 6 characters. The first two are for `red`, the second two are for `green`, and the third two are for `blue`. It's important that this string be surrounded in quotes, otherwise nushell thinks it's a commented out string.
+The "#hex" format is one way you typically see colors represented. It's simply the `#` character followed by 6 characters. The first two are for `red`, the second two are for `green`, and the third two are for `blue`. It's important that this string be surrounded in quotes, otherwise Nushell thinks it's a commented out string.
 
 Example: The primary `red` color is `"#ff0000"` or `"#FF0000"`. Upper and lower case in letters shouldn't make a difference.
 
-This `"#hex"` format allows us to specify 24-bit truecolor tones to different parts of nushell.
+This `"#hex"` format allows us to specify 24-bit truecolor tones to different parts of Nushell.
 
 ## `full "#hex"` format
 
@@ -314,7 +314,7 @@ Here's another small example using multiple color syntaxes with some comments.
 
 ## `Shape` values
 
-As mentioned above, `shape` is a term used to indicate the sytax coloring.
+As mentioned above, `shape` is a term used to indicate the syntax coloring.
 
 Here's the current list of flat shapes.
 
@@ -358,7 +358,7 @@ Here's a small example of how to apply color to these items. Anything not specif
 
 ## `Prompt` configuration and coloring
 
-The nushell prompt is configurable through these environment variables settings.
+The Nushell prompt is configurable through these environment variables:
 
 - `PROMPT_COMMAND`: Code to execute for setting up the prompt (block)
 - `PROMPT_COMMAND_RIGHT`: Code to execute for setting up the _RIGHT_ prompt (block) (see oh-my.nu in nu_scripts)
@@ -400,7 +400,7 @@ Theming combines all the coloring above. Here's a quick example of one we put to
 The key to making theming work is to make sure you specify all themes and colors you're going to use in the `config.nu` file _before_ you declare the `let config = ` line.
 
 ```
-# lets define some colors
+# let's define some colors
 
 let base00 = "#181818" # Default Background
 let base01 = "#282828" # Lighter Background (Used for status bars, line number and folding marks)

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -2,9 +2,9 @@
 
 ## Nushell Configuration with `config.nu`
 
-Nushell uses a configuration system that loads a nushell script file at launch time. That configuration file is called the Nushell `config.nu` file. The path to the configuration file can be found by calling `echo $nu.config-path`. It's a source file that runs, each step adding definitions, environment variables, and more to the global namespace.
+Nushell uses a configuration system that loads+runs a Nushell script file at launch time. That configuration file is called the `config.nu` file, and the path to it can be found by calling `echo $nu.config-path`. `config.nu` can add definitions, environment variables, and more to the global namespace.
 
-An example of the nushell `config.nu` can be found in our repo [here](https://github.com/nushell/nushell/blob/main/src/default_config.nu).
+An example `config.nu` file can be found in our repo [here](https://github.com/nushell/nushell/blob/main/src/default_config.nu).
 
 ### Configuring `$config`
 
@@ -24,7 +24,7 @@ let $config = ($config | update <field name> <field value>)
 
 ### Environment
 
-You can update the environment using `let-env` calls inside of the `config.nu` file. There are some important ones to look at which doing Nushell-specific settings:
+You can set environment variables using `let-env` calls inside the `config.nu` file. These are some important variables to look at for Nushell-specific settings:
 
 - `LS_COLORS`: Sets up colors per file type in ls
 - `PROMPT_COMMAND`: Code to execute for setting up the prompt (block or string)
@@ -48,7 +48,7 @@ You can build the full set of environment variables by running Nu inside of anot
 > env | each { echo $"let-env ($it.name) = '($it.raw)'" } | str collect (char nl)
 ```
 
-This will print out a `let-env` lines, one for each environment variable along with its setting.
+This will print out `let-env` lines, one for each environment variable along with its setting.
 
 Next, on some distros you'll also need to ensure Nu is in the /etc/shells list:
 
@@ -69,7 +69,7 @@ With this, you should be able to `chsh` and set Nu to be your login shell. After
 ### macOS: Keeping `/usr/bin/open` as `open`
 
 Some tools (e.g. Emacs) rely on an `open` command to open files on Mac.
-As nushell has its own `open` command which has different semantics and shadows `/usr/bin/open`, these tools will error out when trying to use it.
+As Nushell has its own `open` command which has different semantics and shadows `/usr/bin/open`, these tools will error out when trying to use it.
 One way to work around this is to define `alias`es in your `config.nu` file like this:
 
 ```

--- a/book/creating_errors.md
+++ b/book/creating_errors.md
@@ -5,7 +5,7 @@ Using the [metadata](metadata.md) information, you can create your own custom er
 * The title of the error
 * The label of error message, which includes both the text of the label and the span to underline
 
-You can use the `error make` command to create your own error messages. For example, let's say you had your own command called `my-command` and you wanted to give an error back to the caller about something wrong the the parameter that was passed in.
+You can use the `error make` command to create your own error messages. For example, let's say you had your own command called `my-command` and you wanted to give an error back to the caller about something wrong with a parameter that was passed in.
 
 First, you can take the span of where the argument is coming from:
 

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -12,7 +12,7 @@ def greet [name] {
 }
 ```
 
-In this definition, we define the `greet` command, which takes a single parameter `name`. Following this parameter is the block that represents what will happen with the custom command runs. When called, the custom command will set the value passed for `name` as the `$name` variable, which will be available to the block.
+In this definition, we define the `greet` command, which takes a single parameter `name`. Following this parameter is the block that represents what will happen when the custom command runs. When called, the custom command will set the value passed for `name` as the `$name` variable, which will be available to the block.
 
 To run the above, we can call it like we would call built-in commands:
 
@@ -31,7 +31,7 @@ As we do, we also get output just as we would with built-in commands:
 
 ## Command names
 
-In Nushell, a command name a string of characters or a quoted string. Here are some examples of valid command names: `greet`, `get-size`, `mycommand123`, `"mycommand"`, `😊`, and `123`. 
+In Nushell, a command name is a string of characters or a quoted string. Here are some examples of valid command names: `greet`, `get-size`, `mycommand123`, `"mycommand"`, `😊`, and `123`. 
 
 _Note: It's common practice in Nushell to separate the words of the command with `-` for better readability._ For example `get-size` instead of `getsize` or `get_size`.
 

--- a/book/dataframes.md
+++ b/book/dataframes.md
@@ -2,7 +2,7 @@
 
 > Note. The dataframe commands are available from version 0.33.1 onwards
 
-As we have seen so far, nushell makes working with data its main priority.
+As we have seen so far, Nushell makes working with data its main priority.
 `Lists` and `Tables` are there to help you cycle through values in order to
 perform multiple operations or find data in a breeze. However, there are
 certain operations where a row-based data layout is not the most efficient way
@@ -11,7 +11,7 @@ like group-by or join using large datasets can be costly memory-wise, and may
 lead to large computation times if they are not done using the appropriate
 data format.
 
-For this reason, the `DataFrame` structure was introduced to nushell. A
+For this reason, the `DataFrame` structure was introduced to Nushell. A
 `DataFrame` stores its data in a columnar format using as its base the [Apache
 Arrow](https://arrow.apache.org/) specification, and uses
 [Polars](https://github.com/pola-rs/polars) as the motor for performing
@@ -24,8 +24,8 @@ processing data.
 
 ## Benchmark comparisons
 
-For this little benchmark exercise we will be comparing native nushell
-commands, dataframe nushell commands and [Python
+For this little benchmark exercise we will be comparing native Nushell
+commands, dataframe Nushell commands and [Python
 Pandas](https://pandas.pydata.org/) commands. For the time being don't pay too
 much attention to the `dataframe` commands. They will be explained in later
 sections of this page.
@@ -34,7 +34,7 @@ sections of this page.
 > machine with a processor Intel(R) Core(TM) i7-10710U (CPU @1.10GHz 1.61 GHz)
 > and 16 gb of RAM.
 >
-> All examples where run on Nushell version 0.33.1.
+> All examples were run on Nushell version 0.33.1.
 
 ### File information
 
@@ -91,7 +91,7 @@ We can have a look at the first lines of the file using `dfr first`:
 ### Loading the file
 
 Let's start by comparing loading times between the various methods. First, we
-will load the data using nushell load command:
+will load the data using Nushell's `open` command:
 
 ```shell
 > benchmark {open .\Data7602DescendingYearOrder.csv}
@@ -103,9 +103,8 @@ will load the data using nushell load command:
 ───┴─────────────────────────
 ```
 
-Loading the file using native nushell commands took 30 seconds. Not bad for
-loading five million records in order to do data analysis. But we can do a bit
-better than that.
+Loading the file using native Nushell functionality took 30 seconds. Not bad for
+loading five million records! But we can do a bit better than that.
 
 Let's now use Pandas. We are going to use the next script to load the file:
 
@@ -129,7 +128,7 @@ And the benchmark for it is:
 
 That is a great improvement, from 30 seconds to 2 seconds. Nicely done, Pandas!
 
-Probably we can load the data a bit faster. This time we will use nushell's
+Probably we can load the data a bit faster. This time we will use Nushell's
 `dfr open` command:
 
 ```shell
@@ -146,13 +145,13 @@ This time it took us 0.6 seconds. Not bad at all.
 
 ### Group-by comparison
 
-Lets do a slightly more complex operation this time. We are going to group the
+Let's do a slightly more complex operation this time. We are going to group the
 data by year, and add groups using the column `geo_count`.
 
-Again, we are going to start with nushell native command.
+Again, we are going to start with a Nushell native command.
 
 > Note: If you want to run this example, be aware that the next command will
-> use a large amount of memory. This may affect the performance of you system
+> use a large amount of memory. This may affect the performance of your system
 > while this is being executed.
 
 ```shell
@@ -197,7 +196,7 @@ And the result from the benchmark is:
 
 Not bad at all. Again, pandas managed to get it done in a fraction of the time.
 
-To finish the comparison, let's try nushell dataframes. We are going to put
+To finish the comparison, let's try Nushell dataframes. We are going to put
 all the operations in one `nu` file, to make sure we are doing similar
 operations:
 
@@ -219,12 +218,12 @@ and the benchmark with dataframes is:
 ───┴───────────────────
 ```
 
-Luckily nushell dataframes managed to halve the time again. Isn't that great?
+Luckily Nushell dataframes managed to halve the time again. Isn't that great?
 
 As you can see, Nushell's `Dataframe` commands are as fast as the most common
 tools that exist today to do data analysis. The commands that are included in
 this release have the potential to become your go-to tool for doing data
-analysis. By composing complex nushell pipelines, you can extract information
+analysis. By composing complex Nushell pipelines, you can extract information
 from data in a reliable way.
 
 ## Working with Dataframes
@@ -337,14 +336,14 @@ $df | dfr aggregate sum | dfr select int_1 int_2 float_1 float_2
 ───┴───────┴───────┴─────────┴─────────
 ```
 
-you can even store the result from this aggregation as you would store any
-other nushell variable
+You can even store the result from this aggregation as you would store any
+other Nushell variable
 
 ```shell
 > let res = ($df | dfr aggregate sum | dfr select int_1 int_2 float_1 float_2)
 ```
 
-and now we have two dataframes stored in memory
+And now we have two dataframes stored in memory
 
 ```shell
 > dfr list
@@ -357,7 +356,7 @@ and now we have two dataframes stored in memory
 ───┴──────┴──────┴─────────
 ```
 
-pretty neat, isn't it?
+Pretty neat, isn't it?
 
 You can perform several aggregations on the dataframe in order to extract basic
 information from the dataframe and do basic data analysis on your brand new
@@ -416,7 +415,7 @@ in order to use it for further operations.
 
 One of the most powerful operations that can be performed with a DataFrame is
 the `group-by`. This command will allow you to perform aggregation operations
-based on a grouping criteria. In nushell, a `GroupBy` is a type of object that
+based on a grouping criteria. In Nushell, a `GroupBy` is a type of object that
 can be stored and reused for multiple aggregations. This is quite handy, since
 the creation of the grouped pairs is the most expensive operation while doing
 group-by and there is no need to repeat it if you are planning to do multiple
@@ -451,7 +450,7 @@ $group | dfr aggregate sum
 ───┴───────┴───────────┴───────────┴─────────────┴─────────────
 ```
 
-and using the same `GroupBy` you can perform now another operation on the
+And using the same `GroupBy` you can perform now another operation on the
 whole dataframe, like `min` in this case
 
 ```shell
@@ -466,8 +465,8 @@ $group | aggregate min
 ───┴───────┴───────────┴───────────┴─────────────┴─────────────
 ```
 
-the created `GroupBy` object is so handy that it can even be used as base for
-pivoting a table.  As an example, Lets use the column called `second` as the
+The created `GroupBy` object is so handy that it can even be used as a base for
+pivoting a table.  As an example, let's use the column called `second` as the
 pivot column and the column `float_1` as the value column
 
 
@@ -491,11 +490,11 @@ pivot column and the column `float_1` as the value column
 > floats where the column `first` is `b` and column `second` is `a`
 
 As you can see, the `GroupBy` object is a very powerful variable and it is
-worthy it to keep in memory to keep exploring your dataset.
+worth keeping in memory while you explore your dataset.
 
 ## Creating Dataframes
 
-It is also possible to construct dataframes from basic nushell primitives, such
+It is also possible to construct dataframes from basic Nushell primitives, such
 as integers, decimals, or strings. Let's create a small dataframe using the
 command `to-df`.
 
@@ -530,8 +529,8 @@ example, let's append two columns to our mini dataframe `$a`
 ───┴───┴───┴────┴────
 ```
 
-the powerful Nushell's piping syntax allows us to create new dataframes by
-taking data from other dataframes and append it to them. Now, if you list your
+Nushell's powerful piping syntax allows us to create new dataframes by
+taking data from other dataframes and appending it to them. Now, if you list your
 dataframes you will see in total four dataframes
 
 ```shell
@@ -608,7 +607,7 @@ previous variable.
 > Note: If you want to see how many variables you have stored in memory you can
 > use `$scope.variables`
 
-Lets rename our previous Series so it has a memorable name
+Let's rename our previous Series so it has a memorable name
 
 ```shell
 > let new_2 = ($new_2 | dfr rename memorable)
@@ -683,12 +682,12 @@ and we can start piping things in order to create new columns and dataframes
 ───┴───┴───┴─────────┴────────
 ```
 
-Nushell piping system can help you create very interesting workflows.
+Nushell's piping system can help you create very interesting workflows.
 
 ## Series and masks
 
 Series have another key use in when working with DataFrames, and it is the fact
-that we can build boolean masks out of them. Lets start by creating a simple
+that we can build boolean masks out of them. Let's start by creating a simple
 mask using the equality operator
 
 ```shell
@@ -718,7 +717,7 @@ and with this mask we can now filter a dataframe, like this
 
 Now we have a new dataframe with only the values where the mask was true.
 
-The masks can also be created from Nushell lists as well, for example:
+The masks can also be created from Nushell lists, for example:
 
 ```shell
 > let mask1 = ([$true $true $false] | dfr to-df mask)
@@ -844,7 +843,7 @@ extract that information
 ───┴───────┴───────┴─────────┴─────────┴───────┴────────┴───────┴────────
 ```
 
-The command `take` is very handy, specially if we mix it with other commands.
+The command `take` is very handy, especially if we mix it with other commands.
 Let's say that we want to extract all rows for the first duplicated element for
 column `first`. In order to do that, we can use the command `dfr
 arg-unique` as shown in the next example
@@ -987,15 +986,15 @@ Or all the duplicated ones
 ───┴───────┴───────┴─────────┴─────────┴───────┴────────┴───────┴────────
 ```
 
-## Dataframes commands
+## Dataframe commands
 
 So far we have seen quite a few operations that can be done using `DataFrame`s
-commands. However, the commands we have used so far, are not all the commands
+commands. However, the commands we have used so far are not all the commands
 available to work with data and be assured that there will be more as the
 feature becomes more stable.
 
-The next list show the available dataframe commands with their description, and
-whenever possible, their analogous nushell command.
+The next list shows the available dataframe commands with their descriptions, and
+whenever possible, their analogous Nushell command.
 
 | Command Name | Applies To | Description | Nushell Equivalent |
 | ------------ | ---------- | ----------- | ------------------ |
@@ -1059,7 +1058,7 @@ However, the future of these dataframes is still very experimental. New
 commands and tools that take advantage of these commands will be added as they
 mature. For example, the next step for dataframes is the introduction of Lazy
 Dataframes. These will allow you to define complex data operations that will be
-executed until you decide to "finish" the pipe. This will give nushell the
+executed until you decide to "finish" the pipe. This will give Nushell the
 chance to select the optimal plan to query the data you would be asking for.
 
 Keep visiting this book in order to check the new things happening to

--- a/book/environment.md
+++ b/book/environment.md
@@ -20,7 +20,7 @@ The last `raw` column shows the actual value that will be sent to external appli
 
 ## Single-use environment variables
 
-The environment is created from the settings in the Nu configuration and from the environment that Nu is run inside of.  You can update the environment permanently using the techniques listed in [configuration](configuration.md) chapter.
+The environment is created from the settings in the Nu configuration and from the environment that Nu is run inside of.  You can update the environment permanently using the techniques listed in the [configuration](configuration.md) chapter.
 
 A common shorthand, inspired by Bash and others, is also available. You can write the above example as:
 

--- a/book/installation.md
+++ b/book/installation.md
@@ -10,9 +10,9 @@ Alternatively, for macOS or Linux, you can install the binary using [Homebrew](h
 
 ### Windows
 
-**Please note:** Nu works on Windows 10 and does not currently have Windows 7/8.1 support.
+**Please note:** Nu works on Windows 10+ and does not currently have Windows 7/8.1 support.
 
-Download the current released `.zip`-file from the [release page](https://github.com/nushell/nushell/releases) and extract it for example to:
+Download the current release's `.zip`-file from the [release page](https://github.com/nushell/nushell/releases) and extract it for example to:
 
 <<< @/snippets/installation/windows_example_extraction_location.sh
 
@@ -32,7 +32,7 @@ Now, `nu` should load on startup of the Windows Terminal.
 
 ## Getting Ready
 
-Before we can install Nu, we need to make sure our system has the necessary requirements. Currently, this means making sure we have both the Rust toolchain and local dependencies installed.
+Before we can install Nu from source, we need to make sure our system has the necessary requirements. Currently, this means making sure we have both the Rust toolchain and local dependencies installed.
 
 ### Installing a compiler suite
 
@@ -76,7 +76,7 @@ You will need to install "libxcb", "openssl-devel" and "libX11-devel":
 
 ### macOS
 
-Using [Homebrew](https://brew.sh/), you will need to install the "openssl" and "cmake" using: 
+Using [Homebrew](https://brew.sh/), you will need to install "openssl" and "cmake" using: 
 
 <<< @/snippets/installation/macos_deps.sh
 
@@ -104,11 +104,11 @@ Once installed, we can run Nu using the `nu` command:
 
 ## Building from source
 
-We can also build our own Nu from source directly from github. This gives us immediate access to the latest Nu features and bug fixes.
+We can also build our own Nu from source directly from GitHub. This gives us immediate access to the latest Nu features and bug fixes.
 
 <<< @/snippets/installation/git_clone_nu.sh
 
-Git will clone the main nushell repo for us. From there, we can build and run Nu if we are using `rustup` with:
+Git will clone the main Nushell repo for us. From there, we can build and run Nu if we are using `rustup` with:
 
 <<< @/snippets/installation/build_nu_from_source.sh
 

--- a/book/loading_data.md
+++ b/book/loading_data.md
@@ -27,7 +27,7 @@ One of Nu's most powerful assets in working with data is the `open` command. It 
 ──────────────────┴───────────────────────────────────────────────────────────────────────────────
 ```
 
-In a similar way to `ls`, opening a file type that Nu understands will give us back something that is more than just text (or a stream of bytes). Here we open a "package.json" file from a JavaScript project. Nu can recognize and open the JSON text and give back a table of data.
+In a similar way to `ls`, opening a file type that Nu understands will give us back something that is more than just text (or a stream of bytes). Here we open a "package.json" file from a JavaScript project. Nu can recognize the JSON text and parse it to a table of data.
 
 If we wanted to check the version of the project we were looking at, we can use the `get` command.
 
@@ -60,7 +60,7 @@ But what happens if you load a text file that isn't one of these? Let's try it:
 > open README.md
 ```
 
-We're shown the contents of the file. If the file is too large, we get a handy scroll-view to look at the file and then jump back to the terminal. To help with readability, Nu will also syntax-highlight common file formats like source files, markdown, and more.
+We're shown the contents of the file. If the file is too large, we get a handy scroll-view to look at the file and then jump back to the terminal. To help with readability, Nu will also syntax-highlight common file formats like source files, Markdown, and more.
 
 Below the surface, what Nu sees in these text files is one large string. Next, we'll talk about how to work with these strings to get the data we need out of them.
 

--- a/book/moving_around.md
+++ b/book/moving_around.md
@@ -34,7 +34,7 @@ Changing the current working directory can also be done if `cd` is omitted and a
 
 ## Filesystem commands
 
-Nu also provides some basic filesystem commands that works cross-platform. 
+Nu also provides some basic filesystem commands that work cross-platform. 
 
 We can move an item from one place to another using the `mv` command:
 

--- a/book/nushell_operator_map.md
+++ b/book/nushell_operator_map.md
@@ -5,7 +5,7 @@ The idea behind this table is to help you understand how Nu operators relate to 
 Note: this table assumes Nu 0.14.1 or later.
 
 
-| Nushell  | SQL      | Python              | .Net LINQ (C#)       | PowerShell             | Bash               |
+| Nushell  | SQL      | Python              | .NET LINQ (C#)       | PowerShell             | Bash               |
 | -------- | -------- | --------------------| -------------------- | ---------------------- | ------------------ |
 | ==       | =        | ==                  | ==                   | -eq, -is               | -eq                |
 | !=       | !=, <>   | !=                  | !=                   | -ne, -isnot            | -ne                |

--- a/book/parallelism.md
+++ b/book/parallelism.md
@@ -20,7 +20,7 @@ We create a record for each entry, and fill it with the name of the directory an
 
 On your machine, the times may vary. For this machine, it took 21 milliseconds for the current directory.
 
-Now, since this operation can be run in parallel, let's convert the above to paralle by changing `each` to `par-each`:
+Now, since this operation can be run in parallel, let's convert the above to parallel by changing `each` to `par-each`:
 
 ```
 > ls | where type == dir | par-each { |it| {name: $it.name, len: (ls $it.name | length) } }
@@ -28,4 +28,4 @@ Now, since this operation can be run in parallel, let's convert the above to par
 
 On this machine, it now runs in 6ms. That's quite a difference!
 
-You'll notice, if you look at the results, that they come back in different orders each run (depending on the number of hardware threads on your system). As tasks finish, and we get the correct result, we may need to additional steps if we want our results in a particular order. For example, for the above, we may want to sort the results by the "name" field. This allows both `each` and `par-each` versions of our script to give the same result.
+You'll notice, if you look at the results, that they come back in different orders each run (depending on the number of hardware threads on your system). As tasks finish, and we get the correct result, we may need to add additional steps if we want our results in a particular order. For example, for the above, we may want to sort the results by the "name" field. This allows both `each` and `par-each` versions of our script to give the same result.

--- a/book/plugins.md
+++ b/book/plugins.md
@@ -1,8 +1,8 @@
 # Plugins
 
-The functionality of Nu can be extended using plugins. The plugins can perform many of the same operations that Nu's built-in commands can, with the added benefit that they can be added separately of Nu itself.
+The functionality of Nu can be extended using plugins. The plugins can perform many of the same operations that Nu's built-in commands can, with the added benefit that they can be added separately from Nu itself.
 
-To add a plugin, simply build it, and then call `register` on it. As you do, you'll need to also tell nushell what protocol the plugin uses.
+To add a plugin, simply build it, and then call `register` on it. As you do, you'll need to also tell Nushell what protocol the plugin uses.
 
 For example:
 

--- a/book/stdout_stderr_exit_codes.md
+++ b/book/stdout_stderr_exit_codes.md
@@ -1,6 +1,6 @@
 # Stdout, Stderr, and Exit Codes
 
-An import piece of interop between Nushell and external commands is working with the standard streams of data coming from the external.
+An important piece of interop between Nushell and external commands is working with the standard streams of data coming from the external.
 
 The first of these important streams is stdout.
 

--- a/book/strings.md
+++ b/book/strings.md
@@ -41,11 +41,11 @@ Nushell currently supports the following escape characters:
   - `\r` - carriage return
   - `\n` - newline (line feed)
   - `\t` - tab
-  - `\uXXXX` - a unicode character (replace XXXX with the number of unicode character)
+  - `\uXXXX` - a unicode character (replace XXXX with the number of the unicode character)
 
 ## String interpolation
 
-More complex string use cases also need a new form of string: the string interpolation. This is a way of building text from both raw text and the result of running expressions. String interpolation combines the results together, giving you a new string.
+More complex string use cases also need a new form of string: string interpolation. This is a way of building text from both raw text and the result of running expressions. String interpolation combines the results together, giving you a new string.
 
 String interpolation uses `$" "` and `$' '` as ways to wrap interpolated text.
 

--- a/book/table_of_contents.md
+++ b/book/table_of_contents.md
@@ -1,20 +1,20 @@
 # Table of Contents
 
-- [Installation](installation.md) - Installing nushell
+- [Installation](installation.md) - Installing Nushell
 - [Introduction](introduction.md) - Getting started
-- [Moving around](moving_around.md) - Moving around in nushell
-- [Types of data](types_of_data.md) - Types of data in nushell
+- [Moving around](moving_around.md) - Moving around in Nushell
+- [Types of data](types_of_data.md) - Types of data in Nushell
 - [Loading data](loading_data.md) - Loading data and using it
 - [Strings](strings.md) - Strings, escape characters, and string interpolation
 - [Working with lists](working_with_lists.md) - Working with Nu lists
 - [Working with tables](working_with_tables.md) - Working with Nu tables
 - [Pipeline](pipeline.md) - How the pipeline works
-- [Configuration](configuration.md) - How to configure nushell
+- [Configuration](configuration.md) - How to configure Nushell
 - [3rd Party Prompts](3rdpartyprompts.md) - How to configure 3rd party prompts
 - [Custom commands](custom_commands.md) - Creating your own commands
 - [Aliases](aliases.md) - How to alias commands
-- [Operators](operators.md) - Operators supported by nushell
-- [Math](math.md) - Math operations in nushell
+- [Operators](operators.md) - Operators supported by Nushell
+- [Math](math.md) - Math operations in Nushell
 - [Variables and subexpressions](variables_and_subexpressions.md) - Working with variables and working with subexpressions
 - [Environment](environment.md) - Working with environment variables
 - [Stdout, stderr, and exit codes](stdout_stderr_exit_codes.md) - Working with stdout, stderr, and exit codes
@@ -24,14 +24,14 @@
 - [Creating your own errors](creating_errors.md) - Creating your own error messages
 - [Shells](shells_in_shells.md) - Working with multiple locations
 - [Escaping commands](escaping.md) - Escaping to native commands of the same name
-- [Plugins](plugins.md) - Enhancing nushell with more features using plugins
+- [Plugins](plugins.md) - Enhancing Nushell with more features using plugins
 - [Parallelism](parallelism.md) - Running your code in parallel
-- [Dataframes](dataframes.md) - Working with dataframes in nushell
-- [Coloring and Theming](coloring_and_theming.md) - How to change the colors and themes in nushell
+- [Dataframes](dataframes.md) - Working with dataframes in Nushell
+- [Coloring and Theming](coloring_and_theming.md) - How to change the colors and themes in Nushell
 - [Regular Expressions](regular_expressions.md) - Guide to use regex
-- [Coming from Bash](coming_from_bash.md) - Guide for those coming to nushell from Bash
-- [Nushell map from shells/DSL](nushell_map.md) - Guide to show how nushell compares with SQL, Linq, PowerShell, and Bash
-- [Nushell map from imperative languages](nushell_map_imperative.md) - Guide to show how nushell compares with Python, Kotlin, C++, C#, and Rust
-- [Nushell map from functional languages](nushell_map_functional.md) - Guide to show how nushell compares with Clojure, Tablecloth (Ocaml / Elm) and Haskell
-- [Nushell operator map](nushell_operator_map.md) - Guide to show how nushell operators compare with those in general purpose programming languages
+- [Coming from Bash](coming_from_bash.md) - Guide for those coming to Nushell from Bash
+- [Nushell map from shells/DSL](nushell_map.md) - Guide to show how Nushell compares with SQL, LINQ, PowerShell, and Bash
+- [Nushell map from imperative languages](nushell_map_imperative.md) - Guide to show how Nushell compares with Python, Kotlin, C++, C#, and Rust
+- [Nushell map from functional languages](nushell_map_functional.md) - Guide to show how Nushell compares with Clojure, Tablecloth (OCaml / Elm) and Haskell
+- [Nushell operator map](nushell_operator_map.md) - Guide to show how Nushell operators compare with those in general purpose programming languages
 - [Command Reference](command_reference.md) - List of all Nushell's commands

--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -35,7 +35,7 @@ You can always evaluate a subexpression and use its result by wrapping the expre
 
 The parentheses contain a pipeline that will run to completion, and the resulting value will then be used. For example, `(ls)` would run the `ls` command and give back the resulting table and `(git branch --show-current)` runs the external git command and returns a string with the name of the current branch. You can also use parentheses to run math expressions like `(2 + 3)`.
 
-Subexpressions can also be pipelines and not just single commands. If we wanted to get a list of filenames larger than ten kilobytes, we can use an subexpression to run a pipelines and assign this to a variable:
+Subexpressions can also be pipelines and not just single commands. If we wanted to get a list of filenames larger than ten kilobytes, we can use an subexpression to run a pipeline and assign this to a variable:
 
 ```
 > let names-of-big-files = (ls | where size > 10kb)

--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -149,7 +149,7 @@ echo $scores | reduce -n { $acc.item + $it.index * $it.item }
 
 
 The `wrap` command converts list to a table. Each list value will
-be converted to a separate row with single column:
+be converted to a separate row with a single column:
 ```bash
 let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
 


### PR DESCRIPTION
I read through the Nu book (not including the individual command pages) and fixed up places with incorrect grammar, incorrect spelling, or awkward wording. As discussed [on Discord](https://discord.com/channels/601130461678272522/729071784321876040/950098216597225472) I also normalized the capitalization of "Nushell" where necessary.

I noticed a few other functional things to clean up in the book, I'll submit another PR for those later.