### PR TITLE
Remove math mode mentions, move short hand syntax documentation

### DIFF
--- a/book/math.md
+++ b/book/math.md
@@ -70,23 +70,3 @@ Math operations are evaluated in the follow order (from highest precedence to lo
 > 3 * (1 + 2)
 9
 ```
-
-## Short-hand math mode
-
-A variation of math mode that Nushell supports is called "short-hand" math mode. This is because it gives you a way of accessing columns using a simple short-hand.
-
-You may have already used this functionality before. If, for example, we wanted to only see rows from `ls` where the entry is at least ten kilobytes, we can write:
-
-```
-> ls | where size > 10kb
-```
-
-The `where size > 10kb` is a command with two parts: the command name `where` and the short-hand math expression `size > 10kb`. We say short-hand because `size` here is the shortened version of writing `$it.size`.  If we look at the fully expanded form, we would see:
-
-```
-> ls | where {|$it| $it.size > 10kb }
-```
-
-Rather than having to type all this out every time a command needs to work with column data, we use this short-hand mode to access column data.
-
-For the expansion to work, the column name must appear on the left-hand side of the operation. Above, `size` appears on the left-hand side of the comparison, which allows the expression to expand into the full math mode block.

--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -63,3 +63,21 @@ We can do a very similar action in a single step using a subexpression path:
 ```
 
 It depends on the needs of the code and your particular style which form works best for you.
+
+## Short-hand subexpressions
+
+Nushell supports accessing columns in a subexpression using a simple short-hand. You may have already used this functionality before. If, for example, we wanted to only see rows from `ls` where the entry is at least ten kilobytes we can write:
+
+```
+> ls | where size > 10kb
+```
+
+The `where size > 10kb` is a command with two parts: the command name `where` and the short-hand expression `size > 10kb`. We say short-hand because `size` here is the shortened version of writing `$it.size`. This could also be written in any of the following ways:
+
+```
+> ls | where $it.size > 10kb
+> ls | where ($it.size > 10kb)
+> ls | where {|$it| $it.size > 10kb }
+```
+
+For short-hand syntax to work, the column name must appear on the left-hand side of the operation (like `size` in `size > 10kb`).

--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -64,7 +64,7 @@ We can do a very similar action in a single step using a subexpression path:
 
 It depends on the needs of the code and your particular style which form works best for you.
 
-## Short-hand subexpressions
+## Short-hand subexpressions (row conditions)
 
 Nushell supports accessing columns in a subexpression using a simple short-hand. You may have already used this functionality before. If, for example, we wanted to only see rows from `ls` where the entry is at least ten kilobytes we can write:
 

--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -43,10 +43,7 @@ let colors = []
 = $colors | empty? # true
 ```
 
-The `in` and `not in` operators are used to test whether a value is in a list.
-Operators can only be used in "math mode".
-One way to enter math mode is to begin an expression with `=`.
-For example:
+The `in` and `not in` operators are used to test whether a value is in a list. For example:
 
 ```bash
 let colors = [red green blue]

--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -43,7 +43,7 @@ let colors = []
 = $colors | empty? # true
 ```
 
-The `in` and `not in` operators are used to test whether a value is in a list. For example:
+The `in` and `not-in` operators are used to test whether a value is in a list. For example:
 
 ```bash
 let colors = [red green blue]


### PR DESCRIPTION
## What?

Remove mentions of "math mode" from the Nu Book. Move the "Short-hand math mode" section from the Math page to the Variables and Subexpressions page, rename it "Short-hand subexpressions".

## Why?

When I read through the Nu Book I was confused by 2 mentions of "math mode". [Here](https://github.com/nushell/nushell.github.io/blob/d9839a5819d74ab99770c7ecfd3881ccd9eecaa2/book/working_with_lists.md?plain=1#L48) it's mentioned in a way that is not reflected in the following example, and [here](https://github.com/nushell/nushell.github.io/blob/d9839a5819d74ab99770c7ecfd3881ccd9eecaa2/book/math.md?plain=1#L76) it's mentioned but only in the context of "short-hand math mode".

JT explained some of the historical context, and it sounds like math mode is a bit less salient to users these days:

> it's mostly just integrated into how expressions work these days. We used to start with a = to turn into "math mode". Now, if we see an expression and it isn't a call to a command, we treat it like a math expression and try to parse it that way

I think we can make the docs more clear by removing the mentions of math mode altogether. The "short-hand math mode" syntax is still worth documenting, but I _think_ the variables+subexpressions page is a better fit than the math page (because the short-hand syntax can also be used with string operators like `=~`).

I'm relatively new to Nu (🥁) so please let me know if I've missed something important here.