### PR TITLE
Update Windows build-from-source requirements

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -40,9 +40,9 @@ For Rust to work properly, you'll need to have a compatible compiler suite insta
 
 * Linux: GCC or Clang
 * macOS: Clang (install Xcode)
-* Windows: [Visual Studio Community Edition](https://visualstudio.microsoft.com/vs/community/)
-
-For Windows, when you install Visual Studio Community Edition, make sure to install the "C++ build tools" as what we need is `link.exe` which is provided as part of that optional install.  With that, we're ready to move to the next step.
+* Windows: MSVC (install [Visual Studio](https://visualstudio.microsoft.com/vs/community/) or the [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022))
+    * Make sure to install the "Desktop development with C++" workload
+    * Any Visual Studio edition will work (Community is free)
 
 ### Installing Rust
 


### PR DESCRIPTION
Closes #63 .

As mentioned in [the `rustup` docs](https://rust-lang.github.io/rustup/installation/windows.html), the VS Build Tools are an OK substitute for anyone who doesn't want all of Visual Studio.

The optional install needed for Rust etc. is called "Desktop development with C++" these days:

<img width="444" alt="image" src="https://user-images.githubusercontent.com/26268125/156972446-21692515-a3dd-4845-a305-68d1921aab35.png">
