### PR TITLE
Update working_with_lists for latest Nu

### DIFF
--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -5,23 +5,20 @@ The literal syntax for creating a `list` is to include expressions
 in square brackets separated by spaces or commas (for readability).
 For example, `[foo bar baz]` or `[foo, bar, baz]`.
 
-To iterate over the elements in a list, use the `each` command.
-The `$it` special variable holds the output of the previous command.
-When used in a block passed to the `each` command, it holds the current item.
-To change `$it` to have `$it.index` and `$it.item` values,
-add the `--numbered` (`-n`) flag.
-For example:
+To iterate over the items in a list, use the `each` command with a [block](types_of_data.html#blocks)
+of Nu code that specifies what to do to each item. The block parameter (e.g. `|it|` in `{ |it| echo $it }`) is normally the current list item, but the `--numbered` (`-n`) flag can change it to have `index` and `item` values if needed. For example:
 
 ```bash
 let names = [Mark Tami Amanda Jeremy]
-echo $names | each { build-string "Hello, " $it "!" }
+$names | each { |it| $"Hello, ($it)!" }
 # Outputs "Hello, Mark!" and three more similar lines.
 
-echo $names | each -n { build-string ($it.index + 1) ")" $it.item }
+$names | each -n { |it| $"($it.index + 1) - ($it.item)" }
+# Outputs "1 - Mark", "2 - Tami", etc.
 ```
 
 The `split row` command creates a list from a string based on a delimiter.
-For example, `let colors = $(echo "red,green,blue" | split row ",")`
+For example, `let colors = ("red,green,blue" | split row ",")`
 creates the list `[red green blue]`.
 
 To access a list item at a given index, use `$name.index`
@@ -30,17 +27,17 @@ For example, the second element in the list above
 which is "Tami" can be accessed with `$names.1`.
 
 The `length` command returns the number of items in a list.
-For example, `echo [red green blue] | length` outputs `3`.
+For example, `[red green blue] | length` outputs `3`.
 
 The `empty?` command determines whether a string, list, or table is empty.
 It can be used with lists as follows:
 
 ```bash
 let colors = [red green blue]
-= $colors | empty? # false
+$colors | empty? # false
 
 let colors = []
-= $colors | empty? # true
+$colors | empty? # true
 ```
 
 The `in` and `not-in` operators are used to test whether a value is in a list. For example:
@@ -56,7 +53,7 @@ The following example gets all the colors whose names end in "e".
 
 ```bash
 let colors = [red orange yellow green blue purple]
-echo $colors | where (echo $it | str ends-with 'e')
+echo $colors | where ($it | str ends-with 'e')
 # The block passed to where must evaluate to a boolean.
 # This outputs the list [orange blue purple].
 
@@ -70,10 +67,10 @@ For example:
 
 ```bash
 # Do any color names end with "e"?
-echo $colors | any? (echo $it | str ends-with "e") # true
+echo $colors | any? ($it | str ends-with "e") # true
 
 # Is the length of any color name less than 3?
-echo $colors | any? (echo $it | str length) < 3 # false
+echo $colors | any? ($it | str length) < 3 # false
 
 # Are any scores greater than 7?
 echo $scores | any? $it > 7 # true
@@ -88,10 +85,10 @@ For example:
 
 ```bash
 # Do all color names end with "e"?
-echo $colors | all? (echo $it | str ends-with "e") # false
+echo $colors | all? ($it | str ends-with "e") # false
 
 # Is the length of all color names greater than or equal to 3?
-echo $colors | all? (echo $it | str length) >= 3 # true
+echo $colors | all? ($it | str length) >= 3 # true
 
 # Are all scores greater than 7?
 echo $scores | all? $it > 7 # false
@@ -106,8 +103,8 @@ For example:
 
 ```bash
 let colors = [yellow green]
-let colors = (echo $colors | prepend red)
-let colors = (echo $colors | append purple)
+let colors = ($colors | prepend red)
+let colors = ($colors | append purple)
 echo $colors # [red yellow green purple]
 ```
 
@@ -123,25 +120,22 @@ echo [[1 2] [3 [4 5 [6 7 8]]]] | flatten | flatten | flatten # [1 2 3 4 5 6 7 8]
 ```
 
 The `reduce` command computes a single value from a list.
-It takes a block which can use the special variables
-`$acc` (for accumulator) and `$it` (for item).
-To specify an initial value for `$acc`, use the `--fold` (`-f`) flag.
-To change `$it` to have `$it.index` and `$it.item` values,
-add the `--numbered` (`-n`) flag.
-This also changes `$acc` to have a `$acc.item` value.
+It uses a block which takes 2 parameters: the current item (conventionally named `it`) and an accumulator
+(conventionally named `acc`). To specify an initial value for the accumulator, use the `--fold` (`-f`) flag.
+To change both parameters to have `index` and `item` values, add the `--numbered` (`-n`) flag.
 For example:
 
 ```bash
 let scores = [3 8 4]
-echo "total =" (echo $scores | reduce { $acc + $it }) # 15
+echo "total =" ($scores | reduce { |it, acc| $acc + $it }) # 15
 
-echo "total =" (echo $scores | math sum) # easier approach, same result
+echo "total =" ($scores | math sum) # easier approach, same result
 
-echo "product =" (echo $scores | reduce --fold 1 { $acc * $it }) # 96
+echo "product =" ($scores | reduce --fold 1 { |it, acc| $acc * $it }) # 96
 
-echo $scores | reduce -n { $acc.item + $it.index * $it.item }
+echo $scores | reduce -n { |it, acc| $acc.item + $it.index * $it.item }
 # This should produce 0*3 + 1*8 + 2*4 = 16.
-# But see https://github.com/nushell/nushell/issues/3298.
+# But see https://github.com/nushell/nushell/issues/4759
 ```
 
 


### PR DESCRIPTION
Lots of examples on the Working with Lists page that needed to be updated. The descriptions of `each` and `reduce` also needed to be updated to reflect changes to block parameters.

Note: the `empty?` examples are currently broken, I raised an issue: https://github.com/nushell/nushell/issues/4786