### PR TITLE
Node+VuePress TLC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2-beta
         with:
-          node-version: '12'
+          node-version: '16'
 
       - run: npm install
       - run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2-beta
         with:
-          node-version: '12'
+          node-version: '16'
 
       - run: npm install
       - run: npm run build

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -386,5 +386,11 @@ module.exports = {
       },
     },
   },
-  plugins: ["@vuepress/plugin-back-to-top", "@vuepress/plugin-medium-zoom"],
+  plugins: [
+    "@vuepress/plugin-back-to-top",
+    "@vuepress/plugin-medium-zoom",
+    ["@vuepress/search", {
+      test: `^(?!.*old_book)` // Exclude the old Nu book from search; it clutters up search results
+    }]
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "vuepress": "^1.8.0"
+    "vuepress": "^1.9.0",
+    "@vuepress/plugin-back-to-top": "^1.9.0",
+    "@vuepress/plugin-medium-zoom": "^1.9.0"
   }
 }


### PR DESCRIPTION
A few website updates:
- Upgrade GitHub Actions to Node 16 (from 12). 16 is the latest LTS release and 12 will be unsupported soon.
- Upgrade VuePress minor version
- Install the VuePress [back-to-top](https://vuepress.vuejs.org/plugin/official/plugin-back-to-top.html) and [medium-zoom](https://vuepress.vuejs.org/plugin/official/plugin-medium-zoom.html) plugins; they were previously causing build warnings because they were enabled but not installed.
- [Exclude the old Nu book from search results](https://vuepress.vuejs.org/plugin/official/plugin-search.html#test); it was making the search results a lot worse (so many duplicates!)

## Testing Performed

Manual testing: clicked around the website, confirmed that the search works as expected in both English and German, confirmed that the VuePress plugins now work.

## Details

The back-to-top and medium-zoom plugins were set up in `config.js` but not installed; previously the build was generating these warnings:

```
warning An error was encountered in plugin "@vuepress/plugin-back-to-top"
warning An error was encountered in plugin "@vuepress/plugin-medium-zoom"
```

Adding the `--debug` flag to `vuepress dev` or `vuepress build` was enough to confirm that it was unable to find those plugins entirely. I'm not a VuePress expert by any means, but I looked around GitHub and confirmed that they need to be installed in package.json.