### PR TITLE
Add RSS feed for blog

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -390,6 +390,16 @@ module.exports = {
   plugins: [
     "@vuepress/plugin-back-to-top",
     "@vuepress/plugin-medium-zoom",
+    ["feed", {
+      canonical_base: "https://www.nushell.sh/",
+      feed_options: {
+        title: "Nushell Blog",
+        link: "https://www.nushell.sh/blog",
+        favicon: "https://www.nushell.sh/icon.png"
+      },
+      posts_directories: ['/blog/'],
+      sort: entries => entries.sort((a, b) => new Date(b.date) - new Date(a.date))
+    }],
     ["@vuepress/search", {
       test: `^(?!.*old_book)` // Exclude the old Nu book from search; it clutters up search results
     }]

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "vuepress": "^1.9.0",
     "@vuepress/plugin-back-to-top": "^1.9.0",
-    "@vuepress/plugin-medium-zoom": "^1.9.0"
+    "@vuepress/plugin-medium-zoom": "^1.9.0",
+    "vuepress": "^1.9.0",
+    "vuepress-plugin-feed": "^0.1.9"
   }
 }


### PR DESCRIPTION
As requested in #85, adding RSS/Atom/JSON feeds for the Nu blog.

I looked around and it seems like [vuepress-plugin-feed](https://github.com/webmasterish/vuepress-plugin-feed) is the most popular RSS plugin for VuePress. The documentation wasn't great but it was fairly easy to install.

After adding this, the website build output includes 3 new files: `feed.atom`, `feed.json`, and `rss.xml`. Example: [feeds.zip](https://github.com/nushell/nushell.github.io/files/8229031/feeds.zip). They can be accessed at https://www.nushell.sh/feed.atom etc.

The feeds are _not_ yet linked to from the website; will add links later once I'm 100% confident the feeds are working as expected in production.