### PR TITLE
Update env var docs for latest Nu

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -24,7 +24,13 @@ let $config = ($config | update <field name> <field value>)
 
 ### Environment
 
-You can set environment variables using `let-env` calls inside the `config.nu` file. These are some important variables to look at for Nushell-specific settings:
+You can set environment variables for the duration of a Nushell session using [`let-env`](commands/let-env.html) calls inside the `config.nu` file. For example:
+
+```
+let-env FOO = 'BAR'
+```
+
+These are some important variables to look at for Nushell-specific settings:
 
 - `LS_COLORS`: Sets up colors per file type in ls
 - `PROMPT_COMMAND`: Code to execute for setting up the prompt (block or string)
@@ -48,7 +54,7 @@ You can build the full set of environment variables by running Nu inside of anot
 > env | each { |it| echo $"let-env ($it.name) = '($it.raw)'" } | str collect (char nl)
 ```
 
-This will print out `let-env` lines, one for each environment variable along with its setting.
+This will print out [`let-env`](commands/let-env.html) lines, one for each environment variable along with its setting.
 
 Next, on some distros you'll also need to ensure Nu is in the /etc/shells list:
 

--- a/book/environment.md
+++ b/book/environment.md
@@ -2,7 +2,7 @@
 
 A common task in a shell is to control the environment that external applications will use. This is often done automatically, as the environment is packaged up and given to the external application as it launches. Sometimes, though, we want to have more precise control over what environment variables an application sees.
 
-You can see the current environment variables using the `env` command:
+You can see the current environment variables using the [`env`](commands/env.html) command:
 ```
    #           name                 type                value                 raw
 ──────────────────────────────────────────────────────────────────────────────────────────
@@ -18,32 +18,32 @@ The actual value of the env. variable used within Nushell is under the `value` c
 You can query the value directly using the `$env` variable, for example, `$env.PATH | length`.
 The last `raw` column shows the actual value that will be sent to external applications (see [Environment variable conversions](#environment-variable-conversions) for details).
 
+The environment is initially created from the Nu [configuration file](configuration.md) and from the environment that Nu is run inside of.
+
 ## Single-use environment variables
 
-The environment is created from the settings in the Nu configuration and from the environment that Nu is run inside of.  You can update the environment permanently using the techniques listed in the [configuration](configuration.md) chapter.
-
-A common shorthand, inspired by Bash and others, is also available. You can write the above example as:
+A common shorthand to set an environment variable once is available, inspired by Bash and others:
 
 ```
 > FOO=BAR echo $env.FOO
 BAR
 ```
 
-You can also temporarily update an environment variable when you run a command or pipeline of commands.
+You can also use [`with-env`](commands/with-env.html) to do the same thing more explicitly:
 
 ```
 > with-env [FOO BAR] { echo $env.FOO }
 BAR
 ```
 
-The `with-env` command will temporarily set the environment variable to the value given (here: the variable "FOO" is given the value "BAR").  Once this is done, the block will run with this new environment variable set.
+The [`with-env`](commands/with-env.html) command will temporarily set the environment variable to the value given (here: the variable "FOO" is given the value "BAR").  Once this is done, the [block](types_of_data.html#blocks) will run with this new environment variable set.
 
 
 ## Scoped environment variables
 
-You can also set environment variables that will be available in the current scope (the block you're in and any block inside of it).
+You can set environment variables that will be available only in the current scope (the block you're in and any block inside of it).
 
-To do so, you can use the `let-env` command.
+To do so, use the [`let-env`](commands/let-env.html) command.
 
 ```
 > let-env FOO = 'BAR'
@@ -51,7 +51,7 @@ To do so, you can use the `let-env` command.
 
 let-env is similar to the **export** command in bash.
 
-If you have more than one environment variable you'd like to set, you can create a table of name/value pairs and load multiple variables at the same time.
+If you have more than one environment variable you'd like to set, you can use [`load-env`](commands/load-env.html) to create a table of name/value pairs and load multiple variables at the same time:
 
 ```
 > load-env { "BOB": "FOO", "JAY": "BAR" }
@@ -59,12 +59,17 @@ If you have more than one environment variable you'd like to set, you can create
 
 ## Permanent environment variables
 
-You can also set environment variables that are set at startup and are available for the duration of Nushell running. These can be set in the `env` section of the [config](configuration.md).
+You can also set environment variables at startup so they are available for the duration of Nushell running. To do this, call [`let-env`](commands/let-env.html) or [`load-env`](commands/load-env.html) in [the Nu configuration file](configuration.md).
+
+```
+# In config.nu
+let-env FOO = 'BAR'
+```
 
 ## Defining environment from custom commands
 
 Due to the scoping rules, any environment variables defined inside a custom command will only exist inside the command's scope.
-However, a command defined as `def-env` instead of `def` (it applies also to `export def`, see [Modules](modules.md)) will preserve the environment on the caller's side:
+However, a command defined as [`def-env`](commands/def-env.html) instead of [`def`](commands/def.html) (it applies also to `export def`, see [Modules](modules.md)) will preserve the environment on the caller's side:
 ```
 > def-env foo [] {
     let-env FOO = 'BAR'
@@ -118,7 +123,7 @@ Because `nu` is an external program, Nushell translated the `[ a b c ]` accordin
 Running commands with `nu -c` does not load the config file, therefore the env conversion for `FOO` is missing and it is displayed as a plain string -- this way we can verify the translation was succesful.
 You can also run this step manually by `do $env.ENV_CONVERSIONS.FOO.to_string [a b c]`
 
-If we look back at the `env` command, the `raw` column shows the value translated by `ENV_CONVERSIONS.<name>.to_string` and the `value` column shows the value used in Nushell (the result of `ENV_CONVERSIONS.<name>.from_string` in the case of `FOO`).
+If we look back at the [`env`](commands/env.html) command, the `raw` column shows the value translated by `ENV_CONVERSIONS.<name>.to_string` and the `value` column shows the value used in Nushell (the result of `ENV_CONVERSIONS.<name>.from_string` in the case of `FOO`).
 If the value is not a string and does not have `to_string` conversion, it is not passed to an external (see the `raw` column of `PROMPT_COMMAND`).
 One exception is `PATH` (`Path` on Windows): By default, it converts the string to a list on startup and from a list to a string when running externals if no manual conversions are specified.
 
@@ -134,13 +139,13 @@ You can remove an environment variable only if it was set in the current scope:
 > hide FOO
 ```
 
-If you want to remove an environment variable stemming from a parent scope, you can `hide` it:
+If you want to remove an environment variable stemming from a parent scope, you can [`hide`](commands/hide.html) it:
 
 ```
 > let-env FOO = 'BAR'
 > do {
     hide FOO
-    # $nu.env.FOO does not exist
+    # $env.FOO does not exist
   }
 > $env.FOO
 BAR


### PR DESCRIPTION
I noticed that the Environment page was a little out of date (it referred to an `env` section in config that no longer exists). Fixed that up and also did some other cleanup while I was in the area (added links, added an example to the Configuration page, etc.).