### PR TITLE
Add links to RSS+Atom feeds

### DIFF
--- a/blog/README.md
+++ b/blog/README.md
@@ -1,3 +1,5 @@
 # Nu Blog
 
+[RSS](/rss.xml) / [Atom](/feed.atom)
+
 <BlogPosts />


### PR DESCRIPTION
Closes #85. The RSS+Atom feeds added in https://github.com/nushell/nushell.github.io/pull/276 seem good in my RSS reader, adding links at the top of the blog page:

![image](https://user-images.githubusercontent.com/26268125/158301205-471f3388-5285-4403-ade0-8a1a1da2e4b3.png)

https://www.nushell.sh/rss.xml
https://www.nushell.sh/feed.atom