### PR TITLE
Organize book pages by section

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -66,7 +66,7 @@ module.exports = {
         sidebar: {
           "/book/": [
             {
-              title: "Nu Book (0.59+)",
+              title: "Getting Started",
               collapsable: false,
               children: [
                 "",
@@ -75,38 +75,62 @@ module.exports = {
                 "moving_around",
                 "types_of_data",
                 "loading_data",
-                "strings",
+                "working_with_strings",
                 "working_with_lists",
                 "working_with_tables",
                 "pipeline",
-                "configuration",
-                "3rdpartyprompts",
+                "command_reference",
+              ],
+            },
+            {
+              title: "Programming in Nu",
+              collapsable: false,
+              children: [
                 "custom_commands",
                 "aliases",
                 "operators",
-                "math",
                 "variables_and_subexpressions",
+                "scripts",
+                "math",
+                "modules",
+              ]
+            },
+            {
+              title: "Nu as a shell",
+              collapsable: false,
+              children: [
+                "configuration",
                 "environment",
                 "stdout_stderr_exit_codes",
-                "modules",
-                "scripts",
-                "metadata",
-                "creating_errors",
-                "shells_in_shells",
                 "escaping",
-                "plugins",
-                "parallelism",
+                "3rdpartyprompts",
                 "line_editor",
-                "dataframes",
                 "coloring_and_theming",
+              ]
+            },
+            {
+              title: "Coming to Nu",
+              collapsable: false,
+              children: [
                 "coming_from_bash",
                 "nushell_map",
                 "nushell_map_imperative",
                 "nushell_map_functional",
                 "nushell_operator_map",
-                "command_reference",
-              ],
+              ]
             },
+            {
+              title: "Advanced",
+              collapsable: false,
+              children: [
+                "creating_errors",
+                "dataframes",
+                "metadata",
+                "shells_in_shells",
+                "parallelism",
+                "plugins",
+              ]
+            }
           ],
           "/old_book/": [
             {

--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -1,4 +1,4 @@
-# Coloring and Theming in Nushell
+# Coloring and theming in Nu
 
 Many parts of Nushell's interface can have their color customized. All of these can be set in the `config.nu` configuration file. If you see the hash/hashtag/pound mark `#` in the config file it means the text after it is commented out.
 

--- a/book/line_editor.md
+++ b/book/line_editor.md
@@ -1,4 +1,4 @@
-# Reedline. Nushell's line editor
+# Reedline, Nu's line editor
 
 Nushell's line editor [Reedline](https://github.com/nushell/reedline) is a
 cross platform line reader designed to be modular and flexible. The engine is

--- a/book/thinking_in_nushell.md
+++ b/book/thinking_in_nushell.md
@@ -1,4 +1,4 @@
-# Thinking in Nushell
+# Thinking in Nu
 
 To help you understand - and get the most out of - Nushell, we've put together this section on "thinking in Nushell". By learning to think in Nushell and use the patterns it provides, you'll hit fewer issues getting started and be better setup for success.
 

--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -1,4 +1,4 @@
-# Strings
+# Working with strings
 
 Strings in Nushell help to hold text data for later use. This can include file names, file paths, names of columns,
 and much more. Strings are so common that Nushell offers a couple ways to work with them, letting you pick what best


### PR DESCRIPTION
An initial pass at organizing the book pages better, as suggested in #295. Also tweaked some page names for consistency.

<img width="214" alt="image" src="https://user-images.githubusercontent.com/26268125/159067335-53f4539d-c4ec-4d3d-a5f4-4136534cb760.png">
