### PR TITLE
Sort commands alphabetically

### DIFF
--- a/book/command_reference.md
+++ b/book/command_reference.md
@@ -2,12 +2,24 @@
 
 To see all commands in Nushell, run [`help commands`](commands/help.md).
 
+<script>
+  export default {
+    computed: {
+      commands() {
+        return this.$site.pages
+          .filter(p => p.path.indexOf('/book/commands/') >= 0)
+          .sort((a,b) => (a.title > b.title) ? 1 : ((b.title > a.title) ? -1 : 0));
+      }
+    }
+  }
+</script>
+
 <table>
   <tr>
     <th>Command</th>
     <th>Description</th>
   </tr>
-  <tr v-for="command in $site.pages.filter(p => p.path.indexOf('/book/commands/') >= 0)">
+  <tr v-for="command in commands">
    <td><a :href="command.path"><code>{{ command.title }}</code></a></td>
    <td style="white-space: pre-wrap;">{{ command.frontmatter.usage }}</td>
   </tr>

--- a/de/book/command_reference.md
+++ b/de/book/command_reference.md
@@ -1,11 +1,23 @@
 # Command Reference
 
+<script>
+  export default {
+    computed: {
+      commands() {
+        return this.$site.pages
+          .filter(p => p.path.indexOf('/book/commands/') >= 0)
+          .sort((a,b) => (a.title > b.title) ? 1 : ((b.title > a.title) ? -1 : 0));
+      }
+    }
+  }
+</script>
+
 <table>
   <tr>
     <th>Command</th>
     <th>Beschreibung</th>
   </tr>
-  <tr v-for="command in $site.pages.filter(p => p.path.indexOf('/book/commands/') >= 0)">
+  <tr v-for="command in commands">
    <td><a :href="command.path"><code>{{ command.title }}</code></a></td>
    <td style="white-space: pre-wrap;">{{ command.frontmatter.usage }}</td>
   </tr>

--- a/ja/book/command_reference.md
+++ b/ja/book/command_reference.md
@@ -1,11 +1,23 @@
 # Command Reference
 
+<script>
+  export default {
+    computed: {
+      commands() {
+        return this.$site.pages
+          .filter(p => p.path.indexOf('/book/commands/') >= 0)
+          .sort((a,b) => (a.title > b.title) ? 1 : ((b.title > a.title) ? -1 : 0));
+      }
+    }
+  }
+</script>
+
 <table>
   <tr>
     <th>コマンド</th>
     <th>説明 </th>
   </tr>
-  <tr v-for="command in $site.pages.filter(p => p.path.indexOf('/book/commands/') >= 0)">
+  <tr v-for="command in commands">
    <td><a :href="command.path"><code>{{ command.title }}</code></a></td>
    <td style="white-space: pre-wrap;">{{ command.frontmatter.usage }}</td>
   </tr>

--- a/pt-BR/book/command_reference.md
+++ b/pt-BR/book/command_reference.md
@@ -1,11 +1,24 @@
 # Command Reference
 
+
+<script>
+  export default {
+    computed: {
+      commands() {
+        return this.$site.pages
+          .filter(p => p.path.indexOf('/book/commands/') >= 0)
+          .sort((a,b) => (a.title > b.title) ? 1 : ((b.title > a.title) ? -1 : 0));
+      }
+    }
+  }
+</script>
+
 <table>
   <tr>
     <th>Command</th>
     <th>Description</th>
   </tr>
-  <tr v-for="command in $site.pages.filter(p => p.path.indexOf('/book/commands/') >= 0)">
+  <tr v-for="command in commands">
    <td><a :href="command.path"><code>{{ command.title }}</code></a></td>
    <td style="white-space: pre-wrap;">{{ command.frontmatter.usage }}</td>
   </tr>


### PR DESCRIPTION
I noticed that the commands on the command reference page are *mostly* ordered alphabetically but not always. Moving them into an explicitly-sorted [computed property](https://vuejs.org/guide/essentials/computed.html) to fix that.

It would be cool if JS had a less clunky way to sort by a property, but AFAIK this is the most concise way to do it.