### PR TITLE
Mention source + shebangs on Scripts page

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -1,12 +1,16 @@
 # Scripts
 
-In Nushell, you can write and run scripts in the Nushell language. To run a script, you pass it as an argument to the `nu` commandline application.
+In Nushell, you can write and run scripts in the Nushell language. To run a script, you can pass it as an argument to the `nu` commandline application:
 
 ```
 > nu myscript.nu
 ```
 
-This will run the script to completion.
+This will run the script to completion in a new instance of Nu. You can also run scripts inside the *current* instance of Nu using [`source`](commands/source.md):
+
+```
+> source myscript.nu
+```
 
 Let's look at an example script file:
 
@@ -69,3 +73,16 @@ def main [x: int] {
 110
 ```
 
+## Shebangs (`!#`)
+
+On Linux and macOS you can optionally use a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) to tell the OS that a file should be interpreted by Nu. For example, with the following in a file named `myscript`:
+
+```
+#!/usr/bin/env nu
+echo "Hello World!"
+```
+
+```
+> ./myscript
+Hello World!
+```


### PR DESCRIPTION
Adding some info about the `source` command and shebangs to the book.

Was initially going to hold off until some discussions about `source` run their course, but changed my mind - happy to revisit these docs later if `source` functionality changes.