### PR TITLE
Fix minor typos and clarify `Parsing and evaluation...` section

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -10,7 +10,7 @@ Hello, and welcome to the Nushell project. The goal of this project is to take t
 Nu takes cues from a lot of familiar territory: traditional shells like bash, object based shells like PowerShell, gradually typed languages like TypeScript, functional programming, systems programming, and more. But rather than trying to be a jack of all trades, Nu focuses its energy on doing a few things well:
 
 * Being a flexible cross-platform shell with a modern feel
-* Solving problems as a modern programming language that works the structure of your data
+* Solving problems as a modern programming language that works with the structure of your data
 * Giving clear error messages and clean IDE support
 
 The easiest way to see what Nu can do is to start with some examples, so let's dive in.

--- a/book/thinking_in_nushell.md
+++ b/book/thinking_in_nushell.md
@@ -20,7 +20,7 @@ While it does have these amenities, Nushell isn't bash. The bash way of working,
 > echo "hello" > output.txt
 ```
 
-In Nushell, we use the `>` as the greater-than operator. This fits better with the language aspect of Nushell. Instead, you pipe to a file that has the job of saving content:
+In Nushell, we use the `>` as the greater-than operator. This fits better with the language aspect of Nushell. Instead, you pipe to a command that has the job of saving content:
 
 ```
 > echo "hello" | save output.txt

--- a/book/thinking_in_nushell.md
+++ b/book/thinking_in_nushell.md
@@ -30,9 +30,9 @@ In Nushell, we use the `>` as the greater-than operator. This fits better with t
 
 ## Parsing and evaluation are different stages
 
-An important part of Nushell's design and specifically where it differs from many dynamic languages is that "parse time" and "evaluation time" are separate and do not mix. These terms come from programming language design and compiler theory where parsing is where you take the text and convert it to an abstract representation, and evaluation is where you take the abstract representation and run it.
+An important part of Nushell's design and specifically where it differs from many dynamic languages is that "parse time" and "evaluation time" are separate and do not mix. These terms come from programming language design and compiler theory, in which parsing is where you convert text to an abstract representation, and evaluation is where you run the abstract representation.
 
-For example, trying to execute the next script doesn't make sense in Nushell:
+For example, the following doesn't make sense in Nushell, and will fail to execute if run as a script:
 
 ```
 echo "def abc [] { 1 + 2 }" | save output.nu
@@ -40,7 +40,7 @@ source "output.nu"
 abc
 ```
 
-The `source` command runs at parse time, where the parser finds all the definitions that are visible to the program. At evaluation time, those definitions should all be visible.
+The `source` command runs at parse time, where the parser finds all the definitions that are visible to the program. By evaluation time, those definitions should all be visible. However, since the output.nu file is not created until evaluation time (by the save command), the source command is unable to read definitions from it during parse time.
 
 In the above, we've expected the evaluator to run between each line, but Nushell does not interleave parsing and evaluation like this.
 


### PR DESCRIPTION
I found two minor typos in the beginning of the book. 

Also, I wanted to try to clarify the `Parsing and evaluation...` section of `Thinking in Nu` because I think this is by far the most confusing section for people coming to Nu. I know there have been discussions of how to clarify it on Discord, but I figured I'd submit some minor changes as a first effort.

---

Personally, I think that the given example is more confusing than is necessary. This is especially true because if you run each line as a separate command in the shell, it will work perfectly - and this is how most people will think to try the script. 

Instead, I would highlight the second example and use that to explain the overall concept. It's much more clear (to me, at least) that sourcing a dynamic path doesn't work because the source command tries to parse the contents of the path before the dynamic expression has been evaluated. We could, for example, give this self-contained example:

```bash
> source $nu.config-path
```

This has the added benefit that it would fail even if run from the shell, unlike the current primary example. Also, I think this is a familiar command to people coming from other shells, because sourcing the [`.bashrc/.zshrc/...`] is the normal way to reload the configuration values. I think that isn't best practice in Nushell, but this section is just about explaining the concepts, not instructing in the proper use of Nu.