### PR TITLE
Fix Scoped `cd` example in 0.60 release blog post

### DIFF
--- a/blog/2022-03-22-nushell_0_60.md
+++ b/blog/2022-03-22-nushell_0_60.md
@@ -272,7 +272,7 @@ In this release, we're also moving to keeping the current directory in the envir
 This allows you to more easily loop over subdirectories without having to do the bookkeeping of remembering to change back to the previous directory:
 
 ```
-> ls | where type == dir | each { cd $it.name; ls | length }
+> ls | where type == dir | each { |it| cd $it.name; ls | length }
 ```
 
 That said, it takes a little getting used to. It does mean that changing a directory in a traditional custom command won't work, as the `PWD` environment variable will reset after the call completes. To help with this, we're also introducing `def-env`, a way to work inside the caller's environment and not lose any environment changes made by the custom command:


### PR DESCRIPTION
Hi!

I just tried out the examples in the release blog post. I got an error on the smart `cd` example because of a missing parameter for looping. See the example below and the patch for the blog post.

```
/home/stefano/〉version                                                                                           03/23/2022 08:33:09 AM
╭────────────────────┬─────────────────────────────────────╮
│ version            │ 0.60.0                              │
│ build_os           │ linux-x86_64                        │
│ rust_version       │ rustc 1.59.0 (9d1b2106e 2022-02-23) │
│ rust_channel       │ stable-x86_64-unknown-linux-gnu     │
│ cargo_version      │ cargo 1.59.0 (49d8809dc 2022-02-10) │
│ pkg_version        │ 0.60.0                              │
│ build_time         │ 2022-03-23 08:20:40 +01:00          │
│ build_rust_channel │ release                             │
│ features           │ default, trash, which, zip          │
│ installed_plugins  │                                     │
╰────────────────────┴─────────────────────────────────────╯
/home/stefano/〉ls | where type == dir | each { cd $it.name; ls | length }                                        03/23/2022 08:33:12 AM
Error: nu::parser::parse_mismatch (link)

  × Parse mismatch during operation.
   ╭─[entry #62:1:1]
 1 │ ls | where type == dir | each { cd $it.name; ls | length }
   ·                                ▲
   ·                                ╰── expected 1 block parameter
   ╰────

/home/stefano/〉ls | where type == dir | each { |it| cd $it.name; ls | length }                                   03/23/2022 08:33:17 AM
╭────┬────╮
│  0 │  1 │
│  1 │  1 │
│  2 │  5 │
│  3 │ 97 │
│  4 │  0 │
│  5 │  8 │
│  6 │  1 │
│  7 │  0 │
│  8 │  0 │
│  9 │  1 │
│ 10 │  0 │
│ 11 │  1 │
│ 12 │  4 │
│ 13 │  9 │
╰────┴────╯
/home/stefano/〉                                                                                                  03/23/2022 08:33:21 AM

```