### PR TITLE
Document optional parameters and rest parameters

### DIFF
--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -106,6 +106,48 @@ The currently accepted types are (as of version 0.59.0):
  - `string`
  - `variable`
 
+## Optional positional parameters
+
+By default, positional parameters are required. If a positional parameter is not passed, we will encounter an error:
+
+```
+  × Missing required positional argument.
+   ╭─[entry #23:1:1]
+ 1 │ greet
+   ·      ▲
+   ·      ╰── missing name
+   ╰────
+  help: Usage: greet <name>
+```
+
+We can instead mark a positional parameter as optional by putting a question mark (`?`) after its name. For example:
+
+```nushell
+def greet [name?: string] {
+  echo "hello" $name
+}
+
+greet
+```
+
+Making a positional parameter optional does not change its name when accessed in the body. As the example above shows, it is still accessed with `$name`, despite the `?` suffix in the parameter list.
+
+When an optional parameter is not passed, its value in the command body is equal to `null` and `$nothing`. We can use this to act on the case where a parameter was not passed:
+
+```nushell
+def greet [name?: string] {
+  if ($name == null) {
+    echo "hello, I don't know your name!"
+  } else {
+    echo "hello" $name
+  }
+}
+
+greet
+```
+
+If required and optional positional parameters are used together, then the required parameters must appear in the definition first.
+
 ## Flags
 
 In addition to passing positional parameters, you can also pass named parameters by defining flags for your custom commands.

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -105,7 +105,7 @@ The currently accepted types are (as of version 0.59.0):
  - `signature`
  - `string`
  - `variable`
-
+ 
 ## Optional positional parameters
 
 By default, positional parameters are required. If a positional parameter is not passed, we will encounter an error:
@@ -204,6 +204,38 @@ Now, we can call this updated definition using the shorthand flag:
 > greet -a 10 hello
 ```
 
+## Rest parameters
+
+There may be cases when you want to define a command which takes any number of positional arguments. We can do this with a rest parameter, using the following `...` syntax:
+
+```nushell
+def greet [...name: string] {
+  echo "hello all:"
+  for $n in $name {
+    echo $n
+  }
+}
+
+greet earth mars jupiter venus
+```
+
+We could call the above definition of the `greet` command with any number of arguments, including none at all. All of the arguments are collected into `$name` as a list.
+
+Rest parameters can be used together with positional parameters:
+
+```
+def greet [vip: string, ...name: string] {
+  echo "hello to our VIP" $vip
+  echo "and hello to everybody else:"
+  for $n in $name {
+    echo $n
+  }
+}
+
+#     $vip          $name
+#     .--. .----------------------.
+greet moon earth mars jupiter venus
+```
 
 ## Documenting your command
 


### PR DESCRIPTION
I've been trying out Nushell as my daily shell again after the 0.60 release!

This PR adds a couple of short sections to the book explaining functionality which I had to look around a bit to find, specifically:

- Optional positional parameters `def something [x?] { ... }`
- Rest parameters: `def something [...x] { ... }`

This is my first PR to these docs, so more than happy to respond to any review comments about style/consistency/etc!