### PR TITLE
docs: table border options

### DIFF
--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -29,11 +29,10 @@ Here are the current options for `table_mode`:
 5. `light`
 6. `thin`
 7. `with_love`
-8. `rounded`
-9. `reinforced`
-10. `heavy`
-11. `none`
-12. `other`
+8. `reinforced`
+9. `heavy`
+10. `none`
+11. `other`
 
 ### `Color symbologies`
 

--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -22,17 +22,17 @@ Table borders are controlled by the `table_mode` setting in `config.nu`. Here is
 
 Here are the current options for `table_mode`:
 
-1. `rounded` # of course, this is the best one :)
-2. `basic`
-3. `compact`
-4. `compact_double`
-5. `light`
-6. `thin`
-7. `with_love`
-8. `reinforced`
-9. `heavy`
-10. `none`
-11. `other`
+- `rounded` # of course, this is the best one :)
+- `basic`
+- `compact`
+- `compact_double`
+- `light`
+- `thin`
+- `with_love`
+- `reinforced`
+- `heavy`
+- `none`
+- `other`
 
 ### `Color symbologies`
 


### PR DESCRIPTION
This PR improves the list of table border options:

- remove duplicate listing of the `rounded` option
- uses a bulleted list instead of a numbered list (since there isn't an order to the options, it's better to use a bulleted list).