### PR TITLE
docs(german): fix grammar in description

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -8,7 +8,7 @@ module.exports = {
     "/de/": {
       lang: "Deutsch",
       title: "Nushell",
-      description: "Eine neuer Art von Shell.",
+      description: "Eine neue Art von Shell.",
     },
     "/es/": {
       lang: "es",


### PR DESCRIPTION
Fixed the wrong gender of the adjective "neue" in the description.

"Art" (species, kind) is female, so it must be "eine **neue** Art"