### PR TITLE
Describe interpolated string escape workarounds

### DIFF
--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -63,7 +63,7 @@ String interpolation has both a single-quoted, `$' '`, and a double-quoted, `$" 
 
 Interpolated strings do not currently support any way of escaping parentheses. If you would like to include parentheses in the resulting string, one workaround is to use sub-expressions which evaluate to the `(` or `)` characters, such as [`char lp` and `char rp`](commands/char.md). For example:
 
-```nushell
+```
 > $"2 + 2 is (2 + 2) (char lp)you guessed it!(char rp)"
 2 + 2 is 4 (you guessed it!)
 ```

--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -59,19 +59,12 @@ greetings, Alice
 
 By wrapping expressions in `()`, we can run them to completion and use the results to help build the string.
 
-String interpolation has both a single-quoted, `$' '`, and a double-quoted, `$" "`, form. These correspond to the single-quoted and double-quoted strings: single-quoted string interpolation doesn't support escape characters such as `\n`, while double-quoted string interpolation does. 
+String interpolation has both a single-quoted, `$' '`, and a double-quoted, `$" "`, form. These correspond to the single-quoted and double-quoted strings: single-quoted string interpolation doesn't support escape characters while double-quoted string interpolation does. 
 
-Interpolated strings do not currently support any way of escaping parentheses. If you would like to include parentheses in the resulting string, one workaround is to use sub-expressions which evaluate to the `(` or `)` characters, such as [`char lp` and `char rp`](commands/char.md). For example:
-
-```
-> $"2 + 2 is (2 + 2) (char lp)you guessed it!(char rp)"
-2 + 2 is 4 (you guessed it!)
-```
-
-Alternatively, you could compose the string using the [`build-string`](commands/build-string.md) command instead:
+As of version 0.61, interpolated strings support escaping parentheses, so that the `(` and `)` characters may be used in a string without Nushell trying to evaluate what appears between them:
 
 ```
-> build-string "2 + 2 is " (2 + 2) " (you guessed it!)"
+> $"2 + 2 is (2 + 2) \(you guessed it!)"
 2 + 2 is 4 (you guessed it!)
 ```
 

--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -59,7 +59,21 @@ greetings, Alice
 
 By wrapping expressions in `()`, we can run them to completion and use the results to help build the string.
 
-String interpolation has both a single-quoted, `$' '`, and a double-quoted, `$" "`, form. These correspond to the single-quoted and double-quoted strings: single-quoted string interpolation doesn't support escape characters while double-quoted string interpolation does. 
+String interpolation has both a single-quoted, `$' '`, and a double-quoted, `$" "`, form. These correspond to the single-quoted and double-quoted strings: single-quoted string interpolation doesn't support escape characters such as `\n`, while double-quoted string interpolation does. 
+
+Interpolated strings do not currently support any way of escaping parentheses. If you would like to include parentheses in the resulting string, one workaround is to use sub-expressions which evaluate to the `(` or `)` characters, such as [`char lp` and `char rp`](commands/char.md). For example:
+
+```nushell
+> $"2 + 2 is (2 + 2) (char lp)you guessed it!(char rp)"
+2 + 2 is 4 (you guessed it!)
+```
+
+Alternatively, you could compose the string using the [`build-string`](commands/build-string.md) command instead:
+
+```
+> build-string "2 + 2 is " (2 + 2) " (you guessed it!)"
+2 + 2 is 4 (you guessed it!)
+```
 
 ## Splitting strings
 


### PR DESCRIPTION
When first dealing with interpolated strings, I found that I needed to escape some parentheses, and couldn't find any documentation about how to do this. A search in Discord said that there isn't any proper way to do this yet (though please correct me if I'm wrong!)

This PR documents the two ways of working around this that I'm aware of.