### PR TITLE
Add `str collect` to "Nu map from ..." tables, and fix entries for `trim`

### DIFF
--- a/book/nushell_map.md
+++ b/book/nushell_map.md
@@ -80,6 +80,8 @@ Note: this table assumes Nu 0.43 or later.
 | split column           |                               |   -                                                  |                                            |                                                 |
 | split row              |                               |   -                                                  |                                            |                                                 |
 | str(`*`)               | string functions              | String class                                         | String class                               |                                                 |
+| str collect            | concat_ws                     | Join                                                 | Join-String                                |                                                 |
+| str trim               | rtrim, ltrim                  | Trim, TrimStart, TrimEnd                             | Trim                                       |                                                 |
 | sum                    | sum                           | Sum                                                  | Measure-Object, measure                    |                                                 |
 | sys(`*`)               |   -                           |   -                                                  | Get-ComputerInfo                           | uname, lshw, lsblk, lscpu, lsusb, hdparam, free |
 | table                  |                               |                                                      | Format-Table, ft, Format-List, fl          |                                                 |
@@ -88,7 +90,6 @@ Note: this table assumes Nu 0.43 or later.
 | tree(`*`)              |   -                           |   -                                                  | tree                                       |                                                 |
 | to                     |   -                           |   -                                                  | Export/ConvertTo-{Csv,Xml,Html,Json}       |                                                 |
 | touch                  |   -                           |   -                                                  | Set-Content                                | touch                                           |
-| trim                   | rtrim, ltrim                  | Trim, TrimStart, TrimEnd                             | Trim                                       |                                                 |
 | uniq                   | distinct                      | Distinct                                             | Get-Unique, gu                             | uniq                                            |
 | upsert                 | As                            |   -                                                  |                                            |                                                 |
 | version                | select @@version              |   -                                                  | $PSVersionTable                            |                                                 |

--- a/book/nushell_map_functional.md
+++ b/book/nushell_map_functional.md
@@ -82,7 +82,9 @@ Note: this table assumes Nu 0.43 or later.
 | split-by               | split, split-{at,with,lines}  | split, words, lines                                  | split, words, lines                        |                                                 |
 | split column           |                               |                                                      |                                            |                                                 |
 | split row              |                               |                                                      |                                            |                                                 |
-| str                    | clojure.string functions      | String functions                                     |                                            |                                                 |
+| str(`*`)               | clojure.string functions      | String functions                                     |                                            |                                                 |
+| str collect            | join                          | concat                                               | intercalate                                |                                                 |
+| str trim               | trim, triml, trimr            | trim, trimLeft, trimRight                            | strip                                      |                                                 |
 | sum                    | apply +                       | sum                                                  | sum                                        |                                                 |
 | sys                    |                               |                                                      |                                            |                                                 |
 | table                  |                               |                                                      |                                            |                                                 |
@@ -90,7 +92,6 @@ Note: this table assumes Nu 0.43 or later.
 | tree(`*`)              |                               |                                                      |                                            |                                                 |
 | to                     |                               |                                                      |                                            |                                                 |
 | touch                  |                               |                                                      |                                            |                                                 |
-| trim                   | trim, triml, trimr            | trim, trimLeft, trimRight                            | strip                                      |                                                 |
 | uniq                   | set                           | Set.empty                                            | Data.Set                                   |                                                 |
 | upsert                 |                               |                                                      |                                            |                                                 |
 | version                |                               |                                                      |                                            |                                                 |

--- a/book/nushell_map_imperative.md
+++ b/book/nushell_map_imperative.md
@@ -82,6 +82,8 @@ Note: this table assumes Nu 0.43 or later.
 | split column           |                               |                                                      |                                            |                                                 |
 | split row              |                               |                                                      |                                            |                                                 |
 | str(`*`)               | str functions                 | String functions                                     | string functions                           | &str, String functions                          |
+| str collect            | str.join                      | joinToString                                         |                                            | join                                            |
+| str trim               | strip, rstrip, lstrip         | trim, trimStart, trimEnd                             | regex                                      | trim, trim_{start,end}, strip_{suffix,prefix}   |
 | sum                    | sum                           | sum                                                  | reduce                                     | sum                                             |
 | sys(`*`)               | sys                           |                                                      |                                            |                                                 |
 | table                  |                               |                                                      |                                            |                                                 |
@@ -89,7 +91,6 @@ Note: this table assumes Nu 0.43 or later.
 | tree(`*`)              |                               |                                                      |                                            |                                                 |
 | to                     | csv, json, sqlite3            |                                                      |                                            |                                                 |
 | touch                  | open(path, 'a').close()       |                                                      |                                            |                                                 |
-| trim                   | strip, rstrip, lstrip         | trim, trimStart, trimEnd                             | regex                                      | trim, trim_{start,end}, strip_{suffix,prefix}   |
 | uniq                   | set                           | Set                                                  | set                                        | HashSet                                         |
 | upsert                 |                               |                                                      |                                            |                                                 |
 | version                | sys.version, sys.version_info |                                                      |                                            |                                                 |


### PR DESCRIPTION
This PR:

- Adds `str collect` to the three "Nu map from..." tables. This subcommand is named differently from most other languages I'm familiar with (I'm used to it being called something like `join`), so I missed this completely when looking for it. Hopefully this would make it more discoverable.
- Renames the `trim` rows to `str trim`. The `trim` command was [removed a while ago](https://github.com/nushell/nushell/pull/2560), so this brings the tables up-to-date with this change.

I think most of `str`'s other subcommands have names very similar to other languages, so I'm not sure they all need to be documented here - but if you think otherwise then I'm happy to add some more too :)