### PR TITLE
chore: Ignore formatting the docs for commands

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+
+node_modules
+package-lock.json
+book/commands/*.md


### PR DESCRIPTION
Disable code formatting for commands' docs
Or, alternatively, you can merge this PR: https://github.com/nushell/nushell.github.io/pull/349