### PR TITLE
Update instructions on aliasing open

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -76,10 +76,10 @@ With this, you should be able to `chsh` and set Nu to be your login shell. After
 
 Some tools (e.g. Emacs) rely on an `open` command to open files on Mac.
 As Nushell has its own [`open`](commands/open.md) command which has different semantics and shadows `/usr/bin/open`, these tools will error out when trying to use it.
-One way to work around this is to define `alias`es in your `config.nu` file like this:
+One way to work around this is to define a custom command for Nushell's `open` and create an alias for the system's `open` in your `config.nu` file like this:
 
 ```
-alias nuopen = open
+def nuopen [arg, --raw (-r)] { if $raw { open -r $arg } else { open $arg } }
 alias open = ^open
 ```
 

--- a/de/book/konfiguration.md
+++ b/de/book/konfiguration.md
@@ -70,10 +70,10 @@ Damit sollte es möglich sein, Nu als Login-Shell mit `chsh` festzulegen. Nach d
 
 Manche Tools (z.B. Emacs) vertrauen darauf, dass `open` Dateien auf dem Mac öffnet.
 Da Nushell einen eigenen `open` Befehl hat, der eine andere Semantik hat und `/usr/bin/open` verbirgt, werden diese Tools einen Fehler werfen, wenn sie verwendet werden.
-Eine Möglichkeit, dieses Problem zu umgehen, ist es, einen `alias` in `config.nu` zu definieren:
+Eine Möglichkeit, dieses Problem zu umgehen, ist es, einen eigenen Befehl und einen `alias` in `config.nu` zu definieren:
 
 ```
-alias nuopen = open
+def nuopen [arg, --raw (-r)] { if $raw { open -r $arg } else { open $arg } }
 alias open = ^open
 ```
 


### PR DESCRIPTION
The previous instructions did not work, because the first alias would also refer to the system's `open`.

This is not an ideal solution, because we lose the nice help info from Nushell's `open`, but it works.