### PR TITLE
Indicate that `which` works like Bash's `type`

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -53,6 +53,7 @@ Note: this table assumes Nu 0.14.1 or later.
 | `echo $FOO`                          | `echo $env.FOO`                                  | Use environment variables                                         |
 | `unset FOO`                          | `hide FOO`                                       | Unset environment variable for current session                    |
 | `alias s="git status -sb"`           | `alias s = git status -sb`                       | Define an alias temporarily                                       |
+| `type FOO`                           | `which FOO`                                      | Display information about a command (built-in, alias, or executable) |
 | `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Add and edit alias permanently (for new shells)                   |
 | `bash -c <commands>`                 | `nu -c <commands>`                               | Run a pipeline of commands (requires 0.9.1 or later)              |
 | `bash <script file>`                 | `nu <script file>`                               | Run a script file (requires 0.9.1 or later)                       |


### PR DESCRIPTION
In Bash, `which` only works on executables; to get information about an alias, function, or built-in, you need to use `type`. Nushell's `which` is therefore more like Bash's `type`.

I'm not sure if the length of the new line justifies reformatting the table so that the end-of-line pipes align again.