### PR TITLE
Add extra_usage to command pages

### DIFF
--- a/book/commands/alias.md
+++ b/book/commands/alias.md
@@ -19,6 +19,11 @@ usage: |
  -  `name`: name of the alias
  -  `initial_value`: equals sign followed by value
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Alias ll to ls -l

--- a/book/commands/ansi.md
+++ b/book/commands/ansi.md
@@ -21,6 +21,51 @@ usage: |
  -  `--osc`: operating system command (ocs) escape sequence without the escape character(s)
  -  `--list`: list available ansi code names
 
+## Notes
+```text
+For escape sequences:
+Escape: '\x1b[' is not required for --escape parameter
+Format: #(;#)m
+Example: 1;31m for bold red or 2;37;41m for dimmed white fg with red bg
+There can be multiple text formatting sequence numbers
+separated by a ; and ending with an m where the # is of the
+following values:
+    attribute_number, abbreviation, description
+    0     reset / normal display
+    1  b  bold or increased intensity
+    2  d  faint or decreased intensity
+    3  i  italic on (non-mono font)
+    4  u  underline on
+    5  l  slow blink on
+    6     fast blink on
+    7  r  reverse video on
+    8  h  nondisplayed (invisible) on
+    9  s  strike-through on
+
+    foreground/bright colors    background/bright colors
+    30/90    black              40/100    black
+    31/91    red                41/101    red
+    32/92    green              42/102    green
+    33/93    yellow             43/103    yellow
+    34/94    blue               44/104    blue
+    35/95    magenta            45/105    magenta
+    36/96    cyan               46/106    cyan
+    37/97    white              47/107    white
+    39       default            49        default
+    https://en.wikipedia.org/wiki/ANSI_escape_code
+
+OSC: '\x1b]' is not required for --osc parameter
+Example: echo [(ansi -o '0') 'some title' (char bel)] | str collect
+Format: #
+    0 Set window title and icon name
+    1 Set icon name
+    2 Set window title
+    4 Set/read color palette
+    9 iTerm2 Grown notifications
+    10 Set foreground color (x11 color spec)
+    11 Set background color (x11 color spec)
+    ... others
+```
 ## Examples
 
 Change color to green

--- a/book/commands/ansi_gradient.md
+++ b/book/commands/ansi_gradient.md
@@ -3,7 +3,7 @@ title: ansi gradient
 layout: command
 version: 0.60.1
 usage: |
-  draw text with a provided start and end code making a gradient
+  Draw text with a provided start and end code making a gradient
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/ansi_strip.md
+++ b/book/commands/ansi_strip.md
@@ -3,7 +3,7 @@ title: ansi strip
 layout: command
 version: 0.60.1
 usage: |
-  strip ansi escape sequences from string
+  Strip ANSI escape sequences from a string
 ---
 
 # `{{ $frontmatter.title }}`
@@ -16,11 +16,11 @@ usage: |
 
 ## Parameters
 
- -  `...column path`: optionally, remove ansi sequences by column paths
+ -  `...column path`: optionally, remove ANSI sequences by column paths
 
 ## Examples
 
-strip ansi escape sequences from string
+Strip ANSI escape sequences from a string
 ```shell
 > echo [ (ansi green) (ansi cursor_on) "hello" ] | str collect | ansi strip
 ```

--- a/book/commands/date.md
+++ b/book/commands/date.md
@@ -3,7 +3,7 @@ title: date
 layout: command
 version: 0.60.1
 usage: |
-  date
+  Date-related commands
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/date_to-timezone.md
+++ b/book/commands/date_to-timezone.md
@@ -18,6 +18,10 @@ usage: |
 
  -  `time zone`: time zone description
 
+## Notes
+```text
+Use 'date list-timezone' to list all supported time zones.
+```
 ## Examples
 
 Get the current date in UTC+05:00

--- a/book/commands/decode.md
+++ b/book/commands/decode.md
@@ -18,6 +18,14 @@ usage: |
 
  -  `encoding`: the text encoding to use
 
+## Notes
+```text
+Multiple encodings are supported, here is an example of a few:
+big5, euc-jp, euc-kr, gbk, iso-8859-1, utf-16, cp1252, latin5
+
+For a more complete list of encodings please refer to the encoding_rs
+documentation link at https://docs.rs/encoding_rs/0.8.28/encoding_rs/#statics
+```
 ## Examples
 
 Decode the output of an external command

--- a/book/commands/def-env.md
+++ b/book/commands/def-env.md
@@ -20,6 +20,11 @@ usage: |
  -  `params`: parameters
  -  `block`: body of the definition
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Set environment variable by call a custom command

--- a/book/commands/def.md
+++ b/book/commands/def.md
@@ -20,6 +20,11 @@ usage: |
  -  `params`: parameters
  -  `block`: body of the definition
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Define a command and run it

--- a/book/commands/detect_columns.md
+++ b/book/commands/detect_columns.md
@@ -3,7 +3,7 @@ title: detect columns
 layout: command
 version: 0.60.1
 usage: |
-  splits contents across multiple columns via the separator.
+  Attempt to automatically split text into multiple columns
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/dfr_as-date.md
+++ b/book/commands/dfr_as-date.md
@@ -3,10 +3,7 @@ title: dfr as-date
 layout: command
 version: 0.60.1
 usage: |
-  Converts string to date. Format example:
-          "%Y-%m-%d"    => 2021-12-31
-          "%d-%m-%Y"    => 31-12-2021
-          "%Y%m%d"      => 2021319 (2021-03-19)
+  Converts string to date.
 ---
 
 # `{{ $frontmatter.title }}`
@@ -19,7 +16,7 @@ usage: |
 
 ## Parameters
 
- -  `format`: formating date string
+ -  `format`: formatting date string
  -  `--not-exact`: the format string may be contained in the date (e.g. foo-2021-01-01-bar could match 2021-01-01)
 
 ## Examples

--- a/book/commands/dfr_as-date.md
+++ b/book/commands/dfr_as-date.md
@@ -19,6 +19,13 @@ usage: |
  -  `format`: formatting date string
  -  `--not-exact`: the format string may be contained in the date (e.g. foo-2021-01-01-bar could match 2021-01-01)
 
+## Notes
+```text
+Format example:
+        "%Y-%m-%d"    => 2021-12-31
+        "%d-%m-%Y"    => 31-12-2021
+        "%Y%m%d"      => 2021319 (2021-03-19)
+```
 ## Examples
 
 Converts string to date

--- a/book/commands/dfr_as-datetime.md
+++ b/book/commands/dfr_as-datetime.md
@@ -19,6 +19,21 @@ usage: |
  -  `format`: formatting date time string
  -  `--not-exact`: the format string may be contained in the date (e.g. foo-2021-01-01-bar could match 2021-01-01)
 
+## Notes
+```text
+Format example:
+        "%y/%m/%d %H:%M:%S"  => 21/12/31 12:54:98
+        "%y-%m-%d %H:%M:%S"  => 2021-12-31 24:58:01
+        "%y/%m/%d %H:%M:%S"  => 21/12/31 24:58:01
+        "%y%m%d %H:%M:%S"    => 210319 23:58:50
+        "%Y/%m/%d %H:%M:%S"  => 2021/12/31 12:54:98
+        "%Y-%m-%d %H:%M:%S"  => 2021-12-31 24:58:01
+        "%Y/%m/%d %H:%M:%S"  => 2021/12/31 24:58:01
+        "%Y%m%d %H:%M:%S"    => 20210319 23:58:50
+        "%FT%H:%M:%S"        => 2019-04-18T02:45:55
+        "%FT%H:%M:%S.%6f"    => microseconds
+        "%FT%H:%M:%S.%9f"    => nanoseconds
+```
 ## Examples
 
 Converts string to datetime

--- a/book/commands/dfr_as-datetime.md
+++ b/book/commands/dfr_as-datetime.md
@@ -3,18 +3,7 @@ title: dfr as-datetime
 layout: command
 version: 0.60.1
 usage: |
-  Converts string to datetime. Format example:
-          "%y/%m/%d %H:%M:%S"  => 21/12/31 12:54:98
-          "%y-%m-%d %H:%M:%S"  => 2021-12-31 24:58:01
-          "%y/%m/%d %H:%M:%S"  => 21/12/31 24:58:01
-          "%y%m%d %H:%M:%S"    => 210319 23:58:50
-          "%Y/%m/%d %H:%M:%S"  => 2021/12/31 12:54:98
-          "%Y-%m-%d %H:%M:%S"  => 2021-12-31 24:58:01
-          "%Y/%m/%d %H:%M:%S"  => 2021/12/31 24:58:01
-          "%Y%m%d %H:%M:%S"    => 20210319 23:58:50
-          "%FT%H:%M:%S"        => 2019-04-18T02:45:55
-          "%FT%H:%M:%S.%6f"    => microseconds
-          "%FT%H:%M:%S.%9f"    => nanoseconds
+  Converts string to datetime.
 ---
 
 # `{{ $frontmatter.title }}`
@@ -27,7 +16,7 @@ usage: |
 
 ## Parameters
 
- -  `format`: formating date time string
+ -  `format`: formatting date time string
  -  `--not-exact`: the format string may be contained in the date (e.g. foo-2021-01-01-bar could match 2021-01-01)
 
 ## Examples

--- a/book/commands/dfr_rename-col.md
+++ b/book/commands/dfr_rename-col.md
@@ -3,7 +3,7 @@ title: dfr rename-col
 layout: command
 version: 0.60.1
 usage: |
-  rename a dataframe column
+  Rename a dataframe column
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/exec.md
+++ b/book/commands/exec.md
@@ -19,6 +19,10 @@ usage: |
  -  `command`: the command to execute
  -  `...rest`: any additional arguments for the command
 
+## Notes
+```text
+Currently supported only on Unix-based systems.
+```
 ## Examples
 
 Execute external 'ps aux' tool

--- a/book/commands/exit.md
+++ b/book/commands/exit.md
@@ -3,7 +3,7 @@ title: exit
 layout: command
 version: 0.60.1
 usage: |
-  Runs a script file in the current context.
+  Exit a Nu shell or exit Nu entirely.
 ---
 
 # `{{ $frontmatter.title }}`
@@ -17,7 +17,7 @@ usage: |
 ## Parameters
 
  -  `exit_code`: Exit code to return immediately with
- -  `--now`: Exit out of the shell immediately
+ -  `--now`: Exit out of all shells immediately (exiting Nu)
 
 ## Examples
 

--- a/book/commands/export.md
+++ b/book/commands/export.md
@@ -14,6 +14,11 @@ usage: |
 
 ```> export ```
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Export a definition from a module

--- a/book/commands/export_alias.md
+++ b/book/commands/export_alias.md
@@ -19,6 +19,11 @@ usage: |
  -  `name`: name of the alias
  -  `initial_value`: equals sign followed by value
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 export an alias of ll to ls -l, from a module

--- a/book/commands/export_def-env.md
+++ b/book/commands/export_def-env.md
@@ -20,6 +20,11 @@ usage: |
  -  `params`: parameters
  -  `block`: body of the definition
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Define a custom command that participates in the environment in a module and call it

--- a/book/commands/export_def.md
+++ b/book/commands/export_def.md
@@ -20,6 +20,11 @@ usage: |
  -  `params`: parameters
  -  `block`: body of the definition
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Define a custom command in a module and call it

--- a/book/commands/export_env.md
+++ b/book/commands/export_env.md
@@ -19,6 +19,11 @@ usage: |
  -  `name`: name of the environment variable
  -  `block`: body of the environment variable definition
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Import and evaluate environment variable from a module

--- a/book/commands/export_extern.md
+++ b/book/commands/export_extern.md
@@ -19,6 +19,11 @@ usage: |
  -  `def_name`: definition name
  -  `params`: parameters
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Export the signature for an external command

--- a/book/commands/extern.md
+++ b/book/commands/extern.md
@@ -19,6 +19,11 @@ usage: |
  -  `def_name`: definition name
  -  `params`: parameters
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Write a signature for an external command

--- a/book/commands/fetch.md
+++ b/book/commands/fetch.md
@@ -23,6 +23,10 @@ usage: |
  -  `--headers {any}`: custom headers you want to add
  -  `--raw`: fetch contents as text rather than a table
 
+## Notes
+```text
+Performs HTTP GET operation.
+```
 ## Examples
 
 Fetch content from url.com

--- a/book/commands/fmt.md
+++ b/book/commands/fmt.md
@@ -3,7 +3,7 @@ title: fmt
 layout: command
 version: 0.60.1
 usage: |
-  format numbers
+  Format a number
 ---
 
 # `{{ $frontmatter.title }}`
@@ -16,7 +16,7 @@ usage: |
 
 ## Examples
 
-format numbers
+Get a record containing multiple formats for the number 42
 ```shell
 > 42 | fmt
 ```

--- a/book/commands/for.md
+++ b/book/commands/for.md
@@ -21,6 +21,11 @@ usage: |
  -  `block`: the block to run
  -  `--numbered`: returned a numbered item ($it.index and $it.item)
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Echo the square of each integer

--- a/book/commands/glob.md
+++ b/book/commands/glob.md
@@ -19,6 +19,10 @@ usage: |
  -  `glob`: the glob expression
  -  `--depth {int}`: directory depth to search
 
+## Notes
+```text
+For more glob pattern help please refer to https://github.com/olson-sean-k/wax
+```
 ## Examples
 
 Search for *.rs files

--- a/book/commands/grid.md
+++ b/book/commands/grid.md
@@ -20,6 +20,15 @@ usage: |
  -  `--color`: draw output with color
  -  `--separator {string}`: character to separate grid with
 
+## Notes
+```text
+grid was built to give a concise gridded layout for ls. however,
+it determines what to put in the grid by looking for a column named
+'name'. this works great for tables and records but for lists we
+need to do something different. such as with '[one two three] | grid'
+it creates a fake column called 'name' for these values so that it
+prints out the list properly.
+```
 ## Examples
 
 Render a simple list to a grid

--- a/book/commands/hash_md5.md
+++ b/book/commands/hash_md5.md
@@ -3,7 +3,7 @@ title: hash md5
 layout: command
 version: 0.60.1
 usage: |
-  hash a value using the md5 hash algorithm
+  Hash a value using the md5 hash algorithm
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/hash_sha256.md
+++ b/book/commands/hash_sha256.md
@@ -3,7 +3,7 @@ title: hash sha256
 layout: command
 version: 0.60.1
 usage: |
-  hash a value using the sha256 hash algorithm
+  Hash a value using the sha256 hash algorithm
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/hide.md
+++ b/book/commands/hide.md
@@ -18,6 +18,14 @@ usage: |
 
  -  `pattern`: import pattern
 
+## Notes
+```text
+Symbols are hidden by priority: First aliases, then custom commands, then environment variables.
+
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+
+```
 ## Examples
 
 Hide the alias just defined

--- a/book/commands/if.md
+++ b/book/commands/if.md
@@ -20,6 +20,11 @@ usage: |
  -  `then_block`: block to run if check succeeds
  -  `else_expression`: expression or block to run if check fails
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Output a value if a condition matches, otherwise return nothing

--- a/book/commands/inc.md
+++ b/book/commands/inc.md
@@ -1,7 +1,7 @@
 ---
 title: inc
 layout: command
-version: 0.59.1
+version: 0.60.1
 usage: |
   Increment a value or version. Optionally use the column of a table.
 ---
@@ -12,10 +12,11 @@ usage: |
 
 ## Signature
 
-`> inc --major --minor --patch`
+```> inc (cell_path) --major --minor --patch```
 
 ## Parameters
 
-- `--major`: increment the major version (eg 1.2.1 -> 2.0.0)
-- `--minor`: increment the minor version (eg 1.2.1 -> 1.3.0)
-- `--patch`: increment the patch version (eg 1.2.1 -> 1.2.2)
+ -  `cell_path`: cell path to update
+ -  `--major`: increment the major version (eg 1.2.1 -> 2.0.0)
+ -  `--minor`: increment the minor version (eg 1.2.1 -> 1.3.0)
+ -  `--patch`: increment the patch version (eg 1.2.1 -> 1.2.2)

--- a/book/commands/into.md
+++ b/book/commands/into.md
@@ -3,7 +3,7 @@ title: into
 layout: command
 version: 0.60.1
 usage: |
-  Apply into function.
+  Commands to convert data from one type to another.
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/into_datetime.md
+++ b/book/commands/into_datetime.md
@@ -3,7 +3,7 @@ title: into datetime
 layout: command
 version: 0.60.1
 usage: |
-  converts text into datetime
+  Convert text into a datetime
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/into_decimal.md
+++ b/book/commands/into_decimal.md
@@ -3,7 +3,7 @@ title: into decimal
 layout: command
 version: 0.60.1
 usage: |
-  converts text into decimal
+  Convert text into a decimal
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/kill.md
+++ b/book/commands/kill.md
@@ -12,7 +12,7 @@ usage: |
 
 ## Signature
 
-```> kill (pid) ...rest --force --quiet --signal```
+```> kill (pid) ...rest --force --quiet```
 
 ## Parameters
 
@@ -20,7 +20,6 @@ usage: |
  -  `...rest`: rest of processes to kill
  -  `--force`: forcefully kill the process
  -  `--quiet`: won't print anything to the console
- -  `--signal {int}`: signal decimal number to be sent instead of the default 15 (unsupported on Windows)
 
 ## Examples
 

--- a/book/commands/let.md
+++ b/book/commands/let.md
@@ -19,6 +19,11 @@ usage: |
  -  `var_name`: variable name
  -  `initial_value`: equals sign followed by value
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Set a variable to a value

--- a/book/commands/module.md
+++ b/book/commands/module.md
@@ -19,6 +19,11 @@ usage: |
  -  `module_name`: module name
  -  `block`: body of the module
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Define a custom command in a module and call it

--- a/book/commands/path.md
+++ b/book/commands/path.md
@@ -13,3 +13,19 @@ usage: |
 ## Signature
 
 ```> path ```
+
+## Notes
+```text
+There are three ways to represent a path:
+
+* As a path literal, e.g., '/home/viking/spam.txt'
+* As a structured path: a table with 'parent', 'stem', and 'extension' (and
+* 'prefix' on Windows) columns. This format is produced by the 'path parse'
+  subcommand.
+* As an inner list of path parts, e.g., '[[ / home viking spam.txt ]]'.
+  Splitting into parts is done by the `path split` command.
+
+All subcommands accept all three variants as an input. Furthermore, the 'path
+join' subcommand can be used to join the structured path or path parts back into
+the path literal.
+```

--- a/book/commands/path_basename.md
+++ b/book/commands/path_basename.md
@@ -23,15 +23,20 @@ usage: |
 
 Get basename of a path
 ```shell
-> '/home/joe/test.txt' | path basename
+> 'C:\Users\joe\test.txt' | path basename
 ```
 
-Get basename of a path by column
+Get basename of a path in a column
 ```shell
-> [[name];[/home/joe]] | path basename -c [ name ]
+> ls .. | path basename -c [ name ]
+```
+
+Get basename of a path in a column
+```shell
+> [[name];[C:\Users\Joe]] | path basename -c [ name ]
 ```
 
 Replace basename of a path
 ```shell
-> '/home/joe/test.txt' | path basename -r 'spam.png'
+> 'C:\Users\joe\test.txt' | path basename -r 'spam.png'
 ```

--- a/book/commands/path_dirname.md
+++ b/book/commands/path_dirname.md
@@ -24,7 +24,7 @@ usage: |
 
 Get dirname of a path
 ```shell
-> '/home/joe/code/test.txt' | path dirname
+> 'C:\Users\joe\code\test.txt' | path dirname
 ```
 
 Get dirname of a path in a column
@@ -34,10 +34,10 @@ Get dirname of a path in a column
 
 Walk up two levels
 ```shell
-> '/home/joe/code/test.txt' | path dirname -n 2
+> 'C:\Users\joe\code\test.txt' | path dirname -n 2
 ```
 
 Replace the part that would be returned with a custom path
 ```shell
-> '/home/joe/code/test.txt' | path dirname -n 2 -r /home/viking
+> 'C:\Users\joe\code\test.txt' | path dirname -n 2 -r C:\Users\viking
 ```

--- a/book/commands/path_exists.md
+++ b/book/commands/path_exists.md
@@ -22,7 +22,7 @@ usage: |
 
 Check if a file exists
 ```shell
-> '/home/joe/todo.txt' | path exists
+> 'C:\Users\joe\todo.txt' | path exists
 ```
 
 Check if a file exists in a column

--- a/book/commands/path_expand.md
+++ b/book/commands/path_expand.md
@@ -23,7 +23,7 @@ usage: |
 
 Expand an absolute path
 ```shell
-> '/home/joe/foo/../bar' | path expand
+> 'C:\Users\joe\foo\..\bar' | path expand
 ```
 
 Expand a path in a column
@@ -33,5 +33,5 @@ Expand a path in a column
 
 Expand a relative path
 ```shell
-> 'foo/../bar' | path expand
+> 'foo\..\bar' | path expand
 ```

--- a/book/commands/path_join.md
+++ b/book/commands/path_join.md
@@ -23,7 +23,7 @@ usage: |
 
 Append a filename to a path
 ```shell
-> '/home/viking' | path join spam.txt
+> 'C:\Users\viking' | path join spam.txt
 ```
 
 Append a filename to a path inside a column
@@ -33,10 +33,10 @@ Append a filename to a path inside a column
 
 Join a list of parts into a path
 ```shell
-> [ '/' 'home' 'viking' 'spam.txt' ] | path join
+> [ 'C:' '\' 'Users' 'viking' 'spam.txt' ] | path join
 ```
 
 Join a structured path into a path
 ```shell
-> [[ parent stem extension ]; [ '/home/viking' 'spam' 'txt' ]] | path join
+> [ [parent stem extension]; ['C:\Users\viking' 'spam' 'txt']] | path join
 ```

--- a/book/commands/path_join.md
+++ b/book/commands/path_join.md
@@ -19,6 +19,11 @@ usage: |
  -  `append`: Path to append to the input
  -  `--columns {table}`: Optionally operate by column path
 
+## Notes
+```text
+Optionally, append an additional path to the result. It is designed to accept
+the output of 'path parse' and 'path split' subcommands.
+```
 ## Examples
 
 Append a filename to a path

--- a/book/commands/path_parse.md
+++ b/book/commands/path_parse.md
@@ -21,19 +21,19 @@ usage: |
 
 ## Examples
 
-Parse a path
+Parse a single path
 ```shell
-> '/home/viking/spam.txt' | path parse
+> 'C:\Users\viking\spam.txt' | path parse
 ```
 
 Replace a complex extension
 ```shell
-> '/home/viking/spam.tar.gz' | path parse -e tar.gz | upsert extension { 'txt' }
+> 'C:\Users\viking\spam.tar.gz' | path parse -e tar.gz | upsert extension { 'txt' }
 ```
 
 Ignore the extension
 ```shell
-> '/etc/conf.d' | path parse -e ''
+> 'C:\Users\viking.d' | path parse -e ''
 ```
 
 Parse all paths under the 'name' column

--- a/book/commands/path_parse.md
+++ b/book/commands/path_parse.md
@@ -19,6 +19,11 @@ usage: |
  -  `--columns {table}`: Optionally operate by column path
  -  `--extension {string}`: Manually supply the extension (without the dot)
 
+## Notes
+```text
+Each path is split into a table with 'parent', 'stem' and 'extension' fields.
+On Windows, an extra 'prefix' column is added.
+```
 ## Examples
 
 Parse a single path

--- a/book/commands/path_relative-to.md
+++ b/book/commands/path_relative-to.md
@@ -19,6 +19,12 @@ usage: |
  -  `path`: Parent shared with the input path
  -  `--columns {table}`: Optionally operate by column path
 
+## Notes
+```text
+Can be used only when the input and the argument paths are either both
+absolute or both relative. The argument path needs to be a parent of the input
+path.
+```
 ## Examples
 
 Find a relative path from two absolute paths

--- a/book/commands/path_relative-to.md
+++ b/book/commands/path_relative-to.md
@@ -23,7 +23,7 @@ usage: |
 
 Find a relative path from two absolute paths
 ```shell
-> '/home/viking' | path relative-to '/home'
+> 'C:\Users\viking' | path relative-to 'C:\Users'
 ```
 
 Find a relative path from two absolute paths in a column
@@ -33,5 +33,5 @@ Find a relative path from two absolute paths in a column
 
 Find a relative path from two relative paths
 ```shell
-> 'eggs/bacon/sausage/spam' | path relative-to 'eggs/bacon/sausage'
+> 'eggs\bacon\sausage\spam' | path relative-to 'eggs\bacon\sausage'
 ```

--- a/book/commands/path_split.md
+++ b/book/commands/path_split.md
@@ -22,7 +22,7 @@ usage: |
 
 Split a path into parts
 ```shell
-> '/home/viking/spam.txt' | path split
+> 'C:\Users\viking\spam.txt' | path split
 ```
 
 Split all paths under the 'name' column

--- a/book/commands/post.md
+++ b/book/commands/post.md
@@ -26,6 +26,10 @@ usage: |
  -  `--raw`: return values as a string instead of a table
  -  `--insecure`: allow insecure server connections when using SSL
 
+## Notes
+```text
+Performs HTTP POST operation.
+```
 ## Examples
 
 Post content to url.com

--- a/book/commands/register.md
+++ b/book/commands/register.md
@@ -21,6 +21,11 @@ usage: |
  -  `--encoding {string}`: Encoding used to communicate with plugin. Options: [capnp, json]
  -  `--shell {path}`: path of shell used to run plugin (cmd, sh, python, etc)
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Register `nu_plugin_query` plugin from ~/.cargo/bin/ dir

--- a/book/commands/seq_date.md
+++ b/book/commands/seq_date.md
@@ -3,7 +3,7 @@ title: seq date
 layout: command
 version: 0.60.1
 usage: |
-  print sequences of dates
+  Print sequences of dates
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/source.md
+++ b/book/commands/source.md
@@ -18,6 +18,11 @@ usage: |
 
  -  `filename`: the filepath to the script file to source
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Runs foo.nu in the current context

--- a/book/commands/split_chars.md
+++ b/book/commands/split_chars.md
@@ -3,7 +3,7 @@ title: split chars
 layout: command
 version: 0.60.1
 usage: |
-  splits a string's characters into separate rows
+  Split a string's characters into separate rows
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/split_column.md
+++ b/book/commands/split_column.md
@@ -3,7 +3,7 @@ title: split column
 layout: command
 version: 0.60.1
 usage: |
-  splits contents across multiple columns via the separator.
+  Split a string into multiple columns using a separator
 ---
 
 # `{{ $frontmatter.title }}`
@@ -16,7 +16,7 @@ usage: |
 
 ## Parameters
 
- -  `separator`: the character that denotes what separates columns
+ -  `separator`: the character or string that denotes what separates columns
  -  `...rest`: column names to give the new columns
  -  `--collapse-empty`: remove empty columns
 

--- a/book/commands/split_row.md
+++ b/book/commands/split_row.md
@@ -3,7 +3,7 @@ title: split row
 layout: command
 version: 0.60.1
 usage: |
-  splits contents over multiple rows via the separator.
+  Split a string into multiple rows using a separator
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_camel-case.md
+++ b/book/commands/str_camel-case.md
@@ -3,7 +3,7 @@ title: str camel-case
 layout: command
 version: 0.60.1
 usage: |
-  converts a string to camelCase
+  Convert a string to camelCase
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_capitalize.md
+++ b/book/commands/str_capitalize.md
@@ -3,7 +3,7 @@ title: str capitalize
 layout: command
 version: 0.60.1
 usage: |
-  capitalizes text
+  Capitalize text
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_collect.md
+++ b/book/commands/str_collect.md
@@ -3,7 +3,7 @@ title: str collect
 layout: command
 version: 0.60.1
 usage: |
-  creates a string from the input, optionally using a separator
+  Concatenate multiple strings into a single string, with an optional separator between each
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_downcase.md
+++ b/book/commands/str_downcase.md
@@ -3,7 +3,7 @@ title: str downcase
 layout: command
 version: 0.60.1
 usage: |
-  downcases text
+  Make text lowercase
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_ends-with.md
+++ b/book/commands/str_ends-with.md
@@ -3,7 +3,7 @@ title: str ends-with
 layout: command
 version: 0.60.1
 usage: |
-  checks if string ends with pattern
+  Check if a string ends with a pattern
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_kebab-case.md
+++ b/book/commands/str_kebab-case.md
@@ -3,7 +3,7 @@ title: str kebab-case
 layout: command
 version: 0.60.1
 usage: |
-  converts a string to kebab-case
+  Convert a string to kebab-case
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_length.md
+++ b/book/commands/str_length.md
@@ -3,7 +3,7 @@ title: str length
 layout: command
 version: 0.60.1
 usage: |
-  outputs the lengths of the strings in the pipeline
+  Output the length of any strings in the pipeline
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_lpad.md
+++ b/book/commands/str_lpad.md
@@ -3,7 +3,7 @@ title: str lpad
 layout: command
 version: 0.60.1
 usage: |
-  pad a string with a character a certain length
+  Left-pad a string to a specific length
 ---
 
 # `{{ $frontmatter.title }}`
@@ -22,12 +22,12 @@ usage: |
 
 ## Examples
 
-Left pad a string with a character a number of places
+Left-pad a string with asterisks until it's 10 characters wide
 ```shell
 > 'nushell' | str lpad -l 10 -c '*'
 ```
 
-Left pad a string with a character a number of places
+Left-pad a string with zeroes until it's 10 character wide
 ```shell
 > '123' | str lpad -l 10 -c '0'
 ```

--- a/book/commands/str_pascal-case.md
+++ b/book/commands/str_pascal-case.md
@@ -3,7 +3,7 @@ title: str pascal-case
 layout: command
 version: 0.60.1
 usage: |
-  converts a string to PascalCase
+  Convert a string to PascalCase
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_replace.md
+++ b/book/commands/str_replace.md
@@ -3,7 +3,7 @@ title: str replace
 layout: command
 version: 0.60.1
 usage: |
-  finds and replaces text
+  Find and replace text
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_reverse.md
+++ b/book/commands/str_reverse.md
@@ -3,7 +3,7 @@ title: str reverse
 layout: command
 version: 0.60.1
 usage: |
-  outputs the reversals of the strings in the pipeline
+  Reverse every string in the pipeline
 ---
 
 # `{{ $frontmatter.title }}`
@@ -20,7 +20,12 @@ usage: |
 
 ## Examples
 
-Return the reversals of multiple strings
+Reverse a single string
 ```shell
 > 'Nushell' | str reverse
+```
+
+Reverse multiple strings in a list
+```shell
+> ['Nushell' 'is' 'cool'] | str reverse
 ```

--- a/book/commands/str_rpad.md
+++ b/book/commands/str_rpad.md
@@ -3,7 +3,7 @@ title: str rpad
 layout: command
 version: 0.60.1
 usage: |
-  pad a string with a character a certain length
+  Right-pad a string to a specific length
 ---
 
 # `{{ $frontmatter.title }}`
@@ -22,12 +22,12 @@ usage: |
 
 ## Examples
 
-Right pad a string with a character a number of places
+Right-pad a string with asterisks until it's 10 characters wide
 ```shell
 > 'nushell' | str rpad -l 10 -c '*'
 ```
 
-Right pad a string with a character a number of places
+Right-pad a string with zeroes until it's 10 characters wide
 ```shell
 > '123' | str rpad -l 10 -c '0'
 ```

--- a/book/commands/str_screaming-snake-case.md
+++ b/book/commands/str_screaming-snake-case.md
@@ -3,7 +3,7 @@ title: str screaming-snake-case
 layout: command
 version: 0.60.1
 usage: |
-  converts a string to SCREAMING_SNAKE_CASE
+  Convert a string to SCREAMING_SNAKE_CASE
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_snake-case.md
+++ b/book/commands/str_snake-case.md
@@ -3,7 +3,7 @@ title: str snake-case
 layout: command
 version: 0.60.1
 usage: |
-  converts a string to snake_case
+  Convert a string to snake_case
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_starts-with.md
+++ b/book/commands/str_starts-with.md
@@ -3,7 +3,7 @@ title: str starts-with
 layout: command
 version: 0.60.1
 usage: |
-  checks if string starts with pattern
+  Check if string starts with a pattern
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_substring.md
+++ b/book/commands/str_substring.md
@@ -3,7 +3,7 @@ title: str substring
 layout: command
 version: 0.60.1
 usage: |
-  substrings text
+  Get part of a string
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_trim.md
+++ b/book/commands/str_trim.md
@@ -3,7 +3,7 @@ title: str trim
 layout: command
 version: 0.60.1
 usage: |
-  trims text
+  Trim whitespace or specific character
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/str_upcase.md
+++ b/book/commands/str_upcase.md
@@ -3,7 +3,7 @@ title: str upcase
 layout: command
 version: 0.60.1
 usage: |
-  upcases text
+  Make text uppercase
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/url_host.md
+++ b/book/commands/url_host.md
@@ -3,7 +3,7 @@ title: url host
 layout: command
 version: 0.60.1
 usage: |
-  gets the host of a url
+  Get the host of a URL
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/url_path.md
+++ b/book/commands/url_path.md
@@ -3,7 +3,7 @@ title: url path
 layout: command
 version: 0.60.1
 usage: |
-  gets the path of a url
+  Get the path of a URL
 ---
 
 # `{{ $frontmatter.title }}`

--- a/book/commands/url_query.md
+++ b/book/commands/url_query.md
@@ -3,7 +3,7 @@ title: url query
 layout: command
 version: 0.60.1
 usage: |
-  gets the query of a url
+  Get the query string of a URL
 ---
 
 # `{{ $frontmatter.title }}`
@@ -20,12 +20,12 @@ usage: |
 
 ## Examples
 
-Get query of a url
+Get a query string
 ```shell
 > echo 'http://www.example.com/?foo=bar&baz=quux' | url query
 ```
 
-No query gives the empty string
+Returns an empty string if there is no query string
 ```shell
 > echo 'http://www.example.com/' | url query
 ```

--- a/book/commands/url_scheme.md
+++ b/book/commands/url_scheme.md
@@ -3,7 +3,7 @@ title: url scheme
 layout: command
 version: 0.60.1
 usage: |
-  gets the scheme (eg http, file) of a url
+  Get the scheme (e.g. http, file) of a URL
 ---
 
 # `{{ $frontmatter.title }}`
@@ -20,7 +20,7 @@ usage: |
 
 ## Examples
 
-Get scheme of a url
+Get the scheme of a URL
 ```shell
 > echo 'http://www.example.com' | url scheme
 ```

--- a/book/commands/use.md
+++ b/book/commands/use.md
@@ -18,6 +18,11 @@ usage: |
 
  -  `pattern`: import pattern
 
+## Notes
+```text
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+```
 ## Examples
 
 Define a custom command in a module and call it

--- a/book/make_docs.nu
+++ b/book/make_docs.nu
@@ -57,6 +57,18 @@ usage: |
         ""
     }
 
+    let extra_usage = if $command.extra_usage == "" { "" } else {
+        # It's a little ugly to encode the extra usage in a code block,
+        # but otherwise Vuepress's Markdown engine makes everything go haywire
+        # (the `ansi` command is a good example).
+        # TODO: find a better way to display plain text with minimal formatting
+        $"## Notes
+```text
+($command.extra_usage)
+```
+"
+    }
+
     let examples = if ($command.examples | length) > 0 {
         let example_top = $"## Examples(char nl)(char nl)"
 
@@ -73,7 +85,7 @@ $"($example.description)
     } else { "" }
 
     let doc = (
-            ($top + $signature + $parameters + $examples) |
+            ($top + $signature + $parameters + $extra_usage + $examples ) |
             lines |
             each {|it| ($it | str trim -r) } |
             str collect (char nl)


### PR DESCRIPTION
The command pages on the website were missing detailed usage info from `extra_usage`. Fixed.

I tried really hard to format the extra usage nicely, but eventually gave up and shoved it all in a Markdown code block. There were too many edge cases where the Vuepress Markdown formatter would go haywire, and a lot of the `extra_usage` info is formatted specifically for a monospace font. Can revisit this later, but for now I just want to get the info on the website.

<img width="456" alt="image" src="https://user-images.githubusercontent.com/26268125/162533921-dd2269aa-a47e-499b-a597-7c89c15ec6e4.png">
