### PR TITLE
Typo fix in 2022-04-12-nushell_0_61.md

### DIFF
--- a/blog/2022-04-12-nushell_0_61.md
+++ b/blog/2022-04-12-nushell_0_61.md
@@ -70,7 +70,7 @@ Just as we added 'config.nu' with 0.60, we're now adding a new additional startu
 * [`each` now also pipes each item as input to the block](https://github.com/nushell/nushell/pull/5136) (jt)
 * Add ability to [opt-in to normal strings in `str replace`](https://github.com/nushell/nushell/pull/5133) (fdncred)
 * `touch` now [includes all common flags](https://github.com/nushell/nushell/pull/5119) (rybertm)
-* `=~` and `=!` now [use regex](https://github.com/nushell/nushell/pull/5117) (rgwood)
+* `=~` and `!~` now [use regex](https://github.com/nushell/nushell/pull/5117) (rgwood)
 * `describe` should now be [more precise](https://github.com/nushell/nushell/pull/5116)
 * completions now [give priority to non-hidden folders](https://github.com/nushell/nushell/pull/5108) (herlon214)
 * [plugins are now loaded for scripts and commands](https://github.com/nushell/nushell/pull/5105) (jt)


### PR DESCRIPTION
Just a tiny typo in the regex operator things `=~` and `!~`