### PR TITLE
Fix command-less `cd` example

### DIFF
--- a/snippets/moving_around/cd_without_command_example.sh
+++ b/snippets/moving_around/cd_without_command_example.sh
@@ -1,1 +1,1 @@
-> new_directory
+> ./new_directory


### PR DESCRIPTION
The book still shows `cd`-ing without the command as `> dir_name` where it should be `> ./dir_name`