### PR TITLE
Update loading_data.md

### DIFF
--- a/book/loading_data.md
+++ b/book/loading_data.md
@@ -200,8 +200,8 @@ license = "MIT"
 In addition to loading files from your filesystem, you can also load URLs by using the [`fetch`](commands/fetch.md) command. This will fetch the contents of the URL from the internet and return it:
 
 ```
-> fetch https://www.jonathanturner.org/feed.xml
-─────┬───────────────────────────
- rss │ [row attributes children]
-─────┴───────────────────────────
+> fetch https://blog.rust-lang.org/feed.xml
+──────┬───────────────────
+ feed │ {record 2 fields}
+──────┴───────────────────
 ```


### PR DESCRIPTION
Fetch example changed to `fetch https://blog.rust-lang.org/feed.xml` (https://www.jonathanturner.org/feed.xml is not working).