### PR TITLE
Correct dependencies for building on debian / unbutu based systems

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -50,9 +50,9 @@ If you'd rather not install Rust via `rustup`, you can also install it via other
 
 #### Debian/Ubuntu
 
-You will need to install the "pkg-config" and "libssl-dev" package:
+You will need to install the "gcc-multilib", "pkg-config" and "libssl-dev" packages:
 
-<<< @/snippets/installation/install_pkg_config_libssl_dev.sh
+<<< @/snippets/installation/install_gcc_multilib_pkg_config_libssl_dev.sh
 
 Linux users who wish to use the `rawkey` or `clipboard` optional features will need to install the "libx11-dev" and "libxcb-composite0-dev" packages:
 

--- a/snippets/installation/install_gcc_multilib_pkg_config_libssl_dev.sh
+++ b/snippets/installation/install_gcc_multilib_pkg_config_libssl_dev.sh
@@ -1,0 +1,1 @@
+apt install gcc-multilib pkg-config libssl-dev 

--- a/snippets/installation/install_pkg_config_libssl_dev.sh
+++ b/snippets/installation/install_pkg_config_libssl_dev.sh
@@ -1,1 +1,0 @@
-apt install pkg-config libssl-dev


### PR DESCRIPTION
Add the dependency gcc-multilib to instructions and snippets for
debian / ubuntu based system.

Discovered and fixed/tested on Linux Mint 20.3 Cinnamon