### PR TITLE
Changed the confusing title of "Working With Strings"

### DIFF
--- a/book/loading_data.md
+++ b/book/loading_data.md
@@ -64,7 +64,7 @@ We're shown the contents of the file. If the file is too large, we get a handy s
 
 Below the surface, what Nu sees in these text files is one large string. Next, we'll talk about how to work with these strings to get the data we need out of them.
 
-## Working with strings
+## Handling Strings
 
 An important part of working with data coming from outside Nu is that it's not always in a format that Nu understands. Often this data is given to us as a string.
 

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -67,7 +67,7 @@ The above is the same as if we had written:
 > echo "hello"
 ```
 
-Also see [Working with Strings](https://www.nushell.sh/book/loading_data.html#working-with-strings).
+Also see [Handling Strings](https://www.nushell.sh/book/loading_data.html#handling-strings).
 
 ## Lines
 


### PR DESCRIPTION
As per issue #405, there are two pages of the title "Working With Strings". I have changed the first to "Handling Strings" in accordance with the suggestions in the issue and changed the relevant links too.