### PR TITLE
Fix broken nu_scripts repo link

### DIFF
--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -380,7 +380,7 @@ If you don't like the default `PROMPT_INDICATOR` you could change it like this.
 > let-env PROMPT_INDICATOR = "> "
 ```
 
-Coloring of the prompt is controlled by the `block` in `PROMPT_COMMAND` where you can write your own custom prompt. We've written a slightly fancy one that has git statuses located in the [nu_scripts repo](https://github.com/nushell/nu_scripts/blob/main/engine-q/prompt/oh-my.nu).
+Coloring of the prompt is controlled by the `block` in `PROMPT_COMMAND` where you can write your own custom prompt. We've written a slightly fancy one that has git statuses located in the [nu_scripts repo](https://github.com/nushell/nu_scripts/blob/main/prompt/oh-my.nu).
 
 ## `LS_COLORS` colors for the `ls` command
 


### PR DESCRIPTION
I was reading the [documentation on prompt configuration](https://www.nushell.sh/book/coloring_and_theming.html#prompt-configuration-and-coloring) and noticed this link didn't _quite_ go to the right place. I think this change will fix that.