### PR TITLE
book/nushell_map_functional.md: add mapM as Haskell equiv. of each

### DIFF
--- a/book/nushell_map_functional.md
+++ b/book/nushell_map_functional.md
@@ -25,7 +25,7 @@ Note: this table assumes Nu 0.43 or later.
 | default                   |                              |                                 |                          |     |
 | drop                      |                              |                                 |                          |     |
 | du                        |                              |                                 |                          |     |
-| each                      | map, mapv, iterate           | map, forEach                    | map                      |     |
+| each                      | map, mapv, iterate           | map, forEach                    | map, mapM                |     |
 | echo                      | println                      |                                 | putStrLn, print          |     |
 | enter                     |                              |                                 |                          |     |
 | exit                      | System/exit                  |                                 |                          |     |


### PR DESCRIPTION
since `each` can do IO, it’s honestly closer to Haskell’s `mapM`