### PR TITLE
Add doc fo loginshell file #4620

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-18.04
     if: ${{ github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        ref: main
+        fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v2-beta

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     if: ${{ github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v3
-        ref: main
-        fetch-depth: 0
+      - uses: actions/checkout@v2
 
       - name: Setup Node
         uses: actions/setup-node@v2-beta

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -83,6 +83,14 @@ Next, on some distros you'll also need to ensure Nu is in the /etc/shells list:
 
 With this, you should be able to `chsh` and set Nu to be your login shell. After a logout, on your next login you should be greeted with a shiny Nu prompt.
 
+### Configuration with `login.nu`
+
+If Nushell is used as a loginshell, you can use a specific configuration file which is only sourced in this case. Therefore a file with name `login.nu` has to be in the standard configuration directory.
+
+The file `login.nu` is sourced after `env.nu` and `config.nu`, so that you can overwrite those configurations if you need.
+
+There is an enviroment variable `$nu.loginshell-path` containing the path to this file.
+
 ### macOS: Keeping `/usr/bin/open` as `open`
 
 Some tools (e.g. Emacs) rely on an `open` command to open files on Mac.

--- a/de/book/konfiguration.md
+++ b/de/book/konfiguration.md
@@ -66,6 +66,14 @@ Als nächstes, muss auf manchen Distributionen sichergestellt werden, dass Nu in
 
 Damit sollte es möglich sein, Nu als Login-Shell mit `chsh` festzulegen. Nach dem Ausloggen und erneutem Einloggen sollte Nu als Shell grüßen.
 
+### Konfiguration mittels `login.nu`
+
+Wenn Nushell als Login-Shell benutzt wird, kann eine spezifische Konfigurationsdatei angelegt werden, die nur in diesem Fall ausgelesen wird. Hierfür muss eine Datei namens `login.nu` im Standard-Konfigurationsverzeichnis abgelegt sein.
+
+Die Datei `login.nu` wird nach `env.nu` und `config.nu` eingelesen, so dass diese Konfigurationen überschrieben werden können.
+
+Der Pfad zu dieser Konfigurationsdatei steht in `$nu.loginshell-path`.
+
 ### macOS: `/usr/bin/open` als `open` behalten
 
 Manche Tools (z.B. Emacs) vertrauen darauf, dass `open` Dateien auf dem Mac öffnet.


### PR DESCRIPTION
Added a section in the documentation for the new config file login.nu (see issue [#4620](https://github.com/nushell/nushell/issues/4620) and PR [#5714](https://github.com/nushell/nushell/pull/5714))