### PR TITLE
Remove MS CRT info now that we're statically linking it

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ $ brew install nushell
 $ winget install nushell
 ```
 
-Windows users may also need to install the latest [Microsoft Visual C++ Redistributable](https://docs.microsoft.com/cpp/windows/latest-supported-vc-redist).
-
 ## Community
 
 Join us [on Discord](https://discord.gg/NtAbbGn) if you have any questions about Nu!

--- a/de/README.md
+++ b/de/README.md
@@ -44,8 +44,6 @@ $ brew install nushell
 $ winget install nushell
 ```
 
-Windowsnutzer müssen unter Umständen die aktuellen [Microsoft Visual C++ Redistributables](https://docs.microsoft.com/cpp/windows/latest-supported-vc-redist) installieren.
-
 ## Community
 
 Wenn es irgendwelche Fragen gibt, am besten unserem (englischsprachigen) [Discord Server](https://discord.gg/NtAbbGn) beitreten. Dort gibt es sehr viele Menschen die gerne weiterhelfen ganz egal ob man neu zu Nu ist oder nicht.

--- a/ja/README.md
+++ b/ja/README.md
@@ -44,8 +44,6 @@ $ brew install nushell
 $ winget install nushell
 ```
 
-また、Windows ユーザーの方は、最新の[Microsoft Visual C++ Redistributable](https://docs.microsoft.com/cpp/windows/latest-supported-vc-redist)のインストールが必要になる場合があります。
-
 ## Nu を Github Actions で利用する
 
 Github Actions で `Nushell` を使うこともできます。 [`setup-nu`](https://github.com/marketplace/actions/setup-nu) が用意されているので、それを使ってください。

--- a/zh-CN/README.md
+++ b/zh-CN/README.md
@@ -44,8 +44,6 @@ $ brew install nushell
 $ winget install nushell
 ```
 
-Windows 用户可能需要安装最新的 [Microsoft Visual C++ Redistributable](https://docs.microsoft.com/cpp/windows/latest-supported-vc-redist)。
-
 ## 社区
 
 如果你有任何问题可以在 [Dicord](https://discord.gg/NtAbbGn) 上找到我们。


### PR DESCRIPTION
Users no longer need to install the C runtime on Windows: https://github.com/nushell/nushell/pull/5717

P.S. I love that "Windows user" is "Windowsnutzer" in German