### PR TITLE
Syntax highlighting as `console`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Nushell is available as [downloadable binaries](https://github.com/nushell/nushe
 
 #### macOS / Linux:
 
-```sh
+```console
 $ brew install nushell
 ```
 
 #### Windows:
 
-```powershell
+```console
 $ winget install nushell
 ```
 


### PR DESCRIPTION
The code blocks are shell sessions and not shell scripts which is why the highlighted oddly (`install` a different color)

---

Out of scope project suggestions:

* Support a mirror on an open source Git forge
* Support an open source communication alternatives like IRC or Matrix