### PR TITLE
Fix outdated `$false` value

### DIFF
--- a/cookbook/help.md
+++ b/cookbook/help.md
@@ -9,7 +9,7 @@ A good way to become familiar with all that nu has to offer is by utilizing the 
 ### How to see all supported commands:
 
 ```shell
-> help commands | where is_custom == $false | first 10 | drop column
+> help commands | where is_custom == false | first 10 | drop column
 ```
 
 Output


### PR DESCRIPTION
`false` and `true` are builtin values since 0.60.0 version. Therefore a dollar sign is redundant.