### PR TITLE
Remove entry for `count`

### DIFF
--- a/book/nushell_map.md
+++ b/book/nushell_map.md
@@ -17,7 +17,6 @@ Note: this table assumes Nu 0.43 or later.
 | clear                  |   -                           |   -                                                  | Clear-Host                                 | clear                                           |
 | compact                |                               |                                                      |                                            |                                                 |
 | config                 |   -                           |   -                                                  | $Profile                                   | vi .bashrc, .profile                            |
-| count                  | count                         | Count                                                | Measure-Object, measure                    | wc                                              |
 | cp                     |   -                           |   -                                                  | Copy-Item, cp, copy                        | cp                                              |
 | date                   | NOW() / getdate()             | DateTime class                                       | Get-Date                                   | date                                            |
 | debug                  |                               |                                                      |                                            |                                                 |


### PR DESCRIPTION
it would show up first when people search for `wc` on the page, but it's no longer a command. `size` is the more useful alternative.