### PR TITLE
Explain how to launch Nu after installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ $ brew install nushell
 $ winget install nushell
 ```
 
+After installing, launch Nu by typing `nu`.
+
 ## Community
 
 Join us [on Discord](https://discord.gg/NtAbbGn) if you have any questions about Nu!

--- a/book/installation.md
+++ b/book/installation.md
@@ -20,6 +20,8 @@ For Windows:
 - [Chocolatey](https://chocolatey.org/) (`choco install nushell`)
 - [Scoop](https://scoop.sh/) (`scoop install nu`)
 
+The main Nushell binary is named `nu` (or `nu.exe` on Windows). After installation, you can launch it by typing `nu`.
+
 ## Build from source
 
 You can also build Nu from source. First, you will need to set up the Rust toolchain and its dependencies.


### PR DESCRIPTION
I recently talked to someone who wasn't sure how to open Nu after installing it from Homebrew. And fair enough, it's not obvious that you launch it as `nu` when many package managers identify it as `nushell`!

This PR just explains how to launch Nu by typing `nu`.