### PR TITLE
FIX: update the links to the default config files

### DIFF
--- a/book/environment.md
+++ b/book/environment.md
@@ -145,7 +145,7 @@ BAR
 ## Environment variable conversions
 
 You can set the `ENV_CONVERSIONS` environment variable to convert other environment variables between a string and a value.
-For example, the [default environment config](https://github.com/nushell/nushell/blob/main/docs/sample_config/default_env.nu) includes conversion of PATH (and Path used on Windows) environment variables from a string to a list.
+For example, the [default environment config](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_env.nu) includes conversion of PATH (and Path used on Windows) environment variables from a string to a list.
 After both `env.nu` and `config.nu` are loaded, any existing environment variable specified inside `ENV_CONVERSIONS` will be translated according to its `from_string` field into a value of any type.
 External tools require environment variables to be strings, therefore, any non-string environment variable needs to be converted first.
 The conversion of value -> string is set by the `to_string` field of `ENV_CONVERSIONS` and is done every time an external command is run.

--- a/book/loading_data.md
+++ b/book/loading_data.md
@@ -69,7 +69,7 @@ Below the surface, what Nu sees in these text files is one large string. Next, w
 
 Nushell Object Notation (NUON) aims to be for Nushell what JavaScript Object Notation (JSON) is for JavaScript.
 That is, NUON code is a valid Nushell code that describes some data structure.
-For example, this is a valid NUON (example from the [default configuration file](https://github.com/nushell/nushell/blob/main/docs/sample_config/default_config.nu)):
+For example, this is a valid NUON (example from the [default configuration file](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_config.nu)):
 
 ```
 {

--- a/de/book/environment.md
+++ b/de/book/environment.md
@@ -140,7 +140,7 @@ BAR
 ## Umgebungsvariablen konvertieren
 
 Mit `ENV_CONVERSIONS` kann eine Umgebungsvariable von einem string zu einem Wert konvertiert werden.
-Zum Beispiel beinhaltet die [default environment config](https://github.com/nushell/nushell/blob/main/docs/sample_config/default_env.nu)
+Zum Beispiel beinhaltet die [default environment config](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_env.nu)
 bereits eine Konvertierung der PATH Umgebungsvariablen (sowie der Path Variablen in Windows) von einem String in eine List.
 
 Nachdem beide `env.nu` und `config.nu` geladen wurden, wird jede existierende Umgebungsvariable, die mit `ENV_CONVERSIONS` definiert ist,

--- a/de/book/konfiguration.md
+++ b/de/book/konfiguration.md
@@ -4,7 +4,7 @@
 
 Nushell nutzt ein Konfigurationssystem, das ein Nushell-Skript beim Start ausführt. Die Konfigurationsdatei wird für Nushell `config.nu` genannt. Der Pfad zu dieser Konfigurationsdatei kann durch den Aufruf von `echo $nu.config-path` herausgefunden werden. Es handelt sich dabei um eine Datei, die abgearbeitet wird und in jedem Schritt Definitionen, Umgebungsvariablen und mehr zum globalen Namespace hinzufügt.
 
-Ein Beispiel für eine Nushell `config.nu` kann [hier](https://github.com/nushell/nushell/blob/main/src/default_config.nu) in unserem Repository gefunden werden.
+Ein Beispiel für eine Nushell `config.nu` kann [hier](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_config.nu) in unserem Repository gefunden werden.
 
 ### `$config` konfigurieren
 

--- a/zh-CN/book/configuration.md
+++ b/zh-CN/book/configuration.md
@@ -10,7 +10,7 @@ Nushell 使用一个配置系统，在启动时加载并运行两个 Nushell 脚
 
 _(你可以把 Nushell 的配置加载顺序想象成在启动时执行两行 [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)：`source /path/to/env.nu`和`source /path/to/config.nu`。因此，用`env.nu`表示环境，用`config.nu`表示其他配置只是一个约定。)_
 
-当你在没有设置这些文件的情况下启动 Nushell，Nushell 会提示你下载[`default env.nu`](https://github.com/nushell/nushell/blob/main/docs/sample_config/default_env.nu)和[`default config.nu`](https://github.com/nushell/nushell/blob/main/docs/sample_config/default_config.nu)。
+当你在没有设置这些文件的情况下启动 Nushell，Nushell 会提示你下载[`default env.nu`](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_env.nu)和[`default config.nu`](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_config.nu)。
 你可以通过浏览这些默认文件，了解环境变量的默认值和所有可配置项的列表。
 
 ### 配置 `$env.config`

--- a/zh-CN/book/environment.md
+++ b/zh-CN/book/environment.md
@@ -145,7 +145,7 @@ BAR
 ## 环境变量转换
 
 你可以通过设置`ENV_CONVERSIONS`环境变量，来在字符串和值之间转换其他环境变量。
-例如，[默认环境配置](https://github.com/nushell/nushell/blob/main/docs/sample_config/default_env.nu)包括将`PATH`（和 Windows 上使用的`Path`）环境变量从一个字符串转换为一个列表。
+例如，[默认环境配置](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_env.nu)包括将`PATH`（和 Windows 上使用的`Path`）环境变量从一个字符串转换为一个列表。
 在 `env.nu` 和 `config.nu` 配置文件加载后，任何在`ENV_CONVERSIONS`内指定的现有环境变量将根据其`from_string`字段被转换为任何类型的值。
 外部工具要求环境变量是字符串，因此，任何非字符串的环境变量需要先进行转换：
 值->字符串的转换由`ENV_CONVERSIONS`的`to_string`字段设置，每次运行外部命令时都会进行转换。


### PR DESCRIPTION
In this PR, I have replaced all occurences of some old and broken links to the default config files.

These files are now [default_config.nu](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_config.nu) and [default_env.nu](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_env.nu) and the book did not link to these new locations on some pages :confused: 

I've run global pattern searches to make sure:
  - I have caught all the bad URLs mentioning one of the two config files in [nushell/nushell.github.io](https://github.com/nushell/nushell.github.io)
  - the two files above are correct and the only ones in [nushell/nushell](https://github.com/nushell/nushell)

Hope you'll find that usefull :relieved:
cheers :tada: 