### PR TITLE
Update config.js/cookbook with direnv example

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -203,6 +203,7 @@ module.exports = {
                 'git',
                 'parsing_git_log',
                 'http',
+                'direnv',
                 'misc',
               ],
             },


### PR DESCRIPTION
Didn't read the contributing guide, sorry. This should make the direnv section appear in the sidebar of the cookbook.