### PR TITLE
fix: all clickable items should have the same color

### DIFF
--- a/book/command_reference.md
+++ b/book/command_reference.md
@@ -21,7 +21,7 @@ To see all commands in Nushell, run [`help commands`](commands/help.md).
     <th>Description</th>
   </tr>
   <tr v-for="command in commands">
-   <td><a :href="command.path"><code>{{ command.title }}</code></a></td>
+   <td><a :href="command.path">{{ command.title }}</a></td>
    <td style="white-space: pre-wrap;">{{ command.frontmatter.usage }}</td>
   </tr>
 </table>


### PR DESCRIPTION
Hi.

In the previous state. It is hard to know that the command is clickable.

![image](https://user-images.githubusercontent.com/17734314/184841119-07e8d897-333e-4a75-b167-4f9a647344b0.png)

To tell reader (without thinking) that those commands is clickable, they need to have the same color as other clickable item.

![image](https://user-images.githubusercontent.com/17734314/184841035-f61ee2c2-c93f-4d47-a941-918efc01131d.png)
