### PR TITLE
FIX: `overlay remove` flags

### DIFF
--- a/book/overlays.md
+++ b/book/overlays.md
@@ -186,13 +186,13 @@ Sometimes, you might want to remove an overlay, but keep all the custom definiti
 
 (spam)> def eggs [] { "eggs" }
 
-(spam)> overlay remove --keep spam
+(spam)> overlay remove --keep-custom spam
 
 (zero)> eggs
 eggs
 ```
 
-The `--keep` flag does exactly that.
+The `--keep-custom` flag does exactly that.
 
 ## Ordering Overlays
 

--- a/book/overlays.md
+++ b/book/overlays.md
@@ -194,6 +194,24 @@ eggs
 
 The `--keep-custom` flag does exactly that.
 
+One can also keep a set of environment variables that were defined inside an overlay, but remove the rest:
+
+```
+(zero)> module spam { export def foo [] { "foo" }; export env FOO {"foo"}}
+
+(zero)> overlay add spam
+
+(spam)> overlay remove spam --keep-env [FOO]
+
+(zero)> foo
+Error: Can't run executable...
+
+(zero)> $env.FOO
+foo
+```
+
+The `--keep-env` flag does exactly that.
+
 ## Ordering Overlays
 
 The overlays are arranged as a stack.

--- a/zh-CN/book/overlays.md
+++ b/zh-CN/book/overlays.md
@@ -154,13 +154,13 @@ _0.64 版本新增：_
 
 (spam)> def eggs [] { "eggs" }
 
-(spam)> overlay remove --keep spam
+(spam)> overlay remove --keep-custom spam
 
 (zero)> eggs
 eggs
 ```
 
-`--keep` 标志正是用来做这个的。
+`--keep-custom` 标志正是用来做这个的。
 
 ## 覆层顺序
 


### PR DESCRIPTION
This PR:
1. changes the mentions to the `--keep` flag of the `overlay remove` command, which does not exist, to `--keep-custom`, which does the same thing
2. adds a small paragraph about the `--keep-env` flag of the `overlay remove` command

NOTES:
- i've changed all mentions to `--keep` using `sed` and `ls **/*`, so there shouldn't be any `--keep` left :ok_hand: 
- i'm not able to write a chinese version of my new paragraph inside `zh-CH/book/overlays.md` :confused: 