### PR TITLE
Create coming_from_cmd.md

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -153,6 +153,7 @@ module.exports = {
               collapsable: false,
               children: [
                 '/book/coming_from_bash.md',
+                '/book/coming_from_cmd.md',
                 '/book/nushell_map.md',
                 '/book/nushell_map_imperative.md',
                 '/book/nushell_map_functional.md',

--- a/book/coming_from_cmd.md
+++ b/book/coming_from_cmd.md
@@ -1,0 +1,57 @@
+# Coming from CMD.EXE
+
+This table was last updated for Nu 0.66.0.
+
+| CMD.EXE                              | Nu                                               | Task                                                              |
+| ------------------------------------ | ------------------------------------------------ | ----------------------------------------------------------------- |
+| `ASSOC`                              |                                                  | Displays or modifies file extension associations                  |
+| `BREAK`                              |                                                  | Trigger debugger breakpoint                                       |
+| `CALL <filename.bat>`                | `<filename.bat>`                                 | Run a batch program                                               |
+|                                      | `nu <filename>`                                  | Run a nu script in a fresh context                                |
+|                                      | `source <filename>`                              | Run a nu script in this context                                   |
+|                                      | `use <filename>`                                 | Run a nu script as a module                                       |
+| `CD` or `CHDIR`                      | `$env.PWD`                                       | Get the present working directory                                 |
+| `CD <directory>`                     | `cd <directory>`                                 | Change the current directory                                      |
+| `CD /D <drive:directory>`            | `cd <drive:directory>`                           | Change the current directory                                      |
+| `CLS`                                | `clear`                                          | Clear the screen                                                  |
+| `COLOR`                              |                                                  | Set the console default foreground/background colors              |
+|                                      | `ansi {flags} (code)`                            | Output ANSI codes to change color                                 |
+| `COPY +<source> <destination>`       | `cp <destination> <source>`                      | Copy files                                                        |
+| `DATE /T`                            | `date now`                                       | Get the current date                                              |
+| `DATE`                               |                                                  | Set the date                                                      |
+| `DEL <file>` or `ERASE <file>`       | `rm <file>`                                      | Delete files                                                      |
+| `DIR`                                | `ls`                                             | List files in the current directory                               |
+| `ECHO <message>`                     | `print <message>`                                | Print the given values to stdout                                  |
+| `ECHO ON`                            |                                                  | Echo executed commands to stdout                                  |
+| `ENDLOCAL`                           | `export env`                                     | Change env in the caller                                          |
+| `EXIT`                               | `exit`                                           | Close the prompt or script                                        |
+| `FOR %<var> IN (<set>) DO <command>` | `for $<var> in <set> { <command> }`              | Run a command for each item in a set                              |
+| `FTYPE`                              |                                                  | Displays or modifies file types used in file extension associations |
+| `GOTO`                               |                                                  | Jump to a label                                                   |
+| `IF ERRORLEVEL <number> <command>`   | `if $env.LAST_EXIT_CODE >= <number> { <command> }` | Run a command if the last command returned an error code >= specified |
+| `IF <string> EQU <string> <command>` | `if <string> == <string> { <command> }`          | Run a command if strings match                                    |
+| `IF EXIST <filename> <command>`      |                                                  | Run a command if the file exists                                  |
+| `IF DEFINED <variable> <command>`    |                                                  | Run a command if the variable is defined                          |
+| `MD` or `MKDIR`                      | `mkdir`                                          | Create directories                                                |
+| `MKLINK`                             |                                                  | Create symbolic links                                             |
+| `MOVE`                               | `mv`                                             | Move files                                                        |
+| `PATH`                               | `$env.Path`                                      | Display the current path variable                                 |
+| `PATH <path>;%PATH%`                 | `let-env Path = ($env.Path | prepend <path>`)    | Edit the path variable                                            |
+| `PATH %PATH%;<path>`                 | `let-env Path = ($env.Path | prepend <path>`)    | Edit the path variable                                            |
+| `PAUSE`                              | `input "Press any key to continue . . ."`        | Pause script execution                                            |
+| `PROMPT <template>`                  | `let-env PROMPT_COMMAND = { <command> }`         | Change the terminal prompt                                        |
+| `PUSHD <path>`/`POPD`                | `enter <path>`/`exit`                            | Change working directory temporarily                              |
+| `REM`                                | `#`                                              | Comments                                                          |
+| `REN` or `RENAME`                    | `mv`                                             | Rename files                                                      |
+| `RD` or `RMDIR`                      | `rm`                                             | Remove directory                                                  |
+| `SET <var>=<string>`                 | `let-env <var> = <string>`                       | Set environment variables                                         |
+| `SETLOCAL`                           | (default behavior)                               | Localize environment changes to a script                          |
+| `START <path>`                       | `explorer <path>`                                | Open a file as if double-clicked in File Explorer                 |
+| `TIME /T`                            | `date now | date format "%H:%M:%S"`              | Get the current time                                              |
+| `TIME`                               |                                                  | Set the current time                                              |
+| `TITLE`                              |                                                  | Set the cmd.exe window name                                       |
+| `TYPE`                               | `open --raw`                                     | Display the contents of a text file                               |
+|                                      | `open`                                           | Open a file as structured data                                    |
+| `VER`                                |                                                  | Display the OS version                                            |
+| `VERIFY`                             |                                                  | Verify that file writes happen                                    |
+| `VOL`                                |                                                  | Show drive information                                            |

--- a/book/coming_from_cmd.md
+++ b/book/coming_from_cmd.md
@@ -36,8 +36,8 @@ This table was last updated for Nu 0.66.0.
 | `MKLINK`                             |                                                  | Create symbolic links                                             |
 | `MOVE`                               | `mv`                                             | Move files                                                        |
 | `PATH`                               | `$env.Path`                                      | Display the current path variable                                 |
-| `PATH <path>;%PATH%`                 | `let-env Path = ($env.Path | prepend <path>`)    | Edit the path variable                                            |
-| `PATH %PATH%;<path>`                 | `let-env Path = ($env.Path | prepend <path>`)    | Edit the path variable                                            |
+| `PATH <path>;%PATH%`                 | `let-env Path = ($env.Path \| prepend <path>`)   | Edit the path variable                                            |
+| `PATH %PATH%;<path>`                 | `let-env Path = ($env.Path \| prepend <path>`)   | Edit the path variable                                            |
 | `PAUSE`                              | `input "Press any key to continue . . ."`        | Pause script execution                                            |
 | `PROMPT <template>`                  | `let-env PROMPT_COMMAND = { <command> }`         | Change the terminal prompt                                        |
 | `PUSHD <path>`/`POPD`                | `enter <path>`/`exit`                            | Change working directory temporarily                              |
@@ -47,7 +47,7 @@ This table was last updated for Nu 0.66.0.
 | `SET <var>=<string>`                 | `let-env <var> = <string>`                       | Set environment variables                                         |
 | `SETLOCAL`                           | (default behavior)                               | Localize environment changes to a script                          |
 | `START <path>`                       | `explorer <path>`                                | Open a file as if double-clicked in File Explorer                 |
-| `TIME /T`                            | `date now | date format "%H:%M:%S"`              | Get the current time                                              |
+| `TIME /T`                            | `date now \| date format "%H:%M:%S"`             | Get the current time                                              |
 | `TIME`                               |                                                  | Set the current time                                              |
 | `TITLE`                              |                                                  | Set the cmd.exe window name                                       |
 | `TYPE`                               | `open --raw`                                     | Display the contents of a text file                               |


### PR DESCRIPTION
Like coming_from_bash.md, this maps cmd builtins to nu concepts. The main goal is to soften [#6359: CMD.exe internal commands no more recognized and throwing errors/breaking scripts](https://github.com/nushell/nushell/issues/6359), which was caused by no longer falling back to calling cmd.exe (https://github.com/nushell/nushell/pull/6253) when a command is not recognized.