### PR TITLE
deduplicate `**' in operators.md

### DIFF
--- a/book/operators.md
+++ b/book/operators.md
@@ -8,7 +8,6 @@ Nushell supports the following operators for common math, logic, and string oper
 | `-`      | subtract                                                |
 | `*`      | multiply                                                |
 | `/`      | divide                                                  |
-| `**`     | exponentiation (power)                                  |
 | `mod`    | modulo                                                  |
 | `==`     | equal                                                   |
 | `!=`     | not equal                                               |


### PR DESCRIPTION
`**' was listed twice as "exponentiation (power)" and as "pow"