### PR TITLE
Update coming_from_cmd.md for nu 0.77

### DIFF
--- a/book/coming_from_cmd.md
+++ b/book/coming_from_cmd.md
@@ -1,6 +1,6 @@
 # Coming from CMD.EXE
 
-This table was last updated for Nu 0.66.0.
+This table was last updated for Nu 0.67.0.
 
 | CMD.EXE                              | Nu                                               | Task                                                              |
 | ------------------------------------ | ------------------------------------------------ | ----------------------------------------------------------------- |
@@ -16,7 +16,8 @@ This table was last updated for Nu 0.66.0.
 | `CLS`                                | `clear`                                          | Clear the screen                                                  |
 | `COLOR`                              |                                                  | Set the console default foreground/background colors              |
 |                                      | `ansi {flags} (code)`                            | Output ANSI codes to change color                                 |
-| `COPY +<source> <destination>`       | `cp <destination> <source>`                      | Copy files                                                        |
+| `COPY <source> <destination>`        | `cp <source> <destination>`                      | Copy files                                                        |
+| `COPY <file1>+<file2> <destination>` | `[<file1>, <file2>] \| each { open --raw } \| str collect \| save --raw <destination>` | Append multiple files into one  |
 | `DATE /T`                            | `date now`                                       | Get the current date                                              |
 | `DATE`                               |                                                  | Set the date                                                      |
 | `DEL <file>` or `ERASE <file>`       | `rm <file>`                                      | Delete files                                                      |


### PR DESCRIPTION
(Just downloaded the new version from winget)

The notable fix is changing `cp <destination> <source>` to `cp <source> <destination>`.

I also went ahead and added an interesting use of cmd `COPY` which I've run into.
