### PR TITLE
Mention coming_from_cmd in coming_to_nu

### DIFF
--- a/book/coming_to_nu.md
+++ b/book/coming_to_nu.md
@@ -3,6 +3,7 @@
 If you are familiar with other shells or programming languages, you might find this chapter useful to get up to speed.
 
 [Coming from Bash](coming_from_bash.md) shows how some patterns typical for Bash, or POSIX shells in general, can be mapped to Nushell.
+Similarly, [Coming from CMD.EXE](coming_from_cmd.md) shows how builtin commands in the Windows Command Prompt can be mapped to Nushell.
 
 Similar comparisons are made for some [other shells and domain-specific languages](nushell_map.md), [imperative languages](nushell_map_imperative.md), and [functional languages](nushell_map_functional.md).
 A separate comparison is made specifically for [operators](nushell_operator_map.md).


### PR DESCRIPTION
like is done for coming_from_bash. This keeps the chapter page as a complete listing of the chapter contents.