### PR TITLE
Note Windows caveat in Escaping to the System

### DIFF
--- a/book/escaping.md
+++ b/book/escaping.md
@@ -13,3 +13,7 @@ Escape to external command:
 ```
 > ^ls
 ```
+
+## Windows note
+
+When running an external command on Windows, nushell [used to](https://www.nushell.sh/blog/2022-08-16-nushell-0_67.html#windows-cmd-exe-changes-rgwood) use [Cmd.exe](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd) to run the command, as a number of common commands on Windows are actually shell builtins and not available as separate executables. [Coming from CMD.EXE](coming_from_cmd.md) contains a list of these commands and how to map them to nushell native concepts.


### PR DESCRIPTION
`^external` no longer runs commands through the CMD interpreter, so does not pick up builtins (except for the explicitly allowed ones). Make this more readily apparent.