### PR TITLE
Note status of calling CMD builtins from Nushell

### DIFF
--- a/book/coming_from_cmd.md
+++ b/book/coming_from_cmd.md
@@ -56,3 +56,5 @@ This table was last updated for Nu 0.67.0.
 | `VER`                                |                                                  | Display the OS version                                            |
 | `VERIFY`                             |                                                  | Verify that file writes happen                                    |
 | `VOL`                                |                                                  | Show drive information                                            |
+
+Before Nu version 0.67, Nu [used to](https://www.nushell.sh/blog/2022-08-16-nushell-0_67.html#windows-cmd-exe-changes-rgwood) use CMD.EXE to launch external commands, which meant that the above builtins could be run as an `^external` command. As of version 0.67, however, Nu no longer uses CMD.EXE to launch externals, meaning the above builtins cannot be run from within Nu, except for `ASSOC`, `DIR`, `ECHO`, `FTYPE`, `MKLINK`, `START`, `VER`, and `VOL`, which are explicitly allowed to be interpreted by CMD if no executable by that name exists.


### PR DESCRIPTION
The list doesn't include `PAUSE` or `CLS` despite them [now being allowed](https://github.com/nushell/nushell/pull/6371), as this page currently targets the released version 0.67.