### PR TITLE
Remove ambiguity about command quotes

### DIFF
--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -65,6 +65,14 @@ Now we can call our custom command as if it were a built-in subcommand of `str`:
 > str mycommand
 ```
 
+Of course, commands with spaces in them are defined in the same way:
+
+```nushell
+def "custom command" [] {
+  echo "this is a custom command with a space in the name!"
+}
+```
+
 ## Parameter types
 
 When defining custom commands, you can name and optionally set the type for each parameter. For example, you can write the above as:

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -45,7 +45,7 @@ returns `hello nushell`
 
 ## Command names
 
-In Nushell, a command name is a string of characters or a quoted string. Here are some examples of valid command names: `greet`, `get-size`, `mycommand123`, `"mycommand"`, `😊`, and `123`.
+In Nushell, a command name is a string of characters. Here are some examples of valid command names: `greet`, `get-size`, `mycommand123`, `my command`, and `😊`. 
 
 _Note: It's common practice in Nushell to separate the words of the command with `-` for better readability._ For example `get-size` instead of `getsize` or `get_size`.
 

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -65,7 +65,7 @@ Now we can call our custom command as if it were a built-in subcommand of `str`:
 > str mycommand
 ```
 
-Of course, commands with spaces in them are defined in the same way:
+Of course, commands with spaces in their names are defined in the same way:
 
 ```nushell
 def "custom command" [] {


### PR DESCRIPTION
Also removes reference to `123` being a valid command name; although defining it throws no error, it's impossible to call it.

Given the next subsection shows how to define a custom command with spaces in it, this should be fine, just removes ambiguity.

Fixes #566.