### PR TITLE
Update former question mark commands in docs

### DIFF
--- a/book/dataframes.md
+++ b/book/dataframes.md
@@ -1143,7 +1143,7 @@ whenever possible, their analogous Nushell command.
 | --------------- | --------------------------- | -------------------------------------------------------------------------- | ----------------------------- |
 | aggregate       | DataFrame, GroupBy, Series  | Performs an aggregation operation on a dataframe, groupby or series object | math                          |
 | all-false       | Series                      | Returns true if all values are false                                       |                               |
-| all-true        | Series                      | Returns true if all values are true                                        | all?                          |
+| all-true        | Series                      | Returns true if all values are true                                        | all                           |
 | arg-max         | Series                      | Return index for max value in series                                       |                               |
 | arg-min         | Series                      | Return index for min value in series                                       |                               |
 | arg-sort        | Series                      | Returns indexes for a sorted series                                        |                               |

--- a/book/nushell_map_functional.md
+++ b/book/nushell_map_functional.md
@@ -41,7 +41,7 @@ Note: this table assumes Nu 0.43 or later.
 | history                   |                              |                                 |                          |     |
 | inc(`*`)                  | inc                          |                                 | succ                     |     |
 | insert                    |                              |                                 |                          |     |
-| empty?                    | empty?                       | isEmpty                         |                          |     |
+| is-empty                  | empty?                       | isEmpty                         |                          |     |
 | keep                      | take, drop-last, pop         | take, init                      | take, init               |     |
 | keep-until                |                              |                                 |                          |     |
 | keep-while                | take-while                   | takeWhile                       | takeWhile                |     |

--- a/book/nushell_map_imperative.md
+++ b/book/nushell_map_imperative.md
@@ -40,7 +40,7 @@ Note: this table assumes Nu 0.43 or later.
 | history      |                               |                                                     |                         |                                               |
 | inc(`*`)     | x += 1                        | x++                                                 | x++                     | x += 1                                        |
 | insert       | list.insert                   |                                                     |                         |                                               |
-| empty?       | is None                       | isEmpty                                             | empty                   | is_empty                                      |
+| is-empty     | is None                       | isEmpty                                             | empty                   | is_empty                                      |
 | keep         | list[:x]                      |                                                     |                         | &Vec[..x]                                     |
 | keep until   |                               |                                                     |                         |                                               |
 | keep while   | itertools.takewhile           |                                                     |                         |                                               |

--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -103,15 +103,15 @@ $names | get $index # gives Tami
 The [`length`](commands/length.md) command returns the number of items in a list.
 For example, `[red green blue] | length` outputs `3`.
 
-The [`empty?`](commands/empty.md) command determines whether a string, list, or table is empty.
+The [`is-empty`](commands/is-empty.md) command determines whether a string, list, or table is empty.
 It can be used with lists as follows:
 
 ```bash
 let colors = [red green blue]
-$colors | empty? # false
+$colors | is-empty # false
 
 let colors = []
-$colors | empty? # true
+$colors | is-empty # true
 ```
 
 The `in` and `not-in` operators are used to test whether a value is in a list. For example:
@@ -123,40 +123,40 @@ let colors = [red green blue]
 'gold' not-in $colors # true
 ```
 
-The [`any?`](commands/any.md) command determines if any item in a list
+The [`any`](commands/any.md) command determines if any item in a list
 matches a given condition.
 For example:
 
 ```bash
 # Do any color names end with "e"?
-$colors | any? ($it | str ends-with "e") # true
+$colors | any ($it | str ends-with "e") # true
 
 # Is the length of any color name less than 3?
-$colors | any? ($it | str length) < 3 # false
+$colors | any ($it | str length) < 3 # false
 
 # Are any scores greater than 7?
-$scores | any? $it > 7 # true
+$scores | any $it > 7 # true
 
 # Are any scores odd?
-$scores | any? $it mod 2 == 1 # true
+$scores | any $it mod 2 == 1 # true
 ```
 
-The [`all?`](commands/all.md) command determines if every item in a list
+The [`all`](commands/all.md) command determines if every item in a list
 matches a given condition.
 For example:
 
 ```bash
 # Do all color names end with "e"?
-$colors | all? ($it | str ends-with "e") # false
+$colors | all ($it | str ends-with "e") # false
 
 # Is the length of all color names greater than or equal to 3?
-$colors | all? ($it | str length) >= 3 # true
+$colors | all ($it | str length) >= 3 # true
 
 # Are all scores greater than 7?
-$scores | all? $it > 7 # false
+$scores | all $it > 7 # false
 
 # Are all scores even?
-$scores | all? $it mod 2 == 0 # false
+$scores | all $it mod 2 == 0 # false
 ```
 
 ## Converting the list

--- a/cookbook/help.md
+++ b/cookbook/help.md
@@ -19,11 +19,11 @@ Output
  # │     name      │  category  │ is_plugin │ is_custom │                             usage
 ───┼───────────────┼────────────┼───────────┼───────────┼────────────────────────────────────────────────────────────────
  0 │ alias         │ core       │ false     │ false     │ Alias a command (with optional flags) to a new name
- 1 │ all?          │ filters    │ false     │ false     │ Test if every element of the input matches a predicate.
+ 1 │ all           │ filters    │ false     │ false     │ Test if every element of the input matches a predicate.
  2 │ ansi          │ platform   │ false     │ false     │ Output ANSI codes to change color.
  3 │ ansi gradient │ platform   │ false     │ false     │ draw text with a provided start and end code making a gradient
  4 │ ansi strip    │ platform   │ false     │ false     │ strip ansi escape sequences from string
- 5 │ any?          │ filters    │ false     │ false     │ Tests if any element of the input matches a predicate.
+ 5 │ any           │ filters    │ false     │ false     │ Tests if any element of the input matches a predicate.
  6 │ append        │ filters    │ false     │ false     │ Append a row to the table.
  7 │ benchmark     │ system     │ false     │ false     │ Time the running time of a block
  8 │ build-string  │ strings    │ false     │ false     │ Create a string from the arguments.

--- a/de/book/working_with_lists.md
+++ b/de/book/working_with_lists.md
@@ -107,15 +107,15 @@ $names | get $index # gives Tami
 Der [`length`](/book/commands/length.md) Befehl gibt die Anzahl Elemente in der Liste zurück.
 Zum Beispiel, `[red green blue] | length` ergibt `3`.
 
-Der [`empty?`](/book/commands/empty.md) Befehl ermittelt, ob ein String, eine Liste oder eine Tabelle leer ist.
+Der [`is-empty`](/book/commands/is-empty.md) Befehl ermittelt, ob ein String, eine Liste oder eine Tabelle leer ist.
 Mit einer Liste wird er so verwendet:
 
 ```bash
 let colors = [red green blue]
-$colors | empty? # false
+$colors | is-empty # false
 
 let colors = []
-$colors | empty? # true
+$colors | is-empty # true
 ```
 
 Der `in` und `not-in` Operator wird verwendet, um zu testen, ob ein Wert in einer Liste vorhanden ist oder nicht.
@@ -128,38 +128,38 @@ let colors = [red green blue]
 'gold' not-in $colors # true
 ```
 
-Der [`any?`](/book/commands/any.md) Befehl ermittelt, ob irgend ein Element der Liste einer Bedingung entspricht.
+Der [`any`](/book/commands/any.md) Befehl ermittelt, ob irgend ein Element der Liste einer Bedingung entspricht.
 Zum Beispiel:
 
 ```bash
 # Do any color names end with "e"?
-echo $colors | any? ($it | str ends-with "e") # true
+echo $colors | any ($it | str ends-with "e") # true
 
 # Is the length of any color name less than 3?
-echo $colors | any? ($it | str length) < 3 # false
+echo $colors | any ($it | str length) < 3 # false
 
 # Are any scores greater than 7?
-echo $scores | any? $it > 7 # true
+echo $scores | any $it > 7 # true
 
 # Are any scores odd?
-echo $scores | any? $it mod 2 == 1 # true
+echo $scores | any $it mod 2 == 1 # true
 ```
 
-Der [`all?`](/book/commands/all.md) Befehl wiederum ermittelt, ob jedes Element der Liste einer Bedingung entspricht.
+Der [`all`](/book/commands/all.md) Befehl wiederum ermittelt, ob jedes Element der Liste einer Bedingung entspricht.
 Zum Beispiel:
 
 ```bash
 # Do all color names end with "e"?
-echo $colors | all? ($it | str ends-with "e") # false
+echo $colors | all ($it | str ends-with "e") # false
 
 # Is the length of all color names greater than or equal to 3?
-echo $colors | all? ($it | str length) >= 3 # true
+echo $colors | all ($it | str length) >= 3 # true
 
 # Are all scores greater than 7?
-echo $scores | all? $it > 7 # false
+echo $scores | all $it > 7 # false
 
 # Are all scores even?
-echo $scores | all? $it mod 2 == 0 # false
+echo $scores | all $it mod 2 == 0 # false
 ```
 
 ## Eine Liste konvertieren

--- a/es/book/mapa_funcional_nushell.md
+++ b/es/book/mapa_funcional_nushell.md
@@ -57,7 +57,7 @@ Nota: Esta tabla asume Nu 0.14.1 o posterior.
 | history         |                            |                          |                          |     |
 | inc(`*`)        | inc                        |                          | succ                     |     |
 | insert          |                            |                          |                          |     |
-| is_empty        | empty?                     |                          |                          |     |
+| is-empty        | empty?                     |                          |                          |     |
 | keep            | take, drop-last, pop       |                          | init, take               |     |
 | keep_until      |                            |                          |                          |     |
 | keep_while      |                            |                          |                          |     |

--- a/ja/book/nushell_map_functional.md
+++ b/ja/book/nushell_map_functional.md
@@ -42,7 +42,7 @@
 | history           |                              |                                 |                          |     |
 | inc(`*`)          | inc                          |                                 | succ                     |     |
 | insert            |                              |                                 |                          |     |
-| is_empty          | empty?                       | isEmpty                         |                          |     |
+| is-empty          | empty?                       | isEmpty                         |                          |     |
 | keep              | take, drop-last, pop         | take, init                      | take, init               |     |
 | keep_until        |                              |                                 |                          |     |
 | keep_while        | take-while                   | takeWhile                       | takeWhile                |     |

--- a/zh-CN/book/dataframes.md
+++ b/zh-CN/book/dataframes.md
@@ -1002,7 +1002,7 @@ $nu.scope.commands | where category =~ expression
 | --------------- | --------------------------- | -------------------------------------------------- | ----------------------------- |
 | aggregate       | DataFrame, GroupBy, Series  | 在一个 DataFrame、GroupBy 或系列对象上执行聚合操作 | math                          |
 | all-false       | Series                      | 如果所有的值都是假的，则返回真                     |                               |
-| all-true        | Series                      | 如果所有的值都是真的，则返回真                     | all?                          |
+| all-true        | Series                      | 如果所有的值都是真的，则返回真                     | all                           |
 | arg-max         | Series                      | 返回系列中最大值的索引                             |                               |
 | arg-min         | Series                      | 返回系列中最小值的索引                             |                               |
 | arg-sort        | Series                      | 返回排序后的系列的索引                             |                               |

--- a/zh-CN/book/nushell_map_functional.md
+++ b/zh-CN/book/nushell_map_functional.md
@@ -41,7 +41,7 @@
 | history                   |                              |                                 |                          |     |
 | inc(`*`)                  | inc                          |                                 | succ                     |     |
 | insert                    |                              |                                 |                          |     |
-| empty?                    | empty?                       | isEmpty                         |                          |     |
+| is-empty                  | empty?                       | isEmpty                         |                          |     |
 | keep                      | take, drop-last, pop         | take, init                      | take, init               |     |
 | keep-until                |                              |                                 |                          |     |
 | keep-while                | take-while                   | takeWhile                       | takeWhile                |     |

--- a/zh-CN/book/nushell_map_imperative.md
+++ b/zh-CN/book/nushell_map_imperative.md
@@ -40,7 +40,7 @@
 | history      |                               |                                                     |                         |                                               |
 | inc(`*`)     | x += 1                        | x++                                                 | x++                     | x += 1                                        |
 | insert       | list.insert                   |                                                     |                         |                                               |
-| empty?       | is None                       | isEmpty                                             | empty                   | is_empty                                      |
+| is-empty     | is None                       | isEmpty                                             | empty                   | is_empty                                      |
 | keep         | list[:x]                      |                                                     |                         | &Vec[..x]                                     |
 | keep until   |                               |                                                     |                         |                                               |
 | keep while   | itertools.takewhile           |                                                     |                         |                                               |

--- a/zh-CN/book/working_with_lists.md
+++ b/zh-CN/book/working_with_lists.md
@@ -100,14 +100,14 @@ $names | get $index # gives Tami
 
 [`length`](/book/commands/length.md)命令返回列表中的元素个数。例如，`[red green blue] | length`输出`3`。
 
-[`empty?`](/book/commands/empty.md) 命令确定一个字符串、列表或表格是否为空。它可以与列表一起使用，如下所示：
+[`is-empty`](/book/commands/is-empty.md) 命令确定一个字符串、列表或表格是否为空。它可以与列表一起使用，如下所示：
 
 ```bash
 let colors = [red green blue]
-$colors | empty? # false
+$colors | is-empty # false
 
 let colors = []
-$colors | empty? # true
+$colors | is-empty # true
 ```
 
 `in` 和 `not-in` 运算符用于测试一个值是否在一个列表中，例如：
@@ -119,36 +119,36 @@ let colors = [red green blue]
 'gold' not-in $colors # true
 ```
 
-[`any?`](/book/commands/any.md)命令用于确定一个列表中是否有任意一个元素匹配给定的条件，例如：
+[`any`](/book/commands/any.md)命令用于确定一个列表中是否有任意一个元素匹配给定的条件，例如：
 
 ```bash
 # Do any color names end with "e"?
-echo $colors | any? ($it | str ends-with "e") # true
+echo $colors | any ($it | str ends-with "e") # true
 
 # Is the length of any color name less than 3?
-echo $colors | any? ($it | str length) < 3 # false
+echo $colors | any ($it | str length) < 3 # false
 
 # Are any scores greater than 7?
-echo $scores | any? $it > 7 # true
+echo $scores | any $it > 7 # true
 
 # Are any scores odd?
-echo $scores | any? $it mod 2 == 1 # true
+echo $scores | any $it mod 2 == 1 # true
 ```
 
-[`all?`](/book/commands/all.md)命令确定一个列表中是否所有元素都匹配给定的条件。例如：
+[`all`](/book/commands/all.md)命令确定一个列表中是否所有元素都匹配给定的条件。例如：
 
 ```bash
 # Do all color names end with "e"?
-echo $colors | all? ($it | str ends-with "e") # false
+echo $colors | all ($it | str ends-with "e") # false
 
 # Is the length of all color names greater than or equal to 3?
-echo $colors | all? ($it | str length) >= 3 # true
+echo $colors | all ($it | str length) >= 3 # true
 
 # Are all scores greater than 7?
-echo $scores | all? $it > 7 # false
+echo $scores | all $it > 7 # false
 
 # Are all scores even?
-echo $scores | all? $it mod 2 == 0 # false
+echo $scores | all $it mod 2 == 0 # false
 ```
 
 ## 转换列表


### PR DESCRIPTION
Account for nushell/nushell#6464

`any?`/`all?`/`empty?` to `any`/`all`/`is-empty`
