### PR TITLE
fix (plugins): python plugin url changed

### DIFF
--- a/book/plugins.md
+++ b/book/plugins.md
@@ -17,6 +17,7 @@ Linux+macOS:
 ```
 
 Windows:
+nu_plugin_python_example.py
 
 ```
 > register .\my_plugins\nu_plugin_cool.exe
@@ -40,7 +41,7 @@ Once registered, the plugin is available as part of your set of commands:
 Nu's main repo contains example plugins that are useful for learning how the plugin protocol works:
 
 - [Rust](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_example)
-- [Python](https://github.com/nushell/nushell/blob/main/crates/nu_plugin_python/plugin.py)
+- [Python](https://github.com/nushell/nushell/blob/main/crates/nu_plugin_python)
 
 ## Debugging
 

--- a/book/plugins.md
+++ b/book/plugins.md
@@ -17,7 +17,6 @@ Linux+macOS:
 ```
 
 Windows:
-nu_plugin_python_example.py
 
 ```
 > register .\my_plugins\nu_plugin_cool.exe


### PR DESCRIPTION
https://github.com/nushell/nushell/commits/d2e4f03d194361676e406717eeb7a7eeafb28b1f/crates/nu_plugin_python/plugin.py?browsing_rename_history=true&new_path=crates/nu_plugin_python/nu_plugin_python_example.py&original_branch=main