### PR TITLE
Make `foo` example for Groups parsable by nushell

### DIFF
--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -260,7 +260,7 @@ Blocks are a useful way to represent code that can be executed on each row of da
 Take this example:
 
 ```
-foo {
+def foo [] {
   line1
   line2; line3 | line4
 }


### PR DESCRIPTION
Currently I get the following running the script with the example copy-pasted as is:
```
Error: nu::shell::external_command (link)

  × External command failed
    ╭─[./build.nu:41:1]
 41 │ 
 42 │ foo {
    · ─┬─
    ·  ╰── did you mean 'for'?
 43 │   line1
    ╰────
```