### PR TITLE
add reference to semicolons, remove redundant `group` from types_of_data

### DIFF
--- a/book/pipelines.md
+++ b/book/pipelines.md
@@ -37,6 +37,19 @@ If a pipeline is getting a bit long for one line, you can enclose it within `(` 
 
 Also see [Subexpressions](https://www.nushell.sh/book/variables_and_subexpressions.html#subexpressions)
 
+## Semicolons
+
+Take this example:
+
+```
+> line1; line2 | line3
+```
+
+Here, semicolons are used in conjunction with pipelines. When a semicolon is used, no output data is produced to be piped. As such, the `$in` variable will not work when used immediately after the semicolon. 
+
+- As there is a semicolon after `line1`, the command will run to completion and get displayed on the screen.
+- `line2` | `line3` is a normal pipeline. It runs, and its contents are displayed after `line1`'s contents.
+
 ## Working with external commands
 
 Nu commands communicate with each other using the Nu data types (see [types of data](types_of_data.md)), but what about commands outside of Nu? Let's look at some examples of working with external commands:

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -254,25 +254,3 @@ Column paths are a path through the table to a specific sub-table, column, row, 
 Blocks represent a block of code in Nu. For example, in the command `each { |it| echo $it }` the block is the portion contained in curly braces, `{ |it| echo $it }`. Block parameters are specified between a pair of pipe symbols (for example, `|it|`) if necessary.
 
 Blocks are a useful way to represent code that can be executed on each row of data. It is idiomatic to use `$it` as a parameter name in [`each`](commands/each.md) blocks, but not required; `each { |x| echo $x }` works the same way as `each { |it| echo $it }`.
-
-## Groups
-
-Take this example:
-
-```
-def foo [] {
-  line1
-  line2; line3 | line4
-}
-```
-
-Inside the block, you have two separate groups that run to completion, a group
-is a semicolon-separated list of pipelines, the last of which is output to the
-screen.
-
-- `line1` is a group unto itself, so that command will run to completion and get
-  displayed on the screen.
-- `line2` is a pipeline inside of the second group. It runs, but its contents
-  are not viewed on the screen.
-- `line3` | `line4` is the second pipeline in the second group. It runs, and its
-  contents get viewed.


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/6668.

The `groups` section is deprecated.