### PR TITLE
Fix example variables using `-` in their name

### DIFF
--- a/book/3rdpartyprompts.md
+++ b/book/3rdpartyprompts.md
@@ -31,12 +31,12 @@ For MacOS users:
 3. Set the PROMPT_COMMAND in the file output by `$nu.config-path`, here is a code snippet:
 
 ```shell
-let posh-dir = (brew --prefix oh-my-posh | str trim)
-let posh-theme = $'($posh-dir)/share/oh-my-posh/themes/'
+let posh_dir = (brew --prefix oh-my-posh | str trim)
+let posh_theme = $'($posh_dir)/share/oh-my-posh/themes/'
 # Change the theme names to: zash/space/robbyrussel/powerline/powerlevel10k_lean/
 # material/half-life/lambda Or double lines theme: amro/pure/spaceship, etc.
 # For more [Themes demo](https://ohmyposh.dev/docs/themes)
-let-env PROMPT_COMMAND = { oh-my-posh prompt print primary --config $'($posh-theme)/zash.omp.json' }
+let-env PROMPT_COMMAND = { oh-my-posh prompt print primary --config $'($posh_theme)/zash.omp.json' }
 # Optional
 let-env PROMPT_INDICATOR = $"(ansi y)$> (ansi reset)"
 ```

--- a/book/commands/input.md
+++ b/book/commands/input.md
@@ -25,5 +25,5 @@ usage: |
 
 Get input from the user, and assign to a variable
 ```shell
-> let user-input = (input)
+> let user_input = (input)
 ```

--- a/book/commands/input.md
+++ b/book/commands/input.md
@@ -25,5 +25,5 @@ usage: |
 
 Get input from the user, and assign to a variable
 ```shell
-> let user_input = (input)
+> let user-input = (input)
 ```

--- a/book/thinking_in_nu.md
+++ b/book/thinking_in_nu.md
@@ -45,7 +45,7 @@ The `source` command will grow the source that is compiled, but the `save` from 
 Another common issue is trying to dynamically create the filename to source from:
 
 ```
-> source $"($my-path)/common.nu"
+> source $"($my_path)/common.nu"
 ```
 
 This would require the evaluator to run and evaluate the string, but unfortunately Nushell needs this information at compile-time.

--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -9,8 +9,8 @@ The simpler of the two evaluation expressions is the variable. During evaluation
 If we create a variable, we can print its contents by using `$` to refer to it:
 
 ```
-> let my-value = 4
-> echo $my-value
+> let my_value = 4
+> echo $my_value
 4
 ```
 
@@ -18,10 +18,10 @@ Variables in Nushell are immutable, that means that you cannot change its value 
 They can be shadowed in nested block, that results in:
 
 ```
-> let my-value = 4
-> do { let my-value = 5; echo $my-value }
+> let my_value = 4
+> do { let my_value = 5; echo $my_value }
 5
-> echo $my-value
+> echo $my_value
 4
 ```
 
@@ -30,13 +30,13 @@ They can be shadowed in nested block, that results in:
 A variable path works by reaching inside of the contents of a variable, navigating columns inside of it, to reach a final value. Let's say instead of `4`, we had assigned a table value:
 
 ```
-> let my-value = [[name]; [testuser]]
+> let my_value = [[name]; [testuser]]
 ```
 
-We can use a variable path to evaluate the variable `$my-value` and get the value from the `name` column in a single step:
+We can use a variable path to evaluate the variable `$my_value` and get the value from the `name` column in a single step:
 
 ```
-> echo $my-value.name
+> echo $my_value.name
 testuser
 ```
 
@@ -49,8 +49,8 @@ The parentheses contain a pipeline that will run to completion, and the resultin
 Subexpressions can also be pipelines and not just single commands. If we wanted to get a list of filenames larger than ten kilobytes, we can use an subexpression to run a pipeline and assign the result to a variable:
 
 ```
-> let names-of-big-files = (ls | where size > 10kb)
-> echo $names-of-big-files
+> let names_of_big_files = (ls | where size > 10kb)
+> echo $names_of_big_files
 ───┬────────────┬──────┬──────────┬──────────────
  # │    name    │ type │   size   │   modified
 ───┼────────────┼──────┼──────────┼──────────────

--- a/de/book/thinking_in_nushell.md
+++ b/de/book/thinking_in_nushell.md
@@ -52,7 +52,7 @@ bevor sie ausgeführt werden kann, können die drei Zeilen nicht im voraus `komp
 Ein anderes Problem ist, einen Dateinamen dynamisch erzeugen zu wollen um ihn auszuführen:
 
 ```
-> source $"($my-path)/common.nu"
+> source $"($my_path)/common.nu"
 ```
 
 Dies würde voraussetzen, dass Nushell die Eingabe auswerten kann um sie dann auszuführen, jedoch wird diese Information zur Kompilierzeit benötigt.

--- a/de/book/variablen_und_unterausdruecke.md
+++ b/de/book/variablen_und_unterausdruecke.md
@@ -9,8 +9,8 @@ Die einfachere Variante der auszuwertenden Ausdrücke ist die Variable. Während
 Wenn eine Variable erzeugt wurde, kann der Inhalt dieser Variable ausgegeben werden, indem `$` vor dem Variablennamen verwendet wird:
 
 ```
-> let my-value = 4
-> echo $my-value
+> let my_value = 4
+> echo $my_value
 4
 ```
 
@@ -19,13 +19,13 @@ Wenn eine Variable erzeugt wurde, kann der Inhalt dieser Variable ausgegeben wer
 Ein Pfad einer Variable funktioniert ähnlich wie ein strukturierter Datentyp. Es kann mittels Referenzen auf den Inhalt der Variable beziehungsweise die Spalten in der Variable zugegriffen werden, um final bei einem bestimmten Wert zu landen. Wenn beispielsweise anstatt der `4` im obigen Beispiel, der Variablen eine Tabelle zugewiesen wurde:
 
 ```
-> let my-value = [[name]; [testuser]]
+> let my_value = [[name]; [testuser]]
 ```
 
-Hier kann ein Pfad der Variable `$my-value` verwendet werden, um den Wert der Spalte `name` in nur einem Schritt zu bekommen:
+Hier kann ein Pfad der Variable `$my_value` verwendet werden, um den Wert der Spalte `name` in nur einem Schritt zu bekommen:
 
 ```
-> echo $my-value.name
+> echo $my_value.name
 testuser
 ```
 
@@ -38,8 +38,8 @@ Die Klammern enthalten eine Pipeline, die bis zum Ende durchlaufen wird und dere
 Unterausdrücke können auch ganze Pipelines statt nur einzelner Befehle enthalten. Um eine Liste von Dateien mit einer Größe größer als 10 Kilobytes zu bekommen, kann die folgende Pipeline verwendet und einer Variable zugewiesen werden:
 
 ```
-> let names-of-big-files = (ls | where size > 10kb)
-> echo $names-of-big-files
+> let names_of_big_files = (ls | where size > 10kb)
+> echo $names_of_big_files
 ───┬────────────┬──────┬──────────┬──────────────
  # │    name    │ type │   size   │   modified
 ───┼────────────┼──────┼──────────┼──────────────

--- a/es/book/variables_y_subexpresiones.md
+++ b/es/book/variables_y_subexpresiones.md
@@ -9,8 +9,8 @@ La variable es el más simple de ambas expresiones de evaluación. Durante la ev
 Si creamos una variable, podemos imprimir su contenido al usar `$` para referir a la misma:
 
 ```
-> let mi-valor = 4
-> echo $mi-valor
+> let mi_valor = 4
+> echo $mi_valor
 4
 ```
 
@@ -19,13 +19,13 @@ Si creamos una variable, podemos imprimir su contenido al usar `$` para referir 
 Una variable ruta funciona al llegar dentro del contenido de una variable, navegando columnas dentro de la misma para alcanzar un valor final. Supongamos que en vez de `4`, hayamos asignado una tabla como valor:
 
 ```
-> let mi-valor = [[nombre]; [pruebausuario]]
+> let mi_valor = [[nombre]; [pruebausuario]]
 ```
 
-Podemos usar variables ruta para evaluar la variable `$mi-valor` y obtener el valor de la columna `nombre` con un solo paso:
+Podemos usar variables ruta para evaluar la variable `$mi_valor` y obtener el valor de la columna `nombre` con un solo paso:
 
 ```
-> echo $mi-valor.nombre
+> echo $mi_valor.nombre
 pruebausuario
 ```
 
@@ -38,8 +38,8 @@ Los paréntesis contienen una tubería que se ejecutará hasta completar, y su v
 Subexpresiones también pueden ser tuberías y no solamente comandos individuales. Si desearamos una lista de nombres de archivos superiores a diez kilobytes, podemos utilizar subexpresiones para ejecutar una tubería y asignar el resultado a una variable:
 
 ```
-> let nombres-de-archivos-grandes = (ls | where size > 10kb)
-> echo $nombres-de-archivos-grandes
+> let nombres_de_archivos_grandes = (ls | where size > 10kb)
+> echo $nombres_de_archivos_grandes
 ───┬────────────┬──────┬──────────┬──────────────
  # │    name    │ type │   size   │   modified
 ───┼────────────┼──────┼──────────┼──────────────

--- a/zh-CN/book/3rdpartyprompts.md
+++ b/zh-CN/book/3rdpartyprompts.md
@@ -31,12 +31,12 @@ MacOS 用户配置步骤：
 3. 在`$nu.config-path`输出的文件中设置`PROMPT_COMMAND`，可以参考下面的代码片段：
 
 ```shell
-let posh-dir = (brew --prefix oh-my-posh | str trim)
-let posh-theme = $'($posh-dir)/share/oh-my-posh/themes/'
+let posh_dir = (brew --prefix oh-my-posh | str trim)
+let posh_theme = $'($posh_dir)/share/oh-my-posh/themes/'
 # Change the theme names to: zash/space/robbyrussel/powerline/powerlevel10k_lean/
 # material/half-life/lambda Or double lines theme: amro/pure/spaceship, etc.
 # For more [Themes demo](https://ohmyposh.dev/docs/themes)
-let-env PROMPT_COMMAND = { oh-my-posh prompt print primary --config $'($posh-theme)/zash.omp.json' }
+let-env PROMPT_COMMAND = { oh-my-posh prompt print primary --config $'($posh_theme)/zash.omp.json' }
 # Optional
 let-env PROMPT_INDICATOR = $"(ansi y)$> (ansi reset)"
 ```

--- a/zh-CN/book/thinking_in_nu.md
+++ b/zh-CN/book/thinking_in_nu.md
@@ -45,7 +45,7 @@ abc
 另一个常见的问题是试图动态地创建文件名并`source`，如下：
 
 ```bash
-> source $"($my-path)/common.nu"
+> source $"($my_path)/common.nu"
 ```
 
 这就需要求值器(Evaluator)运行并对字符串进行求值(Evaluate)，但不幸的是，Nushell 在编译时就需要这些信息。

--- a/zh-CN/book/variables_and_subexpressions.md
+++ b/zh-CN/book/variables_and_subexpressions.md
@@ -9,8 +9,8 @@
 如果我们创建了一个变量，我们可以通过使用`$`来引用它并打印其内容：
 
 ```bash
-> let my-value = 4
-> echo $my-value
+> let my_value = 4
+> echo $my_value
 4
 ```
 
@@ -18,10 +18,10 @@ Nushell 中的变量是不可变的，这意味着你不能在声明后修改它
 不过它们可以在嵌套块中被隐藏，这导致：
 
 ```bash
-> let my-value = 4
-> do { let my-value = 5; echo $my-value }
+> let my_value = 4
+> do { let my_value = 5; echo $my_value }
 5
-> echo $my-value
+> echo $my_value
 4
 ```
 
@@ -30,13 +30,13 @@ Nushell 中的变量是不可变的，这意味着你不能在声明后修改它
 变量路径通过深入变量的内容，找到其中的列，并最终获得一个值。比如，对于前面的例子如果我们不是赋值`4`，而是赋值了一个表的值：
 
 ```bash
-> let my-value = [[name]; [testuser]]
+> let my_value = [[name]; [testuser]]
 ```
 
-我们可以使用一个变量路径来访问变量`$my-value`并只用一步从`name`列获得数值：
+我们可以使用一个变量路径来访问变量`$my_value`并只用一步从`name`列获得数值：
 
 ```bash
-> echo $my-value.name
+> echo $my_value.name
 testuser
 ```
 
@@ -49,8 +49,8 @@ testuser
 子表达式也可以是管道，而不仅仅是单个命令。如果我们想得到一个大于 10KB 的文件名列表，我们可以使用子表达式来运行一个管道，并将其赋值给一个变量：
 
 ```bash
-> let names-of-big-files = (ls | where size > 10kb)
-> echo $names-of-big-files
+> let names_of_big_files = (ls | where size > 10kb)
+> echo $names_of_big_files
 ───┬────────────┬──────┬──────────┬──────────────
  # │    name    │ type │   size   │   modified
 ───┼────────────┼──────┼──────────┼──────────────


### PR DESCRIPTION
This PR fixes examples using the `-` character in their name, which does not seem to be valid in nu 0.69.1.

I found these occurences with the regexes `let \w+-` and `\$\w+-`, so it's possible I missed something.