### PR TITLE
Add documentation for completions with descriptions

### DIFF
--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -58,3 +58,16 @@ export extern "git push" [
 ```
 
 Custom completions will serve the same role in this example as in the previous examples. The examples above call into two different custom completions, based on the position the user is currently in.
+
+## Custom descriptions
+
+As an alternative to returning a list of strings, a completion function can also return a list of records with a `value` and `description` field.
+
+```
+def my_commits [] {
+    [
+        { value: "5c2464", description: "Add .gitignore" },
+        { value: "f3a377", description: "Initial commit" }
+    ]
+}
+```


### PR DESCRIPTION
Document the ability to return a list of `{value: "", description: ""}` records from a completion function.

context: https://discordapp.com/channels/601130461678272522/958067223187062834/1002353516515442759