### PR TITLE
Fixed various issues in make_docs.nu

### DIFF
--- a/book/make_docs.nu
+++ b/book/make_docs.nu
@@ -94,21 +94,10 @@ def get-doc [command] {
   let ex = $command.extra_usage
   # Certain commands' extra_usage is wrapped in code block markup to prevent their code from
   # being interpreted as markdown. This is strictly hard-coded for now.
-  let extra_usage = if $ex == "" { "" } else if $command.command in ['def-env' 'export def-env' 'as-date' 'as-datetime' ansi] {
-    $"## Notes(char nl)```text(char nl)($command.extra_usage)(char nl)```(char nl)"
+  let extra_usage = if $ex == "" { "" } else if $command.name in ['def-env' 'export def-env' 'as-date' 'as-datetime' ansi] {
+    $"## Notes(char nl)```text(char nl)($ex)(char nl)```(char nl)"
   } else {
-    ""
-  }
-
-  let parameters = if $no_param { "" } else { $"## Parameters(char nl)(char nl)($params)(char nl)(char nl)" }
-
-  let ex = $command.extra_usage
-  # Certain commands' extra_usage is wrapped in code block markup to prevent their code from
-  # being interpreted as markdown. This is strictly hard-coded for now.
-  let extra_usage = if $ex == "" { "" } else if $command.command in ['def-env' 'export def-env' 'as-date' 'as-datetime' ansi] {
-    $"## Notes(char nl)```text(char nl)($command.extra_usage)(char nl)```(char nl)"
-  } else {
-    $"## Notes(char nl)( $ex )(char nl)(char nl)"
+    $"## Notes(char nl)($ex)(char nl)"
   }
 
   let examples = if ($command.examples | length) > 0 {

--- a/book/make_docs.nu
+++ b/book/make_docs.nu
@@ -9,7 +9,7 @@ if $book_exists == false {
 }
 
 # Old commands are currently not deleted because some of them
-# are platform-specific, and a single run of this script will not regenerate
+# are platform-specific (currently `exec`, `registry query`), and a single run of this script will not regenerate
 # all of them.
 #do -i { rm book/commands/*.md }
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "github:nushell/nushell.github.io",
   "type": "module",
   "scripts": {
+    "update": "nu book/make_docs.nu",
     "dev": "vuepress dev",
     "build": "vuepress build",
     "prepare": "husky install",


### PR DESCRIPTION
* Certain hard-coded commands' `extra_usage` is wrapped in code block markup to prevent their code from being interpreted as markdown, instead of every command's `extra_usage` being wrapped.
* No longer deletes files due to erasing platform-specific commands.
* Notes now appear before parameters, in accordance with the actual nu `help`.
* Added task to `package.json` to run it.
 
~~Also reran make_docs.nu.~~