### PR TITLE
Mention nushell also run on BSD systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ actionText: Get Started →
 actionLink: /book/
 features:
   - title: Pipelines to control any OS
-    details: Nu works on Linux, macOS, and Windows. Learn it once, then use it anywhere.
+    details: Nu works on Linux, macOS, BSD and Windows. Learn it once, then use it anywhere.
   - title: Everything is data
     details: Nu pipelines use structured data so you can safely select, filter, and sort the same way every time. Stop parsing strings and start solving problems.
   - title: Powerful plugins

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ actionText: Get Started →
 actionLink: /book/
 features:
   - title: Pipelines to control any OS
-    details: Nu works on Linux, macOS, BSD and Windows. Learn it once, then use it anywhere.
+    details: Nu works on Linux, macOS, BSD, and Windows. Learn it once, then use it anywhere.
   - title: Everything is data
     details: Nu pipelines use structured data so you can safely select, filter, and sort the same way every time. Stop parsing strings and start solving problems.
   - title: Powerful plugins


### PR DESCRIPTION
It's not much but I imported nushell into OpenBSD packages, so the website can now include BSD in the operating system list where it's known to run.

I think it's worth mentioning because it implies nushell is really portable, but as it's too niche I prefered not adding any extra info with regard to installation, and it's already covered by package manager / source install.