### PR TITLE
Simplified examples by removing unneeded `echo` calls

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -17,7 +17,7 @@ Note: this table assumes Nu 0.60.0 or later.
 | `ls -la`                             | `ls --long --all` or `ls -la`                    | List files with all available information, including hidden files |
 | `ls -d */`                           | `ls \| where type == dir`                        | List directories                                                  |
 | `find . -name *.rs`                  | `ls **/*.rs`                                     | Find recursively all files that match a given pattern             |
-| `find . -name Makefile \| xargs vim` | `ls **/Makefile \| get name \| vim $in`        | Pass values as command parameters                                 |
+| `find . -name Makefile \| xargs vim` | `ls **/Makefile \| get name \| vim $in`          | Pass values as command parameters                                 |
 | `cd <directory>`                     | `cd <directory>`                                 | Change to the given directory                                     |
 | `cd`                                 | `cd`                                             | Change to the home directory                                      |
 | `cd -`                               | `cd -`                                           | Change to the previous directory                                  |
@@ -42,21 +42,21 @@ Note: this table assumes Nu 0.60.0 or later.
 |                                      | `help --find <string>`                           | Search for match in all available commands                        |
 | `command1 && command2`               | `command1; command2`                             | Run a command, and if it's successful run a second                |
 | `stat $(which git)`                  | `stat (which git).path`                          | Use command output as argument for other command                  |
-| `echo /tmp/$RANDOM` | `echo $"/tmp/(random integer)"` | Use command output in a string |
-| `cargo b --jobs=$(nproc)` | `cargo b $"--jobs=(sys \| get cpu \| length)"` | Use command output in an option |
-| `echo $PATH`                         | `echo $env.PATH`                                 | See the current path                                              |
+| `echo /tmp/$RANDOM`                  | `$"/tmp/(random integer)"`                       | Use command output in a string                                    |
+| `cargo b --jobs=$(nproc)`            | `cargo b $"--jobs=(sys \| get cpu \| length)"`   | Use command output in an option                                   |
+| `echo $PATH`                         | `$env.PATH`                                      | See the current path                                              |
 | `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Update PATH permanently                                           |
 | `export PATH = $PATH:/usr/other/bin` | `let-env PATH = ($env.PATH \| append /usr/other/bin)` | Update PATH temporarily                                      |
-| `export`                             | `echo $env`                                      | List the current environment variables                            |
+| `export`                             | `$env`                                           | List the current environment variables                            |
 | `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Update environment variables permanently                          |
 | `FOO=BAR ./bin`                      | `FOO=BAR ./bin`                                  | Update environment temporarily                                    |
 | `export FOO=BAR`                     | `let-env FOO = BAR`                              | Set environment variable for current session                      |
-| `echo $FOO`                          | `echo $env.FOO`                                  | Use environment variables                                         |
+| `echo $FOO`                          | `$env.FOO`                                       | Use environment variables                                         |
 | `unset FOO`                          | `hide FOO`                                       | Unset environment variable for current session                    |
 | `alias s="git status -sb"`           | `alias s = git status -sb`                       | Define an alias temporarily                                       |
 | `type FOO`                           | `which FOO`                                      | Display information about a command (builtin, alias, or executable) |
 | `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Add and edit alias permanently (for new shells)                   |
-| `bash -c <commands>`                 | `nu -c <commands>`                               | Run a pipeline of commands (requires 0.9.1 or later)              |
-| `bash <script file>`                 | `nu <script file>`                               | Run a script file (requires 0.9.1 or later)                       |
+| `bash -c <commands>`                 | `nu -c <commands>`                               | Run a pipeline of commands                                        |
+| `bash <script file>`                 | `nu <script file>`                               | Run a script file                                                 |
 | `\`                                  | `( <command> )`                                  | A command can span multiple lines when wrapped with `(` and `)`   |
 | `pwd`                                | `$env.PWD`                                       | Display the current directory                                     |

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -308,7 +308,7 @@ greet earth mars jupiter venus
 ```
 
 ::: tip
-Each line of a command has its resulting value printed out when run, as long as it isn't `null`. Hence, `"hello all:"` above will be printed out despite not being the return value.
+Each line of a command has its resulting value printed out when run, as long as it isn't `null`. Hence, `"hello all:"` above will be printed out despite not being the return value. To prevent this, you can place `null` (or the `ignore` command) at the end of the pipeline, like so: `"hello all:" | null`. Also note that most file system commands, such as `save` or `cd`, always output `null`.
 
 We could call the above definition of the `greet` command with any number of arguments, including none at all. All of the arguments are collected into `$name` as a list.
 

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -8,9 +8,12 @@ An example definition of a custom command:
 
 ```nushell
 def greet [name] {
-  echo "hello" $name
+  ['hello' $name]
 }
 ```
+
+::: tip
+The value produced by the last line of a command becomes the command's returned value. In this case, a list containing the string `'hello'` and `$name` is returned.
 
 In this definition, we define the `greet` command, which takes a single parameter `name`. Following this parameter is the block that represents what will happen when the custom command runs. When called, the custom command will set the value passed for `name` as the `$name` variable, which will be available to the block.
 
@@ -30,11 +33,11 @@ As we do, we also get output just as we would with built-in commands:
 ```
 
 ::: tip
-`echo` returns its arguments separately to the pipeline. If you want to use it to generate a single string append ` | str join` to the pipeline:
+If you want to generate a single string, you can use the string interpolation syntax to embed $name in it:
 
 ```nushell
 def greet [name] {
-  echo "hello " $name | str join
+  $"hello ($name)"
 }
 
 greet nushell
@@ -55,7 +58,7 @@ You can also define subcommands to commands using a space. For example, if we wa
 
 ```nushell
 def "str mycommand" [] {
-  echo hello
+  hello
 }
 ```
 
@@ -69,7 +72,7 @@ Of course, commands with spaces in their names are defined in the same way:
 
 ```nushell
 def "custom command" [] {
-  echo "this is a custom command with a space in the name!"
+  "this is a custom command with a space in the name!"
 }
 ```
 
@@ -79,7 +82,7 @@ When defining custom commands, you can name and optionally set the type for each
 
 ```nushell
 def greet [name: string] {
-  echo "hello " $name | str join
+  $"hello ($name)"
 }
 ```
 
@@ -89,7 +92,7 @@ For example, let's say you wanted to take in an `int` instead:
 
 ```nushell
 def greet [name: int] {
-  echo "hello " $name | str join
+  $"hello ($name)"
 }
 
 greet world
@@ -102,7 +105,7 @@ error: Type Error
   ┌─ shell:6:7
   │
 5 │ greet world
-  │       ^^^^^ Expected int, found world
+  │       ^^^^^ Expected int
 ```
 
 This can help you guide users of your definitions to call them with only the supported types.
@@ -138,7 +141,7 @@ To make a parameter optional and directly provide a default value for it you can
 
 ```nushell
 def greet [name = "nushell"] {
-  echo "hello " $name | str join
+  $"hello ($name)"
 }
 ```
 
@@ -155,7 +158,7 @@ You can also combine a default value with a [type requirement](#parameter-types)
 
 ```
 def congratulate [age: int = 18] {
-  echo "Happy birthday! Wow you are " $age " years old now!" | str join
+  $"Happy birthday! You are ($age) years old now!"
 }
 ```
 
@@ -179,7 +182,7 @@ We can instead mark a positional parameter as optional by putting a question mar
 
 ```nushell
 def greet [name?: string] {
-  echo "hello" $name | str join
+  $"hello ($name)"
 }
 
 greet
@@ -187,14 +190,14 @@ greet
 
 Making a positional parameter optional does not change its name when accessed in the body. As the example above shows, it is still accessed with `$name`, despite the `?` suffix in the parameter list.
 
-When an optional parameter is not passed, its value in the command body is equal to `null` and `$nothing`. We can use this to act on the case where a parameter was not passed:
+When an optional parameter is not passed, its value in the command body is equal to `null`. We can use this to act on the case where a parameter was not passed:
 
 ```nushell
 def greet [name?: string] {
   if ($name == null) {
-    echo "hello, I don't know your name!"
+    "hello, I don't know your name!"
   } else {
-    echo "hello " $name | str join
+    $"hello ($name)"
   }
 }
 
@@ -216,7 +219,7 @@ def greet [
   name: string
   --age: int
 ] {
-  echo $name $age
+  [$name $age]
 }
 ```
 
@@ -249,7 +252,7 @@ def greet [
   name: string
   --age (-a): int
 ] {
-  echo $name $age
+  [$name $age]
 }
 ```
 
@@ -270,9 +273,9 @@ def greet [
   --twice
 ] {
   if $twice {
-    echo $name $name $age $age
+    [$name $name $age $age]
   } else {
-    echo $name $age
+    [$name $age]
   }
 }
 ```
@@ -295,14 +298,17 @@ There may be cases when you want to define a command which takes any number of p
 
 ```nushell
 def greet [...name: string] {
-  echo "hello all:"
+  "hello all:"
   for $n in $name {
-    echo $n
+    $n
   }
 }
 
 greet earth mars jupiter venus
 ```
+
+::: tip
+Each line of a command has its resulting value printed out when run, as long as it isn't `null`. Hence, `"hello all:"` above will be printed out despite not being the return value.
 
 We could call the above definition of the `greet` command with any number of arguments, including none at all. All of the arguments are collected into `$name` as a list.
 
@@ -310,10 +316,10 @@ Rest parameters can be used together with positional parameters:
 
 ```
 def greet [vip: string, ...name: string] {
-  echo "hello to our VIP " $vip | str join
-  echo "and hello to everybody else:"
+  $"hello to our VIP ($vip)" 
+  "and hello to everybody else:"
   for $n in $name {
-    echo $n
+    $n
   }
 }
 
@@ -333,7 +339,7 @@ def greet [
   name: string
   --age (-a): int
 ] {
-  echo $name $age
+  [$name $age]
 }
 ```
 
@@ -361,7 +367,7 @@ def greet [
   name: string      # The name of the person to greet
   --age (-a): int   # The age of the person
 ] {
-  echo $name $age
+  [$name $age]
 }
 ```
 

--- a/book/environment.md
+++ b/book/environment.md
@@ -102,14 +102,14 @@ Therefore, it follows the same rules as other environment variables (for example
 A common shorthand to set an environment variable once is available, inspired by Bash and others:
 
 ```
-> FOO=BAR echo $env.FOO
+> FOO=BAR $env.FOO
 BAR
 ```
 
 You can also use [`with-env`](commands/with-env.html) to do the same thing more explicitly:
 
 ```
-> with-env { FOO: BAR } { echo $env.FOO }
+> with-env { FOO: BAR } { $env.FOO }
 BAR
 ```
 

--- a/book/hooks.md
+++ b/book/hooks.md
@@ -1,7 +1,7 @@
 # Hooks
 
 Hooks allow you to run a code snippet at some predefined situations.
-They are only available in the interactive mode ([REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)), they do not work if you run a Nushell with a script (`nu script.nu`) or commands (`nu -c "echo foo"`) arguments.
+They are only available in the interactive mode ([REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)), they do not work if you run a Nushell with a script (`nu script.nu`) or commands (`nu -c "print foo"`) arguments.
 
 Currently, we support these types of hooks:
 

--- a/book/nushell_map.md
+++ b/book/nushell_map.md
@@ -1,101 +1,74 @@
 # Nu map from other shells and domain specific languages
 
-The idea behind this table is to help you understand how Nu builtins and plugins relate to other known shells and domain specific languages. We've tried to produce a map of all the Nu commands and what their equivalents are in other languages. Contributions are welcome.
+The idea behind this table is to help you understand how Nu builtins and plugins relate to other known shells and domain specific languages. We've tried to produce a map of relevant Nu commands and what their equivalents are in other languages. Contributions are welcome.
 
 Note: this table assumes Nu 0.43 or later.
 
 
 | Nushell                | SQL                           | .Net LINQ (C#)                                       | PowerShell (without external modules)      | Bash                                            |
 | ---------------------- | ----------------------------- | ---------------------------------------------------- | ------------------------------------------ | ----------------------------------------------- |
-| alias                  |   -                           |   -                                                  | alias                                      | alias                                           |
-| append                 |   -                           | Append                                               | -Append                                    |                                                 |
-| args                   |   -                           |   -                                                  |                                            |                                                 |
-| autoview               |   -                           |   -                                                  |                                            |                                                 |
+| alias                  |                               |                                                      | alias                                      | alias                                           |
+| append                 |                               | Append                                               | -Append                                    |                                                 |
 | math avg               | avg                           | Average                                              | Measure-Object, measure                    |                                                 |
 | calc, `<math expression>` | math operators             | Aggregate, Average, Count, Max, Min, Sum             |                                            | bc                                              |
-| cd                     |   -                           |   -                                                  | Set-Location, cd                           | cd                                              |
-| clear                  |   -                           |   -                                                  | Clear-Host                                 | clear                                           |
-| compact                |                               |                                                      |                                            |                                                 |
-| config                 |   -                           |   -                                                  | $Profile                                   | vi .bashrc, .profile                            |
-| cp                     |   -                           |   -                                                  | Copy-Item, cp, copy                        | cp                                              |
+| cd                     |                               |                                                      | Set-Location, cd                           | cd                                              |
+| clear                  |                               |                                                      | Clear-Host                                 | clear                                           |
+| config                 |                               |                                                      | $Profile                                   | vi .bashrc, .profile                            |
+| cp                     |                               |                                                      | Copy-Item, cp, copy                        | cp                                              |
 | date                   | NOW() / getdate()             | DateTime class                                       | Get-Date                                   | date                                            |
-| debug                  |                               |                                                      |                                            |                                                 |
-| default                |                               |                                                      |                                            |                                                 |
-| drop                   |                               |                                                      |                                            |                                                 |
-| du                     |   -                           |   -                                                  |                                            | du                                              |
+| du                     |                               |                                                      |                                            | du                                              |
 | each                   | cursor                        |                                                      | ForEach-Object, foreach, for               |                                                 |
-| echo                   | print, union all              |   -                                                  | Write-Output, write                        | echo                                            |
-| enter                  |   -                           |   -                                                  |                                            |                                                 |
-| exit                   |   -                           |                                                      | exit                                       | exit                                            |
-| fetch                  |   -                           | HttpClient,WebClient, HttpWebRequest/Response        | Invoke-WebRequest                          | wget                                            |
+| exit                   |                               |                                                      | exit                                       | exit                                            |
+| fetch                  |                               | HttpClient,WebClient, HttpWebRequest/Response        | Invoke-WebRequest                          | wget                                            |
 | first                  | top, limit                    | First, FirstOrDefault                                | Select-Object -First                       | head                                            |
 | format                 |                               | String.Format                                        | String.Format                              |                                                 |
-| from                   | import flatfile, openjson, cast(variable as xml) |   -                               | Import/ConvertFrom-{Csv,Xml,Html,Json}     |                                                 |
+| from                   | import flatfile, openjson, cast(variable as xml) |                                   | Import/ConvertFrom-{Csv,Xml,Html,Json}     |                                                 |
 | get                    |                               | Select                                               | (cmd).column                               |                                                 |
 | group-by               | group by                      | GroupBy, group                                       | Group-Object, group                        |                                                 |
-| headers                |                               |                                                      |                                            |                                                 |
-| help                   | sp_help                       |   -                                                  | Get-Help, help, man                        | man                                             |
-| histogram              |   -                           |   -                                                  |                                            |                                                 |
-| history                |   -                           |   -                                                  | Get-History, history                       | history                                         |
-| inc(`*`)               |   -                           |                                                      |   -                                        |   -                                             |
+| help                   | sp_help                       |                                                      | Get-Help, help, man                        | man                                             |
+| history                |                               |                                                      | Get-History, history                       | history                                         |
 | is_empty               | is null                       | String.InNullOrEmpty                                 | String.InNullOrEmpty                       |                                                 |
-| keep, =take            | top, limit                    | Take                                                 | Select-Object -First                       | head                                            |
-| keep-until             |                               |                                                      |                                            |                                                 |
-| keep-while             |                               | TakeWhile                                            |                                            |                                                 |
-| kill                   |   -                           |   -                                                  | Stop-Process, kill                         | kill                                            |
+| kill                   |                               |                                                      | Stop-Process, kill                         | kill                                            |
 | last                   |                               | Last, LastOrDefault                                  | Select-Object -Last                        | tail                                            |
 | length                 | count                         | Count                                                | Measure-Object, measure                    | wc                                              |
-| lines                  |   -                           |   -                                                  | File.ReadAllLines                          |                                                 |
-| ls                     |   -                           |   -                                                  | Get-ChildItem, dir, ls                     | ls                                              |
-| match(`*`)             | case when                     | Regex.IsMatch                                        | [regex]                                    |                                                 |
-| merge                  |                               |                                                      |                                            |                                                 |
-| mkdir                  |   -                           |   -                                                  | mkdir, md                                  | mkdir                                           |
-| mv                     |   -                           |   -                                                  | Move-Item, mv, move, mi                    | mv                                              |
-| next                   |                               |                                                      |                                            |                                                 |
+| lines                  |                               |                                                      | File.ReadAllLines                          |                                                 |
+| ls                     |                               |                                                      | Get-ChildItem, dir, ls                     | ls                                              |
+| mkdir                  |                               |                                                      | mkdir, md                                  | mkdir                                           |
+| mv                     |                               |                                                      | Move-Item, mv, move, mi                    | mv                                              |
 | nth                    | limit x offset y, rownumber = | ElementAt                                            | [x], indexing operator, ElementAt          |                                                 |
 | open                   |                               |                                                      | Get-Content, gc, cat, type                 | cat                                             |
-| parse                  |                               |                                                      |                                            |                                                 |
-| transpose              | pivot                         |   -                                                  |                                            |                                                 |
-| post(`*`)              |   -                           | HttpClient,WebClient, HttpWebRequest/Response        | Invoke-WebRequest                          |                                                 |
-| prepend                |                               |                                                      |                                            |                                                 |
-| prev                   |                               |                                                      |                                            |                                                 |
-| ps(`*`)                |   -                           |   -                                                  | Get-Process, ps, gps                       | ps                                              |
-| pwd                    |   -                           |   -                                                  | Get-Location, pwd                          | pwd                                             |
+| print                  | print, union all              |                                                      | Write-Output, write                        | echo                                            |
+| transpose              | pivot                         |                                                      |                                            |                                                 |
+| ps                     |                               |                                                      | Get-Process, ps, gps                       | ps                                              |
+| pwd                    |                               |                                                      | Get-Location, pwd                          | pwd                                             |
 | range                  |                               | Range                                                | 1..10, 'a'..'f'                            |                                                 |
 | reduce                 |                               | Aggregate                                            |                                            |                                                 |
-| reject                 |                               |                                                      |                                            |                                                 |
-| rename                 |   -                           |   -                                                  | Rename-Item, ren, rni                      | mv                                              |
+| rename                 |                               |                                                      | Rename-Item, ren, rni                      | mv                                              |
 | reverse                |                               | Reverse                                              | [Array]::Reverse($var)                     |                                                 |
-| rm                     |   -                           |   -                                                  | Remove-Item, del, erase, rd, ri, rm, rmdir | rm                                              |
-| save                   |   -                           |   -                                                  | Write-Output, Out-File                     | > foo.txt                                       |
+| rm                     |                               |                                                      | Remove-Item, del, erase, rd, ri, rm, rmdir | rm                                              |
+| save                   |                               |                                                      | Write-Output, Out-File                     | > foo.txt                                       |
 | select                 | select                        | Select                                               | Select-Object, select                      |                                                 |
-| shells                 |   -                           |   -                                                  |   -                                        |                                                 |
-| shuffle                |                               | Random                                               | Sort-Object {Get-Random}                   |   -                                             |
+| shuffle                |                               | Random                                               | Sort-Object {Get-Random}                   |                                                 |
 | size                   |                               |                                                      | Measure-Object, measure                    | wc                                              |
 | skip                   | where row_number()            | Skip                                                 | Select-Object -Skip                        |                                                 |
-| skip until             |                               |                                                      |                                            |                                                 |
+| skip until             |                               | SkipWhile                                            |                                            |                                                 |
 | skip while             |                               | SkipWhile                                            |                                            |                                                 |
 | sort-by                | order by                      | OrderBy, OrderByDescending, ThenBy, ThenByDescending | Sort-Object, sort                          |                                                 |
 | split-by               |                               | Split                                                | Split                                      |                                                 |
-| split column           |                               |   -                                                  |                                            |                                                 |
-| split row              |                               |   -                                                  |                                            |                                                 |
-| str(`*`)               | string functions              | String class                                         | String class                               |                                                 |
-| str join            | concat_ws                     | Join                                                 | Join-String                                |                                                 |
+| str                    | string functions              | String class                                         | String class                               |                                                 |
+| str join               | concat_ws                     | Join                                                 | Join-String                                |                                                 |
 | str trim               | rtrim, ltrim                  | Trim, TrimStart, TrimEnd                             | Trim                                       |                                                 |
 | sum                    | sum                           | Sum                                                  | Measure-Object, measure                    |                                                 |
-| sys(`*`)               |   -                           |   -                                                  | Get-ComputerInfo                           | uname, lshw, lsblk, lscpu, lsusb, hdparam, free |
+| sys                    |                               |                                                      | Get-ComputerInfo                           | uname, lshw, lsblk, lscpu, lsusb, hdparam, free |
 | table                  |                               |                                                      | Format-Table, ft, Format-List, fl          |                                                 |
-| tags                   |   -                           |   -                                                  |   -                                        |                                                 |
-| textview(`*`)          |   -                           |   -                                                  | Get-Content, cat                           |                                                 |
-| tree(`*`)              |   -                           |   -                                                  | tree                                       |                                                 |
-| to                     |   -                           |   -                                                  | Export/ConvertTo-{Csv,Xml,Html,Json}       |                                                 |
-| touch                  |   -                           |   -                                                  | Set-Content                                | touch                                           |
+| take                   | top, limit                    | Take                                                 | Select-Object -First                       | head                                            |
+| take until             |                               | TakeWhile                                            |                                            |                                                 |
+| take while             |                               | TakeWhile                                            |                                            |                                                 |
+| to                     |                               |                                                      | Export/ConvertTo-{Csv,Xml,Html,Json}       |                                                 |
+| touch                  |                               |                                                      | Set-Content                                | touch                                           |
 | uniq                   | distinct                      | Distinct                                             | Get-Unique, gu                             | uniq                                            |
-| upsert                 | As                            |   -                                                  |                                            |                                                 |
-| version                | select @@version              |   -                                                  | $PSVersionTable                            |                                                 |
-| with_env               |   -                           |   -                                                  | $env:FOO = 'bar'                           | export foo = "bar"                              |
+| upsert                 | As                            |                                                      |                                            |                                                 |
+| version                | select @@version              |                                                      | $PSVersionTable                            |                                                 |
+| with_env               |                               |                                                      | $env:FOO = 'bar'                           | export foo = "bar"                              |
 | where                  | where                         | Where                                                | Where-Object, where, "?" operator          |                                                 |
-| which                  |   -                           |   -                                                  |   -                                        | which                                           |
-| wrap                   |                               |                                                      |                                            |                                                 |
-
-* `*` - these commands are part of the standard plugins
+| which                  |                               |                                                      |                                            | which                                           |

--- a/book/nushell_map_functional.md
+++ b/book/nushell_map_functional.md
@@ -1,103 +1,47 @@
 # Nu map from functional languages
 
-The idea behind this table is to help you understand how Nu builtins and plugins relate to functional languages. We've tried to produce a map of all the Nu commands and what their equivalents are in other languages. Contributions are welcome.
+The idea behind this table is to help you understand how Nu builtins and plugins relate to functional languages. We've tried to produce a map of relevant Nu commands and what their equivalents are in other languages. Contributions are welcome.
 
 Note: this table assumes Nu 0.43 or later.
 
 | Nushell                   | Clojure                      | Tablecloth (Ocaml / Elm)        | Haskell                  |     |
 | ------------------------- | ---------------------------- | ------------------------------- | ------------------------ | --- |
-| alias                     |                              |                                 |                          |     |
 | append                    | conj, into, concat           | append, (++), concat, concatMap | (++)                     |     |
-| args                      |                              |                                 |                          |     |
-| autoview                  |                              |                                 |                          |     |
-| math avg                  |                              |                                 |                          |     |
 | into binary               | Integer/toHexString          |                                 | showHex                  |     |
-| calc, `<math expression>` | math operators               |                                 |                          |     |
-| cd                        |                              |                                 |                          |     |
-| clear                     |                              |                                 |                          |     |
-| clip                      |                              |                                 |                          |     |
-| compact                   |                              |                                 |                          |     |
-| config                    |                              |                                 |                          |     |
 | count                     | count                        | length, size                    | length, size             |     |
-| cp                        |                              |                                 |                          |     |
 | date                      | java.time.LocalDate/now      |                                 |                          |     |
-| debug                     |                              |                                 |                          |     |
-| default                   |                              |                                 |                          |     |
-| drop                      |                              |                                 |                          |     |
-| du                        |                              |                                 |                          |     |
 | each                      | map, mapv, iterate           | map, forEach                    | map, mapM                |     |
-| echo                      | println                      |                                 | putStrLn, print          |     |
-| enter                     |                              |                                 |                          |     |
 | exit                      | System/exit                  |                                 |                          |     |
-| fetch(`*`)                |                              |                                 |                          |     |
 | first                     | first                        | head                            | head                     |     |
 | format                    | format                       |                                 | Text.Printf.printf       |     |
-| from                      |                              |                                 |                          |     |
-| get                       |                              |                                 |                          |     |
 | group-by                  | group-by                     |                                 | group, groupBy           |     |
-| headers                   |                              |                                 |                          |     |
 | help                      | doc                          |                                 |                          |     |
-| histogram                 |                              |                                 |                          |     |
-| history                   |                              |                                 |                          |     |
-| inc(`*`)                  | inc                          |                                 | succ                     |     |
-| insert                    |                              |                                 |                          |     |
 | is-empty                  | empty?                       | isEmpty                         |                          |     |
-| keep                      | take, drop-last, pop         | take, init                      | take, init               |     |
-| keep-until                |                              |                                 |                          |     |
-| keep-while                | take-while                   | takeWhile                       | takeWhile                |     |
-| kill                      |                              |                                 |                          |     |
 | last                      | last, peek, take-last        | last                            | last                     |     |
 | lines                     |                              |                                 | lines, words, split-with |     |
-| ls                        |                              |                                 |                          |     |
-| match(`*`)                | re-matches, re-seq, re-find  |                                 |                          |     |
-| merge                     |                              |                                 |                          |     |
-| mkdir                     |                              |                                 |                          |     |
-| mv                        |                              |                                 |                          |     |
-| next                      |                              |                                 |                          |     |
-| nth                       | nth                          | Array.get                       | lookup                   |     |
+| match                     | re-matches, re-seq, re-find  |                                 |                          |     |
+ nth                       | nth                          | Array.get                       | lookup                   |     |
 | open                      | with-open                    |                                 |                          |     |
-| parse                     |                              |                                 |                          |     |
 | transpose                 | (apply mapv vector matrix)   |                                 | transpose                |     |
-| post(`*`)                 |                              |                                 |                          |     |
 | prepend                   | cons                         | cons, ::                        | ::                       |     |
-| prev                      |                              |                                 |                          |     |
-| ps                        |                              |                                 |                          |     |
-| pwd                       |                              |                                 |                          |     |
+| print                     | println                      |                                 | putStrLn, print          |     |
 | range, 1..10              | range                        | range                           | 1..10, 'a'..'f'          |     |
 | reduce                    | reduce, reduce-kv            | foldr                           | foldr                    |     |
-| reject                    |                              |                                 |                          |     |
-| rename                    |                              |                                 |                          |     |
 | reverse                   | reverse, rseq                | reverse, reverseInPlace         | reverse                  |     |
-| rm                        |                              |                                 |                          |     |
-| save                      |                              |                                 |                          |     |
 | select                    | select-keys                  |                                 |                          |     |
-| shells                    |                              |                                 |                          |     |
 | shuffle                   | shuffle                      |                                 |                          |     |
 | size                      | count                        |                                 | size, length             |     |
 | skip                      | rest                         | tail                            | tail                     |     |
-| skip until                |                              |                                 |                          |     |
+| skip until                | drop-while                   |                                 |                          |     |
 | skip while                | drop-while                   | dropWhile                       | dropWhile, dropWhileEnd  |     |
 | sort-by                   | sort, sort-by, sorted-set-by | sort, sortBy, sortWith          | sort, sortBy             |     |
-| split-by                  | split, split-{at,with,lines} | split, words, lines             | split, words, lines      |     |
-| split column              |                              |                                 |                          |     |
-| split row                 |                              |                                 |                          |     |
-| str(`*`)                  | clojure.string functions     | String functions                |                          |     |
-| str join               | join                         | concat                          | intercalate              |     |
+| split row                 | split, split-{at,with,lines} | split, words, lines             | split, words, lines      |     |
+| str                       | clojure.string functions     | String functions                |                          |     |
+| str join                  | join                         | concat                          | intercalate              |     |
 | str trim                  | trim, triml, trimr           | trim, trimLeft, trimRight       | strip                    |     |
 | sum                       | apply +                      | sum                             | sum                      |     |
-| sys                       |                              |                                 |                          |     |
-| table                     |                              |                                 |                          |     |
-| tags                      |                              |                                 |                          |     |
-| tree(`*`)                 |                              |                                 |                          |     |
-| to                        |                              |                                 |                          |     |
-| touch                     |                              |                                 |                          |     |
+| take                      | take, drop-last, pop         | take, init                      | take, init               |     |
+| take until                | take-while                   | takeWhile                       | takeWhile                |     |
+| take while                | take-while                   | takeWhile                       | takeWhile                |     |
 | uniq                      | set                          | Set.empty                       | Data.Set                 |     |
-| upsert                    |                              |                                 |                          |     |
-| version                   |                              |                                 |                          |     |
-| with_env                  |                              |                                 |                          |     |
-| what                      |                              |                                 |                          |     |
 | where                     | filter, filterv, select      | filter, filterMap               | filter                   |     |
-| which                     |                              |                                 |                          |     |
-| wrap                      |                              |                                 |                          |     |
-
-- `*` - these commands are part of the standard plugins

--- a/book/nushell_map_imperative.md
+++ b/book/nushell_map_imperative.md
@@ -1,101 +1,77 @@
 # Nu map from imperative languages
 
-The idea behind this table is to help you understand how Nu built-ins and plugins relate to imperative languages. We've tried to produce a map of all the Nu commands and what their equivalents are in other languages. Contributions are welcome.
+The idea behind this table is to help you understand how Nu built-ins and plugins relate to imperative languages. We've tried to produce a map of programming-relevant Nu commands and what their equivalents are in other languages. Contributions are welcome.
 
 Note: this table assumes Nu 0.43 or later.
 
 | Nushell      | Python                        | Kotlin (Java)                                       | C++                     | Rust                                          |
 | ------------ | ----------------------------- | --------------------------------------------------- | ----------------------- | --------------------------------------------- |
-| alias        |                               |                                                     |                         |                                               |
 | append       | list.append, set.add          | add                                                 | push_back, emplace_back | push, push_back                               |
-| args         |                               |                                                     |                         |                                               |
-| autoview     |                               |                                                     |                         |                                               |
 | math avg     | statistics.mean               |                                                     |                         |                                               |
 | calc, = math | math operators                | math operators                                      | math operators          | math operators                                |
-| cd           |                               |                                                     |                         |                                               |
-| clear        |                               |                                                     |                         |                                               |
-| clip         |                               |                                                     |                         |                                               |
-| compact      |                               |                                                     |                         |                                               |
-| config       |                               |                                                     |                         |                                               |
 | count        | len                           | size, length                                        | length                  | len                                           |
 | cp           | shutil.copy                   |                                                     |                         |                                               |
 | date         | datetime.date.today           | java.time.LocalDate.now                             |                         |                                               |
-| debug        |                               |                                                     |                         |                                               |
-| default      |                               |                                                     |                         |                                               |
-| drop         |                               |                                                     |                         |                                               |
+| drop         | list[:-3]                     |                                                     |                         |                                               |
 | du           | shutil.disk_usage             |                                                     |                         |                                               |
 | each         | for                           | for                                                 | for                     | for                                           |
-| echo         | print                         | println                                             | printf                  | println!                                      |
-| enter        |                               |                                                     |                         |                                               |
 | exit         | exit                          | System.exit, kotlin.system.exitProcess              | exit                    | exit                                          |
 | fetch        | urllib.request.urlopen        |                                                     |                         |                                               |
-| first        | list[0]                       | List[0], peek                                       | vector[0], top          | Vec[0]                                        |
+| first        | list[:x]                      | List[0], peek                                       | vector[0], top          | Vec[0]                                        |
 | format       | format                        | format                                              | format                  | format!                                       |
 | from         | csv, json, sqlite3            |                                                     |                         |                                               |
 | get          | dict[\"key\"]                 | Map[\"key\"]                                        | map[\"key\"]            | HashMap["key"], get, entry                    |
 | group-by     | itertools.groupby             | groupBy                                             |                         | group_by                                      |
-| headers      |                               |                                                     |                         |                                               |
+| headers      | keys                          |                                                     |                         |                                               |
 | help         | help                          |                                                     |                         |                                               |
-| histogram    |                               |                                                     |                         |                                               |
-| history      |                               |                                                     |                         |                                               |
-| inc(`*`)     | x += 1                        | x++                                                 | x++                     | x += 1                                        |
-| insert       | list.insert                   |                                                     |                         |                                               |
-| is-empty     | is None                       | isEmpty                                             | empty                   | is_empty                                      |
-| keep         | list[:x]                      |                                                     |                         | &Vec[..x]                                     |
-| keep until   |                               |                                                     |                         |                                               |
-| keep while   | itertools.takewhile           |                                                     |                         |                                               |
+| insert       | dict[\"key\"] = val           |                                                     |                         |                                               |
+| is-empty     | is None, is []                | isEmpty                                             | empty                   | is_empty                                      |
+| take         | list[:x]                      |                                                     |                         | &Vec[..x]                                     |
+| take until   | itertools.takewhile           |                                                     |                         |                                               |
+| take while   | itertools.takewhile           |                                                     |                         |                                               |
 | kill         | os.kill                       |                                                     |                         |                                               |
-| last         | list[-1]                      |                                                     |                         | &Vec[Vec.len()-1]                             |
+| last         | list[-x:]                     |                                                     |                         | &Vec[Vec.len()-1]                             |
 | lines        | split, splitlines             | split                                               | views::split            | split, split_whitespace, rsplit, lines        |
 | ls           | os.listdir                    |                                                     |                         |                                               |
-| match(`*`)   | re.findall                    | Regex.matches                                       | regex_match             |                                               |
-| merge        |                               |                                                     |                         |                                               |
+| match        | re.findall                    | Regex.matches                                       | regex_match             |                                               |
+| merge        | dict.append                   |                                                     |                         |                                               |
 | mkdir        | os.mkdir                      |                                                     |                         |                                               |
 | mv           | shutil.move                   |                                                     |                         |                                               |
-| next         |                               |                                                     |                         |                                               |
-| nth          | list[x]                       | List[x]                                             | vector[x]               | Vec[x]                                        |
+| get          | list[x]                       | List[x]                                             | vector[x]               | Vec[x]                                        |
 | open         | open                          |                                                     |                         |                                               |
-| parse        |                               |                                                     |                         |                                               |
 | transpose    | zip(\*matrix)                 |                                                     |                         |                                               |
-| post(`*`)    | urllib.request.urlopen        |                                                     |                         |                                               |
+| post         | urllib.request.urlopen        |                                                     |                         |                                               |
 | prepend      | deque.appendleft              |                                                     |                         |                                               |
-| prev         |                               |                                                     |                         |                                               |
-| ps(`*`)      | os.listdir('/proc')           |                                                     |                         |                                               |
+| print        | print                         | println                                             | printf                  | println!                                      |
+| ps           | os.listdir('/proc')           |                                                     |                         |                                               |
 | pwd          | os.getcwd                     |                                                     |                         |                                               |
 | range        | range                         | .., until, downTo, step                             | iota                    | ..                                            |
 | reduce       | functools.reduce              | reduce                                              | reduce                  | fold, rfold, scan                             |
-| reject       |                               |                                                     |                         |                                               |
+| reject       | del                           |                                                     |                         |                                               |
 | rename       | shutil.move                   |                                                     |                         |                                               |
 | reverse      | reversed, list.reverse        | reverse, reversed, asReversed                       | reverse                 | rev                                           |
 | rm           | os.remove                     |                                                     |                         |                                               |
 | save         | io.TextIOWrapper.write        |                                                     |                         |                                               |
-| select       | {k:dict[k] for k in keylist}  |                                                     |                         |                                               |
-| shells       |                               |                                                     |                         |                                               |
+| select       | {k:dict[k] for k in keys}     |                                                     |                         |                                               |
 | shuffle      | random.shuffle                |                                                     |                         |                                               |
 | size         | len                           |                                                     |                         |                                               |
 | skip         | list[x:]                      |                                                     |                         | &Vec[x..],skip                                |
-| skip until   |                               |                                                     |                         |                                               |
+| skip until   | itertools.dropwhile           |                                                     |                         |                                               |
 | skip while   | itertools.dropwhile           |                                                     |                         | skip_while                                    |
 | sort-by      | sorted, list.sort             | sortedBy, sortedWith, Arrays.sort, Collections.sort | sort                    | sort                                          |
-| split-by     | str.split{,lines}, re.split   | split                                               | views::split            | split                                         |
-| split column |                               |                                                     |                         |                                               |
-| split row    |                               |                                                     |                         |                                               |
-| str(`*`)     | str functions                 | String functions                                    | string functions        | &str, String functions                        |
-| str join  | str.join                      | joinToString                                        |                         | join                                          |
+| split row    | str.split{,lines}, re.split   | split                                               | views::split            | split                                         |
+| str          | str functions                 | String functions                                    | string functions        | &str, String functions                        |
+| str join     | str.join                      | joinToString                                        |                         | join                                          |
 | str trim     | strip, rstrip, lstrip         | trim, trimStart, trimEnd                            | regex                   | trim, trim*{start,end}, strip*{suffix,prefix} |
 | sum          | sum                           | sum                                                 | reduce                  | sum                                           |
-| sys(`*`)     | sys                           |                                                     |                         |                                               |
-| table        |                               |                                                     |                         |                                               |
-| tags         |                               |                                                     |                         |                                               |
-| tree(`*`)    |                               |                                                     |                         |                                               |
-| to           | csv, json, sqlite3            |                                                     |                         |                                               |
+| sys          | sys                           |                                                     |                         |                                               |
+| to           | import csv, json, sqlite3     |                                                     |                         |                                               |
 | touch        | open(path, 'a').close()       |                                                     |                         |                                               |
 | uniq         | set                           | Set                                                 | set                     | HashSet                                       |
-| upsert       |                               |                                                     |                         |                                               |
+| upsert       | dict[\"key\"] = val           |                                                     |                         |                                               |
 | version      | sys.version, sys.version_info |                                                     |                         |                                               |
 | with-env     | os.environ                    |                                                     |                         |                                               |
 | where        | filter                        | filter                                              | filter                  | filter                                        |
 | which        | shutil.which                  |                                                     |                         |                                               |
-| wrap         |                               |                                                     |                         |                                               |
+| wrap         | { "key" : val }               |                                                     |                         |                                               |
 
-- `*` - these commands are part of the standard plugins

--- a/book/pipelines.md
+++ b/book/pipelines.md
@@ -19,7 +19,7 @@ The last command, `save "Cargo_new.toml"`, is an output (sometimes called a "sin
 The `$in` variable will collect the pipeline into a value for you, allowing you to access the whole stream as a parameter:
 
 ```nushell
-> echo 1 2 3 | $in.1 * $in.2
+> [1 2 3] | $in.1 * $in.2
 6
 ```
 

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -17,7 +17,7 @@ Let's look at an example script file:
 ```
 # myscript.nu
 def greet [name] {
-  echo "hello" $name
+  ["hello" $name]
 }
 
 greet "world"
@@ -31,7 +31,7 @@ In the above, first `greet` is defined by the Nushell interpreter. This allows u
 greet "world"
 
 def greet [name] {
-  echo "hello" $name
+  ["hello" $name]
 }
 ```
 
@@ -79,7 +79,7 @@ On Linux and macOS you can optionally use a [shebang](<https://en.wikipedia.org/
 
 ```
 #!/usr/bin/env nu
-echo "Hello World!"
+"Hello World!"
 ```
 
 ```

--- a/book/stdout_stderr_exit_codes.md
+++ b/book/stdout_stderr_exit_codes.md
@@ -34,7 +34,7 @@ Nushell tracks the last exit code of the recently completed external in one of t
 
 ```
 > do -i { external }
-> echo $env.LAST_EXIT_CODE
+> $env.LAST_EXIT_CODE
 ```
 
 The second uses a command called [`complete`](commands/complete.md).

--- a/book/thinking_in_nu.md
+++ b/book/thinking_in_nu.md
@@ -16,17 +16,17 @@ Nushell, for example, also has support for other common capabilities like gettin
 
 While it does have these amenities, Nushell isn't bash. The bash way of working, and the POSIX style in general, is not one that Nushell supports. For example, in bash, you might use:
 
-```
+```sh
 > echo "hello" > output.txt
 ```
 
 In Nushell, we use the `>` as the greater-than operator. This fits better with the language aspect of Nushell. Instead, you pipe to a command that has the job of saving content:
 
 ```
-> echo "hello" | save output.txt
+> "hello" | save output.txt
 ```
 
-**Thinking in Nushell:** The way Nushell views data is that data flows through the pipeline until it reaches the user or is handled by a final command. Nushell uses commands to do work. Learning these commands and when to use them helps you compose many kinds of pipelines.
+**Thinking in Nushell:** The way Nushell views data is that data flows through the pipeline until it reaches the user or is handled by a final command. You can simply type data, from strings to JSON-style lists and records, and follow it with `|` to send it through the pipeline. Nushell uses commands to do work and produce more data. Learning these commands and when to use them helps you compose many kinds of pipelines.
 
 ## Think of Nushell as a compiled language
 
@@ -35,7 +35,7 @@ An important part of Nushell's design and specifically where it differs from man
 For example, the following doesn't make sense in Nushell, and will fail to execute if run as a script:
 
 ```
-echo "def abc [] { 1 + 2 }" | save output.nu
+"def abc [] { 1 + 2 }" | save output.nu
 source "output.nu"
 abc
 ```

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -42,7 +42,7 @@ A string of characters that represents text. There are a few ways these can be c
   - `$"6 x 7 = (6 * 7)"`
   - `ls | each { |it| $"($it.name) is ($it.size)" }`
 - Bare strings
-  - `hello`
+  - `"hello"`
 
 See [Working with strings](working_with_strings.md) and [Handling Strings](https://www.nushell.sh/book/loading_data.html#handling-strings) for details.
 

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -42,7 +42,7 @@ A string of characters that represents text. There are a few ways these can be c
   - `$"6 x 7 = (6 * 7)"`
   - `ls | each { |it| $"($it.name) is ($it.size)" }`
 - Bare strings
-  - `echo hello`
+  - `hello`
 
 See [Working with strings](working_with_strings.md) and [Handling Strings](https://www.nushell.sh/book/loading_data.html#handling-strings) for details.
 
@@ -171,7 +171,7 @@ Structured data builds from the simple data. For example, instead of a single in
 Records hold key-value pairs, much like objects in JSON. As these can sometimes have many fields, a record is printed up-down rather than left-right:
 
 ```
-> echo {name: sam, rank: 10}
+> {name: sam, rank: 10}
 ╭──────┬─────╮
 │ name │ sam │
 │ rank │ 10  │
@@ -181,7 +181,7 @@ Records hold key-value pairs, much like objects in JSON. As these can sometimes 
 You can iterate over records by first transposing it into a table:
 
 ```
-> echo {name: sam, rank: 10} | transpose key value
+> {name: sam, rank: 10} | transpose key value
 ╭───┬──────┬───────╮
 │ # │ key  │ value │
 ├───┼──────┼───────┤
@@ -197,7 +197,7 @@ Lists can hold more than one value. These can be simple values. They can also ho
 Example: a list of strings
 
 ```
-> echo [sam fred george]
+> [sam fred george]
 ───┬────────
  0 │ sam
  1 │ fred
@@ -212,7 +212,7 @@ The table is a core data structure in Nushell. As you run commands, you'll see t
 We can create our own tables similarly to how we create a list. Because tables also contain columns and not just values, we pass in the name of the column values:
 
 ```
-> echo [[column1, column2]; [Value1, Value2]]
+> [[column1, column2]; [Value1, Value2]]
 ───┬─────────┬─────────
  # │ column1 │ column2
 ───┼─────────┼─────────
@@ -223,7 +223,7 @@ We can create our own tables similarly to how we create a list. Because tables a
 We can also create a table with multiple rows of data:
 
 ```
-> echo [[column1, column2]; [Value1, Value2] [Value3, Value4]]
+> [[column1, column2]; [Value1, Value2] [Value3, Value4]]
 ───┬─────────┬─────────
  # │ column1 │ column2
 ───┼─────────┼─────────
@@ -235,7 +235,7 @@ We can also create a table with multiple rows of data:
 You can also create a table as a list of records:
 
 ```
-> echo [{name: sam, rank: 10}, {name: bob, rank: 7}]
+> [{name: sam, rank: 10}, {name: bob, rank: 7}]
 ╭───┬──────┬──────╮
 │ # │ name │ rank │
 ├───┼──────┼──────┤
@@ -251,6 +251,6 @@ Column paths are a path through the table to a specific sub-table, column, row, 
 
 ## Blocks
 
-Blocks represent a block of code in Nu. For example, in the command `each { |it| echo $it }` the block is the portion contained in curly braces, `{ |it| echo $it }`. Block parameters are specified between a pair of pipe symbols (for example, `|it|`) if necessary.
+Blocks represent a block of code in Nu. For example, in the command `each { |it| print $it }` the block is the portion contained in curly braces, `{ |it| print $it }`. Block parameters are specified between a pair of pipe symbols (for example, `|it|`) if necessary. You can also use `$in` in most blocks instead of providing a parameter: `each { print $in }`
 
-Blocks are a useful way to represent code that can be executed on each row of data. It is idiomatic to use `$it` as a parameter name in [`each`](commands/each.md) blocks, but not required; `each { |x| echo $x }` works the same way as `each { |it| echo $it }`.
+Blocks are a useful way to represent code that can be executed on each row of data. It is idiomatic to use `$it` as a parameter name in [`each`](commands/each.md) blocks, but not required; `each { |x| print $x }` works the same way as `each { |it| print $it }`.

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -42,7 +42,8 @@ A string of characters that represents text. There are a few ways these can be c
   - `$"6 x 7 = (6 * 7)"`
   - `ls | each { |it| $"($it.name) is ($it.size)" }`
 - Bare strings
-  - `"hello"`
+  - `print hello`
+  - `[foo bar baz]`
 
 See [Working with strings](working_with_strings.md) and [Handling Strings](https://www.nushell.sh/book/loading_data.html#handling-strings) for details.
 

--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -10,7 +10,7 @@ If we create a variable, we can print its contents by using `$` to refer to it:
 
 ```
 > let my_value = 4
-> echo $my_value
+> $my_value
 4
 ```
 
@@ -19,9 +19,9 @@ They can be shadowed in nested block, that results in:
 
 ```
 > let my_value = 4
-> do { let my_value = 5; echo $my_value }
+> do { let my_value = 5; $my_value }
 5
-> echo $my_value
+> $my_value
 4
 ```
 
@@ -36,7 +36,7 @@ A variable path works by reaching inside of the contents of a variable, navigati
 We can use a variable path to evaluate the variable `$my_value` and get the value from the `name` column in a single step:
 
 ```
-> echo $my_value.name
+> $my_value.name
 testuser
 ```
 
@@ -50,7 +50,7 @@ Subexpressions can also be pipelines and not just single commands. If we wanted 
 
 ```
 > let names_of_big_files = (ls | where size > 10kb)
-> echo $names_of_big_files
+> $names_of_big_files
 ───┬────────────┬──────┬──────────┬──────────────
  # │    name    │ type │   size   │   modified
 ───┼────────────┼──────┼──────────┼──────────────
@@ -70,7 +70,7 @@ Subexpressions also support paths. For example, let's say we wanted to get a lis
 We can do a very similar action in a single step using a subexpression path:
 
 ```
-> echo (ls).name
+> (ls).name
 ```
 
 It depends on the needs of the code and your particular style which form works best for you.
@@ -97,7 +97,7 @@ For short-hand syntax to work, the column name must appear on the left-hand side
 You may find something strange when you're using subexpression with external commands, for example:
 
 ```
-> echo $"my pwd is (pwd), hooray!"
+> $"my pwd is (pwd), hooray!"
 ```
 
 And nu gives you the following output:
@@ -110,7 +110,7 @@ my pwd is /private/tmp
 That's because when you execute `(pwd)`, it yields to `/private/tmp\n`, and the value is inserted into our string, so the raw string will be `my pwd is /private/tmp\n, hooray!`, and then `\n` is a newline character.  A work around can be put `str trim` after external command, like this:
 
 ```
-> echo $"my pwd is (pwd | str trim), hooray!"
+> $"my pwd is (pwd | str trim), hooray!"
 ```
 
 Then everything will be normal.

--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -34,7 +34,7 @@ $colors # [red yellow green purple]
 ## Iterating over lists
 
 To iterate over the items in a list, use the [`each`](commands/each.md) command with a [block](types_of_data.html#blocks)
-of Nu code that specifies what to do to each item. The block parameter (e.g. `|it|` in `{ |it| echo $it }`) is normally the current list item, but the `--numbered` (`-n`) flag can change it to have `index` and `item` values if needed. For example:
+of Nu code that specifies what to do to each item. The block parameter (e.g. `|it|` in `{ |it| print $it }`) is normally the current list item, but the `--numbered` (`-n`) flag can change it to have `index` and `item` values if needed. For example:
 
 ```bash
 let names = [Mark Tami Amanda Jeremy]
@@ -71,11 +71,11 @@ For example:
 
 ```bash
 let scores = [3 8 4]
-echo $"total = ($scores | reduce { |it, acc| $acc + $it })" # total = 15
+$"total = ($scores | reduce { |it, acc| $acc + $it })" # total = 15
 
-echo $"total = ($scores | math sum)" # easier approach, same result
+$"total = ($scores | math sum)" # easier approach, same result
 
-echo $"product = ($scores | reduce --fold 1 { |it, acc| $acc * $it })" # total = 96
+$"product = ($scores | reduce --fold 1 { |it, acc| $acc * $it })" # total = 96
 
 $scores | reduce -n { |it, acc| $acc.item + $it.index * $it.item } # 3 + 1*8 + 2*4 = 19
 ```

--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -46,15 +46,15 @@ Nushell currently supports the following escape characters:
 
 Like other shell languages (but unlike most other programming languages) strings can also be written without any quotes:
 ```sh
-> echo hello
+> hello
 hello
 ```
 
-Be careful though, some bare words have special meaning in nu and so will not be interpreted as a string:
+Be careful though - some bare words have special meaning in nu and so will not be interpreted as a string:
 ```
-> echo true | describe
+> true | describe
 bool
-> echo trueX | describe
+> trueX | describe
 string
 ```
 So, while bare strings are useful for informal command line usage, when programming more formally in nu you should generally use quotes.

--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -44,20 +44,47 @@ Nushell currently supports the following escape characters:
 
 ## Bare strings
 
-Like other shell languages (but unlike most other programming languages) strings can also be written without any quotes:
+Like other shell languages (but unlike most other programming languages) strings consisting of a single 'word' can also be written without any quotes:
 ```sh
-> hello
+> print hello
 hello
+> [hello] | describe
+list<string>
+```
+But be careful - if you use a bare word plainly on the command line (that is, not inside a data structure or used as a command parameter) or inside round brackets `(` `)`, it will be interpreted as an external command:
+```
+> hello
+Error: nu::shell::external_command
+
+  × External command failed
+   ╭─[entry #5:1:1]
+ 1 │ hello
+   · ──┬──
+   ·   ╰── executable was not found
+   ╰────
+  help: program not found
 ```
 
-Be careful though - some bare words have special meaning in nu and so will not be interpreted as a string:
+Also, many bare words have special meaning in nu, and so will not be interpreted as a string:
 ```
 > true | describe
 bool
+> [true] | describe
+list<bool>
+> [trueX] | describe
+list<string>
 > trueX | describe
-string
+Error: nu::shell::external_command
+
+  × External command failed
+   ╭─[entry #5:1:1]
+ 1 │ trueX | describe
+   · ──┬──
+   ·   ╰── executable was not found
+   ╰────
+  help: program not found
 ```
-So, while bare strings are useful for informal command line usage, when programming more formally in nu you should generally use quotes.
+So, while bare strings are useful for informal command line usage, when programming more formally in nu, you should generally use quotes.
 
 
 ## String interpolation

--- a/contributor-book/plugins.md
+++ b/contributor-book/plugins.md
@@ -247,7 +247,7 @@ If you're already running `nu` during the installation process of your plugin, e
 
 ```
 > nu
-> echo hello | len
+> hello | len
 5
 > help len
 This is my custom len plugin


### PR DESCRIPTION
Basically none of the given examples actually need `echo`, and they are improved by shortening them or replacing them with bare list `[ ]` syntax.

Also improved readability/accuracy of language comparison tables:

 * "All commands" text changed to "relevant commands".
 * Removed commands were removed.
 * Commands with no data in the other columns were removed due to having no relevant information and making the table needlessly long.
 * Some other rows were amended based on my limited experience.