### PR TITLE
Fix let-env Path example to be accurate for Windows

### DIFF
--- a/book/environment.md
+++ b/book/environment.md
@@ -38,7 +38,7 @@ Using the `let-env` command is the most straightforward method
 So, if you want to extend the Windows `Path` variable, for example, you could do that as follows.
 
 ```
-let-env Path = ($env.Path | prepend '\path\you\want\to\add')
+let-env Path = ($env.Path | prepend 'C:\path\you\want\to\add')
 ```
 
 Here we've prepended our folder to the existing folders in the Path, so it will have the highest priority.

--- a/book/environment.md
+++ b/book/environment.md
@@ -33,15 +33,15 @@ Using the `let-env` command is the most straightforward method
 > let-env FOO = 'BAR'
 ```
 
-'let-env' is similar to the **export** command in bash.
+'let-env' is similar to the **export** command in Bash.
 
-So if you want to extend the `PATH` variable for example, you could do that as follows.
+So, if you want to extend the Windows `Path` variable, for example, you could do that as follows.
 
 ```
-let-env PATH = ($env.PATH | prepend '/path/you/want/to/add')
+let-env Path = ($env.Path | prepend '\path\you\want\to\add')
 ```
 
-Here we've prepended our folder to the existing folders in the PATH, so it will have the highest priority.
+Here we've prepended our folder to the existing folders in the Path, so it will have the highest priority.
 If you want to give it the lowest priority instead, you can use the `append` command.
 
 ### [`load-env`](commands/load-env.html)


### PR DESCRIPTION
Closes https://github.com/nushell/nushell/issues/6733

I understand I could have reworded this to make it clear it works for POSIX only, but I decided to go with this instead because Windows capitalisation is a bit counterintuitive and could do with clarification more.