### PR TITLE
Fix variable path expression example

### DIFF
--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -36,7 +36,7 @@ A variable path works by reaching inside of the contents of a variable, navigati
 We can use a variable path to evaluate the variable `$my_value` and get the value from the `name` column in a single step:
 
 ```
-> $my_value.name
+> $my_value.name.0
 testuser
 ```
 


### PR DESCRIPTION
Hello! I'm learning nushell with the book and I'm blown away so far.

I ran this example code and it seems to me `$my_value.name` returns that column as a list. `.0` is required to get the first element and the desired output.