### PR TITLE
Fix tip boxes in `book/custom_commands.md`

### DIFF
--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -14,6 +14,7 @@ def greet [name] {
 
 ::: tip
 The value produced by the last line of a command becomes the command's returned value. In this case, a list containing the string `'hello'` and `$name` is returned.
+:::
 
 In this definition, we define the `greet` command, which takes a single parameter `name`. Following this parameter is the block that represents what will happen when the custom command runs. When called, the custom command will set the value passed for `name` as the `$name` variable, which will be available to the block.
 
@@ -309,6 +310,7 @@ greet earth mars jupiter venus
 
 ::: tip
 Each line of a command has its resulting value printed out when run, as long as it isn't `null`. Hence, `"hello all:"` above will be printed out despite not being the return value. To prevent this, you can place `null` (or the `ignore` command) at the end of the pipeline, like so: `"hello all:" | null`. Also note that most file system commands, such as `save` or `cd`, always output `null`.
+:::
 
 We could call the above definition of the `greet` command with any number of arguments, including none at all. All of the arguments are collected into `$name` as a list.
 


### PR DESCRIPTION
Don't forget to close the tip/warning boxes with `:::`