### PR TITLE
docs: 📝 document the catch block parameter

### DIFF
--- a/book/commands/try.md
+++ b/book/commands/try.md
@@ -38,3 +38,8 @@ Try to run a missing command
 ```shell
 > try { asdfasdf } catch { echo 'missing' }
 ```
+
+Try to run a missing command, and parse the error
+```shell
+> try { asdfasdf } catch {|err| if ("executable was not found" in $"($err)") { print "Missing Command" } else { print "Unexpected Error" }}
+```


### PR DESCRIPTION
As discussed on discord, this PR is about documenting the catch block optional parameter (containing the actual Error).
Not sure how to make it clear and not too lengthy...

### Proposed option

**Try to run a missing command, and parse the error**
```shell
> try { asdfasdf } catch {|err| if ("executable was not found" in $"($err)") { print "Missing Command" } else { print "Unexpected Error" }}
```

### Other considered options

1. **Try to run a missing command, do something and return the error.**: 
	```nu
	try { asdfasdf } catch {|err| echo 'missing' | $err }
	```
2. **Try to run a missing command, return the raw error as string**:
	```nu
	try { asdfasdf } catch {|err| print $"Got Error: ($err)"}
	```
	*Suggested by @kubouch , might be the most straightforward one actually*