### PR TITLE
Fix syntax error for menu

### DIFF
--- a/book/line_editor.md
+++ b/book/line_editor.md
@@ -599,7 +599,7 @@ modifying these values from the config object:
   let $config = {
     ...
 
-    menus = [
+    menus: [
       ...
       {
         name: completion_menu


### PR DESCRIPTION
We need a `:` instead of `=` in this line.