### PR TITLE
Update plugins.md

### DIFF
--- a/book/plugins.md
+++ b/book/plugins.md
@@ -32,7 +32,7 @@ When [`register`](commands/register.md) is called:
 Once registered, the plugin is available as part of your set of commands:
 
 ```
-> help commands | where is_plugin == true
+> help commands | where command_type == "plugin"
 ```
 
 ## Examples


### PR DESCRIPTION
If I'm understanding that correctly from [this PR](https://github.com/nushell/nushell/pull/7052) `command_type` should be `plugin` if it comes from a plugin.