### PR TITLE
remove a broken link in "Introducing nushell" # "Plugins"

### DIFF
--- a/blog/2019-08-23-introducing-nushell.md
+++ b/blog/2019-08-23-introducing-nushell.md
@@ -312,7 +312,7 @@ That's right, we're in the file. Can we `cd`? Oh yes, we can:
 
 # Plugins
 
-Nu can't come with everything you might want to do with it, so we're releasing Nu with the ability to extend it with plugins. There's more information in the [plugins chapters](https://book.nushell.sh/en/plugins). Nu will look for these plugins in your path, and load them up on startup.
+Nu can't come with everything you might want to do with it, so we're releasing Nu with the ability to extend it with plugins. There's more information in the plugins chapters. Nu will look for these plugins in your path, and load them up on startup.
 
 # All because of Rust
 

--- a/blog/2019-08-23-introducing-nushell.md
+++ b/blog/2019-08-23-introducing-nushell.md
@@ -312,7 +312,7 @@ That's right, we're in the file. Can we `cd`? Oh yes, we can:
 
 # Plugins
 
-Nu can't come with everything you might want to do with it, so we're releasing Nu with the ability to extend it with plugins. There's more information in the plugins chapters. Nu will look for these plugins in your path, and load them up on startup.
+Nu can't come with everything you might want to do with it, so we're releasing Nu with the ability to extend it with plugins. There's more information in the [plugins chapters](https://www.nushell.sh/book/plugins.html). Nu will look for these plugins in your path, and load them up on startup.
 
 # All because of Rust
 


### PR DESCRIPTION
Should close #741.

This PR removes a broken link to the "plugins chapter" from the first paragraph of the [_Plugins_ section in _Introducing nushell_](https://www.nushell.sh/blog/2019-08-23-introducing-nushell.html#plugins):
- https://book.nushell.sh/en/plugins is dead and should not be accessed, as discussed in #741

### a question
maybe we should do one of the following?
- remove the whole "_There's more information in the plugins chapters._" sentence
- keep that sentence but link to the "_plugins_" page at https://www.nushell.sh/book/plugins.html, until the contributors book is up and online again

you tell me :wink: 