### PR TITLE
link to default config file in the "explore" page

### DIFF
--- a/book/explore.md
+++ b/book/explore.md
@@ -40,7 +40,7 @@ To find out the comprehensive list of commands you can type `:help`.
 ## Config
 
 You can configure many things (including styles and colors), via config.
-You can find an example configuration in `default-config.nu`.
+You can find an example configuration in [`default-config.nu`](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_config.nu).
 
 ## Examples
 


### PR DESCRIPTION
This should close #742.

As agreed in #742, this PR simply links the "`default-config.nu`" text from the [`explore` page](https://www.nushell.sh/book/explore.html#config) to the [`default-config.nu`](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/sample_config/default_config.nu) file of the source base of `nushell` :+1: 