### PR TITLE
Add separate page for setting Nu as default shell

### DIFF
--- a/.vuepress/configs/sidebar/en.ts
+++ b/.vuepress/configs/sidebar/en.ts
@@ -13,6 +13,7 @@ export const sidebarEn: SidebarConfig = {
       collapsible: false,
       children: [
         '/book/installation.md',
+        '/book/default_shell.md',
         '/book/quick_tour.md',
         '/book/moving_around.md',
         '/book/thinking_in_nu.md',

--- a/book/default_shell.md
+++ b/book/default_shell.md
@@ -14,9 +14,9 @@
 ## Setting Nu as login shell (Linux, BSD & macOS)
 
 ::: warning
-We do not recommend setting your login shell to Nu.
-Some programs on your system might assume that your login shell is [POSIX](https://en.wikipedia.org/wiki/POSIX) compatible.
-Breaking that assumption often leads to unexpected issues.
+Nu is still in development and is not intended to be POSIX compliant.
+Be aware that some programs on your system might assume that your login shell is [POSIX](https://en.wikipedia.org/wiki/POSIX) compatible.
+Breaking that assumption can lead to unexpected issues.
 :::
 
 To set the login shell you can use the [`chsh`](https://linux.die.net/man/1/chsh) command.

--- a/book/default_shell.md
+++ b/book/default_shell.md
@@ -1,0 +1,29 @@
+# Default shell
+
+## Setting Nu as default shell on your terminal
+
+|     Terminal     | Platform     |                                                                                                                 Instructions                                                                                                                 |
+| :--------------: | ------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|  GNOME Terminal  | Linux & BSDs |                                  Open `Edit > Preferences`. In the right-hand panel, select the `Command` tab, tick `Run a custom command instead of my shell`, and set `Custom command` to the path to Nu.                                  |
+|     Konsole      | Linux & BSDs |                                                                                   Open `Settings > Edit Current Profile`. Set `Command` to the path to Nu.                                                                                   |
+|  XFCE Terminal   | Linux & BSDs |                                                           Open `Edit > Preferences`. Check `Run a custom command instead of my shell`, and set `Custom command` to the path to Nu.                                                           |
+|   Terminal.app   | macOS        | Open `Terminal > Preferences`. Ensure you are on the `Profiles` tab, which should be the default tab. In the right-hand panel, select the `Shell` tab. Tick `Run command`, put the path to Nu in the textbox, and untick `Run inside shell`. |
+|      iTerm2      | macOS        |                       Open `iTerm > Preferences`. Select the `Profiles` tab. In the right-hand panel under `Command`, change the dropdown from `Login Shell` to `Custom Shell`, and put the path to Nu in the textbox.                       |
+| Windows Terminal | Windows      |    Press `Ctrl`+`,` to open `Settings`. Go to `Add a new profile > New empty profile`. Fill in the 'Name' and enter path to Nu in the 'Command line' textbox. Go to `Startup` option and select Nu as the 'Default profile'. Hit `Save`.     |
+
+## Setting Nu as login shell (Linux, BSD & macOS)
+
+::: warning
+We do not recommend setting your login shell to Nu.
+Some programs on your system might assume that your login shell is [POSIX](https://en.wikipedia.org/wiki/POSIX) compatible.
+Breaking that assumption often leads to unexpected issues.
+:::
+
+To set the login shell you can use the [`chsh`](https://linux.die.net/man/1/chsh) command.
+Some Linux distributions have a list of valid shells located in `/etc/shells` and will disallow changing the shell until Nu is in the whitelist.
+You may see an error similar to the one below if you haven't updated the `shells` file:
+
+@[code](@snippets/installation/chsh_invalid_shell_error.sh)
+
+You can add Nu to the list of allowed shells by appending your Nu binary to the `shells` file.
+The path to add can be found with the command `which nu`, usually it is `$HOME/.cargo/bin/nu`.

--- a/book/installation.md
+++ b/book/installation.md
@@ -99,27 +99,3 @@ You can also build and run Nu in release mode:
 @[code](@snippets/installation/build_nu_from_source_release.sh)
 
 People familiar with Rust may wonder why we do both a "build" and a "run" step if "run" does a build by default. This is to get around a shortcoming of the new `default-run` option in Cargo, and ensure that all plugins are built, though this may not be required in the future.
-
-## Setting the login shell (\*nix)
-
-**!!! Nu is still in development, and may not be stable for everyday use. !!!**
-
-To set the login shell you can use the [`chsh`](https://linux.die.net/man/1/chsh) command.
-Some Linux distributions have a list of valid shells located in `/etc/shells` and will disallow changing the shell until Nu is in the whitelist. You may see an error similar to the one below if you haven't updated the `shells` file:
-
-@[code](@snippets/installation/chsh_invalid_shell_error.sh)
-
-You can add Nu to the list of allowed shells by appending your Nu binary to the `shells` file.
-The path to add can be found with the command `which nu`, usually it is `$HOME/.cargo/bin/nu`.
-
-## Setting the default shell (Windows Terminal)
-
-If you are using [Windows Terminal](https://github.com/microsoft/terminal) you can set `nu` as your default shell by adding:
-
-@[code](@snippets/installation/windows_terminal_default_shell.sh)
-
-to `"profiles"` in your Terminal Settings (JSON-file). The last thing to do is to change the `"defaultProfile"` to:
-
-@[code](@snippets/installation/windows_change_default_profile.sh)
-
-Now, `nu` should load on startup of the Windows Terminal.


### PR DESCRIPTION
- Adds instructions to add Nu to your terminal
- Advises against setting Nu as login shell

Heavily inspired by
https://elv.sh/get/#using-elvish-as-your-default-shell