### PR TITLE
Remove note about environment scoping in def_env page

### DIFF
--- a/book/commands/def-env.md
+++ b/book/commands/def-env.md
@@ -23,37 +23,7 @@ usage: |
  -  `params`: parameters
  -  `block`: body of the definition
 
-## Notes
-```text
-This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nu.html
 
-=== EXTRA NOTE ===
-All blocks are scoped, including variable definition and environment variable changes.
-
-Because of this, the following doesn't work:
-
-def-env cd_with_fallback [arg = ""] {
-    let fall_back_path = "/tmp"
-    if $arg != "" {
-        cd $arg
-    } else {
-        cd $fall_back_path
-    }
-}
-
-Instead, you have to use cd in the top level scope:
-
-def-env cd_with_fallback [arg = ""] {
-    let fall_back_path = "/tmp"
-    let path = if $arg != "" {
-        $arg
-    } else {
-        $fall_back_path
-    }
-    cd $path
-}
-```
 ## Examples
 
 Set environment variable by call a custom command


### PR DESCRIPTION
The current page contains an obsolete note warning users about blocks creating scopes constraining environment changes.

As block scoping rules changed, this note should be removed.