### PR TITLE
fix statement about `lines` output type ("table"→"list")

### DIFF
--- a/book/loading_data.md
+++ b/book/loading_data.md
@@ -131,7 +131,7 @@ The first thing we want to do when bringing in the file is to work with it a lin
 ───┴──────────────────────────────
 ```
 
-We can see that we're working with the lines because we're back into a table. Our next step is to see if we can split up the rows into something a little more useful. For that, we'll use the [`split`](commands/split.md) command. [`split`](commands/split.md), as the name implies, gives us a way to split a delimited string. We will use [`split`](commands/split.md)'s `column` subcommand to split the contents across multiple columns. We tell it what the delimiter is, and it does the rest:
+We can see that we're working with the lines because we're back into a list. Our next step is to see if we can split up the rows into something a little more useful. For that, we'll use the [`split`](commands/split.md) command. [`split`](commands/split.md), as the name implies, gives us a way to split a delimited string. We will use [`split`](commands/split.md)'s `column` subcommand to split the contents across multiple columns. We tell it what the delimiter is, and it does the rest:
 
 ```
 > open people.txt | lines | split column "|"

--- a/de/book/loading_data.md
+++ b/de/book/loading_data.md
@@ -104,7 +104,7 @@ Zuerst wird die Datei so geladen, dass jede Zeile für sich verarbeitet werden k
 ───┴──────────────────────────────
 ```
 
-Dadurch wird bereits wieder eine Tabelle ausgegeben. Im nächsten Schritt sollen die Spalten
+Dadurch wird bereits wieder eine Liste ausgegeben. Im nächsten Schritt sollen die Spalten
 in etwas brauchbares aufgeteilt werden.
 Dafür verwenden wir den [`split`](/book/commands/split.md) Befehl. Wie der Name schon verräht,
 kann damit ein String durch ein Trennzeichen aufgesplittet oder aufgetrennt werden.

--- a/de/book/loading_data.md
+++ b/de/book/loading_data.md
@@ -104,7 +104,7 @@ Zuerst wird die Datei so geladen, dass jede Zeile für sich verarbeitet werden k
 ───┴──────────────────────────────
 ```
 
-Dadurch wird bereits wieder eine Liste ausgegeben. Im nächsten Schritt sollen die Spalten
+Dadurch wird bereits wieder eine Liste ausgegeben. Im nächsten Schritt sollen die Zeilen
 in etwas brauchbares aufgeteilt werden.
 Dafür verwenden wir den [`split`](/book/commands/split.md) Befehl. Wie der Name schon verräht,
 kann damit ein String durch ein Trennzeichen aufgesplittet oder aufgetrennt werden.


### PR DESCRIPTION
Fix statement about `lines` output type, which is a `list`, not a `table`.

This fixes it in the original English and in the German translation. Other translations contain the same error, but will have to be fixed in separate changes, as I don't know them well enough.