### PR TITLE
[es] fix statement about `lines` output type ("tabla"→"lista")

### DIFF
--- a/es/book/cargando_datos.md
+++ b/es/book/cargando_datos.md
@@ -75,7 +75,7 @@ Lo primero que queremos hacer al cargar el archivo es trabajarlo línea por lín
 ---+------------------------------
 ```
 
-Podemos darnos cuenta que estamos trabajando con las líneas porque estamos de vuelta a una tabla. Nuestro próximo paso es mirar si podemos dividir las filas a algo más útil. Para eso, usaremos el comando `split`. `split`, como implica el nombre, nos da una manera de dividir una cadena delimitada. Usaremos el subcomando `column` para dividir el contenido a varias columnas. Indicamos cuál es el delimitador y se hace el resto:
+Podemos darnos cuenta que estamos trabajando con las líneas porque estamos de vuelta a una lista. Nuestro próximo paso es mirar si podemos dividir las filas a algo más útil. Para eso, usaremos el comando `split`. `split`, como implica el nombre, nos da una manera de dividir una cadena delimitada. Usaremos el subcomando `column` para dividir el contenido a varias columnas. Indicamos cuál es el delimitador y se hace el resto:
 
 ```
 > open gente.txt | lines | split column "|"


### PR DESCRIPTION
Fix statement about `lines` output type, which is a `list`, not a `table`.

This should fix it in the Spanish translation. See PR #764 for a fix of the same problem in the English original and in the German translation.

I don't really know Spanish. I simply looked up the term to use in [Tipos de datos→Listas](https://www.nushell.sh/es/book/tipos_de_datos.html#listas) (and in [Tipos de datos→ Datos estructurados](https://www.nushell.sh/es/book/tipos_de_datos.html#datos-estructurados) where it occurs in singular, albeit not referring to the data type), so it's quite possible I'm introducing grammatical errors.