### PR TITLE
[pt-BR] fix statement about `lines` output type ("tabela"→"lista")

### DIFF
--- a/pt-BR/book/carregando_dados.md
+++ b/pt-BR/book/carregando_dados.md
@@ -75,7 +75,7 @@ A primeira coisa que queremos fazer ao carregar o arquivo é trabalhar com ele l
 ---+------------------------------
 ```
 
-Podemos notar que estamos lidando com linhas porque voltamos a ver uma tabela. Nosso próximo passo é tentar dividir as linhas em algo um pouco mais útil. Para isso, vamos usar o comando `split column`. Como o nome implica, esse comando nos dá uma forma de dividir em colunas uma string delimitada. Informamos qual é o delimitador e o comando faz o resto:
+Podemos notar que estamos lidando com linhas porque voltamos a ver uma lista. Nosso próximo passo é tentar dividir as linhas em algo um pouco mais útil. Para isso, vamos usar o comando `split column`. Como o nome implica, esse comando nos dá uma forma de dividir em colunas uma string delimitada. Informamos qual é o delimitador e o comando faz o resto:
 
 ```shell
 > open people.txt | lines | split column "|"


### PR DESCRIPTION
Fix statement about `lines` output type, which is a `list`, not a `table`.

This should fix it in the Brazilian Portuguese translation. See PR #764 for a fix of the same problem in the English original and in the German translation.

I don't really know Portuguese. I simply looked up the term to use in [Tipos de dados→Listas](https://www.nushell.sh/pt-BR/book/tipos_de_dados.html#listas) (and in [Tipos de dados→Dados estruturados](https://www.nushell.sh/pt-BR/book/tipos_de_dados.html#dados-estruturados) where it occurs in singular, albeit not referring to the data type), so it's quite possible I'm introducing grammatical errors.