### PR TITLE
Fix changed history command to match default in config

### DIFF
--- a/book/line_editor.md
+++ b/book/line_editor.md
@@ -628,7 +628,7 @@ liking.
 ### History menu
 
 The history menu is a handy way to access the editor history. When activating
-the menu (default `Ctrl+x`) the command history is presented in reverse
+the menu (default `Ctrl+r`) the command history is presented in reverse
 chronological order, making it extremely easy to select a previous command.
 
 The history menu can be configured by modifying these values from the config object:


### PR DESCRIPTION
This PR provides a fix from changing `Ctrl+x` to `Ctrl+r` on the [Reedline Page](https://www.nushell.sh/book/line_editor.html#completion-menu). This fix addresses this [issue](https://github.com/nushell/nushell.github.io/issues/737).