### PR TITLE
Fix: updating pages that used each -n command

### DIFF
--- a/book/commands/par-each.md
+++ b/book/commands/par-each.md
@@ -31,5 +31,5 @@ Multiplies each number. Note that the list will become arbitrarily disordered.
 
 Iterate over each element, print the matching value and its index
 ```shell
-> [1 2 3] | par-each -n { |it| if $it.item == 2 { $"found 2 at ($it.index)!"} }
+> [1 2 3] | enumerate | par-each { |it| if $it.item == 2 { $"found 2 at ($it.index)!"} }
 ```

--- a/book/thinking_in_nu.md
+++ b/book/thinking_in_nu.md
@@ -71,7 +71,7 @@ This new `x` is visible to any code that follows this line. Careful use of shado
 Loop counters are another common pattern for mutable variables and are built into most iterating commands, for example you can get both each item and an index of each item using the `-n` flag on [`each`](commands/each.md):
 
 ```
-> ls | each -n { |it| $"Number ($it.index) is size ($it.item.size)" }
+> ls | enumerate | each { |it| $"Number ($it.index) is size ($it.item.size)" }
 ```
 
 You can also use the [`reduce`](commands/reduce.md) command to work in the same way you might mutate a variable in a loop. For example, if you wanted to find the largest string in a list of strings, you might do:

--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -41,7 +41,7 @@ let names = [Mark Tami Amanda Jeremy]
 $names | each { |it| $"Hello, ($it)!" }
 # Outputs "Hello, Mark!" and three more similar lines.
 
-$names | each -n { |it| $"($it.index + 1) - ($it.item)" }
+$names | enumerate | each { |it| $"($it.index + 1) - ($it.item)" }
 # Outputs "1 - Mark", "2 - Tami", etc.
 ```
 

--- a/de/book/thinking_in_nushell.md
+++ b/de/book/thinking_in_nushell.md
@@ -88,7 +88,7 @@ Schleifenzähler sind ein anderes häufiges Muster für veränderliche Variablen
 Zum Beispiel kann sowohl jedes Element wie auch dessen Index mit dem `-n` Flag von [`each`](/book/commands/each.md) erreicht werden:
 
 ```
-> ls | each -n { |it| $"Number ($it.index) is size ($it.item.size)" }
+> ls | enumerate | each { |it| $"Number ($it.index) is size ($it.item.size)" }
 ```
 
 Mit dem [`reduce`](/book/commands/reduce.md) kann eine ähnliche Funktionalität erreicht werden wie man es von Variablen in Schleifen kennt.

--- a/de/book/working_with_lists.md
+++ b/de/book/working_with_lists.md
@@ -46,7 +46,7 @@ let names = [Mark Tami Amanda Jeremy]
 $names | each { |it| $"Hello, ($it)!" }
 # Outputs "Hello, Mark!" and three more similar lines.
 
-$names | each -n { |it| $"($it.index + 1) - ($it.item)" }
+$names | enumerate | each { |it| $"($it.index + 1) - ($it.item)" }
 # Outputs "1 - Mark", "2 - Tami", etc.
 ```
 

--- a/zh-CN/book/thinking_in_nu.md
+++ b/zh-CN/book/thinking_in_nu.md
@@ -69,7 +69,7 @@ let x = $x + 1
 循环计数器是可变变量的另一种常见模式，它被内置于大多数迭代命令中，例如，你可以使用[`each`](/book/commands/each.md)上的`-n`标志同时获得每个元素的值和索引：
 
 ```bash
-> ls | each -n { |it| $"Number ($it.index) is size ($it.item.size)" }
+> ls | enumerate | each { |it| $"Number ($it.index) is size ($it.item.size)" }
 ```
 
 你也可以使用[`reduce`](/book/commands/reduce.md)命令来达到上述目的，其方式与你在循环中修改一个变量相同。例如，如果你想在一个字符串列表中找到最长的字符串，你可以这样做：

--- a/zh-CN/book/working_with_lists.md
+++ b/zh-CN/book/working_with_lists.md
@@ -40,7 +40,7 @@ let names = [Mark Tami Amanda Jeremy]
 $names | each { |it| $"Hello, ($it)!" }
 # Outputs "Hello, Mark!" and three more similar lines.
 
-$names | each -n { |it| $"($it.index + 1) - ($it.item)" }
+$names | enumerate | each { |it| $"($it.index + 1) - ($it.item)" }
 # Outputs "1 - Mark", "2 - Tami", etc.
 ```
 


### PR DESCRIPTION
This PR addresses this [issue](https://github.com/nushell/nushell.github.io/issues/774). The docs were still using `each -n` so I have updated it to use `enumerate | each` as seen in the newest version of Nushell. 