### PR TITLE
Add short flags to command docs, fix #509

### DIFF
--- a/commands/docs/ansi.md
+++ b/commands/docs/ansi.md
@@ -20,9 +20,9 @@ usage: |
 ## Parameters
 
  -  `code`: the name of the code to use like 'green' or 'reset' to reset the color
- -  `--escape`: escape sequence without the escape character(s)
- -  `--osc`: operating system command (ocs) escape sequence without the escape character(s)
- -  `--list`: list available ansi code names
+ -  `--escape` `(-e)`: escape sequence without the escape character(s)
+ -  `--osc` `(-o)`: operating system command (ocs) escape sequence without the escape character(s)
+ -  `--list` `(-l)`: list available ansi code names
 
 ## Notes
 ```text

--- a/commands/docs/bits_not.md
+++ b/commands/docs/bits_not.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--signed`: always treat input number as a signed number
+ -  `--signed` `(-s)`: always treat input number as a signed number
  -  `--number-bytes {string}`: the size of unsigned number in bytes, it can be 1, 2, 4, 8, auto
 
 ## Examples

--- a/commands/docs/bits_rol.md
+++ b/commands/docs/bits_rol.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `bits`: number of bits to rotate left
- -  `--signed`: always treat input number as a signed number
+ -  `--signed` `(-s)`: always treat input number as a signed number
  -  `--number-bytes {string}`: the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`
 
 ## Examples

--- a/commands/docs/bits_ror.md
+++ b/commands/docs/bits_ror.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `bits`: number of bits to rotate right
- -  `--signed`: always treat input number as a signed number
+ -  `--signed` `(-s)`: always treat input number as a signed number
  -  `--number-bytes {string}`: the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`
 
 ## Examples

--- a/commands/docs/bits_shl.md
+++ b/commands/docs/bits_shl.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `bits`: number of bits to shift left
- -  `--signed`: always treat input number as a signed number
+ -  `--signed` `(-s)`: always treat input number as a signed number
  -  `--number-bytes {string}`: the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`
 
 ## Examples

--- a/commands/docs/bits_shr.md
+++ b/commands/docs/bits_shr.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `bits`: number of bits to shift right
- -  `--signed`: always treat input number as a signed number
+ -  `--signed` `(-s)`: always treat input number as a signed number
  -  `--number-bytes {string}`: the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`
 
 ## Examples

--- a/commands/docs/bytes_add.md
+++ b/commands/docs/bytes_add.md
@@ -22,7 +22,7 @@ usage: |
  -  `data`: the binary to add
  -  `...rest`: for a data structure input, add bytes to the data at the given cell paths
  -  `--index {int}`: index to insert binary data
- -  `--end`: add to the end of binary
+ -  `--end` `(-e)`: add to the end of binary
 
 ## Examples
 

--- a/commands/docs/bytes_index-of.md
+++ b/commands/docs/bytes_index-of.md
@@ -21,8 +21,8 @@ usage: |
 
  -  `pattern`: the pattern to find index of
  -  `...rest`: for a data structure input, find the indexes at the given cell paths
- -  `--all`: returns all matched index
- -  `--end`: search from the end of the binary
+ -  `--all` `(-a)`: returns all matched index
+ -  `--end` `(-e)`: search from the end of the binary
 
 ## Examples
 

--- a/commands/docs/bytes_remove.md
+++ b/commands/docs/bytes_remove.md
@@ -21,8 +21,8 @@ usage: |
 
  -  `pattern`: the pattern to find
  -  `...rest`: for a data structure input, remove bytes from data at the given cell paths
- -  `--end`: remove from end of binary
- -  `--all`: remove occurrences of finding binary
+ -  `--end` `(-e)`: remove from end of binary
+ -  `--all` `(-a)`: remove occurrences of finding binary
 
 ## Examples
 

--- a/commands/docs/bytes_replace.md
+++ b/commands/docs/bytes_replace.md
@@ -22,7 +22,7 @@ usage: |
  -  `find`: the pattern to find
  -  `replace`: the replacement pattern
  -  `...rest`: for a data structure input, replace bytes in data at the given cell paths
- -  `--all`: replace all occurrences of find binary
+ -  `--all` `(-a)`: replace all occurrences of find binary
 
 ## Examples
 

--- a/commands/docs/cal.md
+++ b/commands/docs/cal.md
@@ -19,12 +19,12 @@ usage: |
 
 ## Parameters
 
- -  `--year`: Display the year column
- -  `--quarter`: Display the quarter column
- -  `--month`: Display the month column
+ -  `--year` `(-y)`: Display the year column
+ -  `--quarter` `(-q)`: Display the quarter column
+ -  `--month` `(-m)`: Display the month column
  -  `--full-year {int}`: Display a year-long calendar for the specified year
  -  `--week-start {string}`: Display the calendar with the specified day as the first day of the week
- -  `--month-names`: Display the month names instead of integers
+ -  `--month-names` `(-)`: Display the month names instead of integers
 
 ## Examples
 

--- a/commands/docs/char.md
+++ b/commands/docs/char.md
@@ -21,9 +21,9 @@ usage: |
 
  -  `character`: the name of the character to output
  -  `...rest`: multiple Unicode bytes
- -  `--list`: List all supported character names
- -  `--unicode`: Unicode string i.e. 1f378
- -  `--integer`: Create a codepoint from an integer
+ -  `--list` `(-l)`: List all supported character names
+ -  `--unicode` `(-u)`: Unicode string i.e. 1f378
+ -  `--integer` `(-i)`: Create a codepoint from an integer
 
 ## Examples
 

--- a/commands/docs/collect.md
+++ b/commands/docs/collect.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `closure`: the closure to run once the stream is collected
- -  `--keep-env`: let the block affect environment variables
+ -  `--keep-env` `(-)`: let the block affect environment variables
 
 ## Examples
 

--- a/commands/docs/commandline.md
+++ b/commands/docs/commandline.md
@@ -20,6 +20,6 @@ usage: |
 ## Parameters
 
  -  `cmd`: the string to perform the operation with
- -  `--append`: appends the string to the end of the buffer
- -  `--insert`: inserts the string into the buffer at the cursor position
- -  `--replace`: replaces the current contents of the buffer (default)
+ -  `--append` `(-a)`: appends the string to the end of the buffer
+ -  `--insert` `(-i)`: inserts the string into the buffer at the cursor position
+ -  `--replace` `(-r)`: replaces the current contents of the buffer (default)

--- a/commands/docs/config_reset.md
+++ b/commands/docs/config_reset.md
@@ -19,9 +19,9 @@ usage: |
 
 ## Parameters
 
- -  `--nu`: reset only nu config, config.nu
- -  `--env`: reset only env config, env.nu
- -  `--without-backup`: do not make a backup
+ -  `--nu` `(-n)`: reset only nu config, config.nu
+ -  `--env` `(-e)`: reset only env config, env.nu
+ -  `--without-backup` `(-w)`: do not make a backup
 
 ## Examples
 

--- a/commands/docs/cp.md
+++ b/commands/docs/cp.md
@@ -21,10 +21,10 @@ usage: |
 
  -  `source`: the place to copy from
  -  `destination`: the place to copy to
- -  `--recursive`: copy recursively through subdirectories
- -  `--verbose`: show successful copies in addition to failed copies (default:false)
- -  `--interactive`: ask user to confirm action
- -  `--no-symlink`: no symbolic links are followed, only works if -r is active
+ -  `--recursive` `(-r)`: copy recursively through subdirectories
+ -  `--verbose` `(-v)`: show successful copies in addition to failed copies (default:false)
+ -  `--interactive` `(-i)`: ask user to confirm action
+ -  `--no-symlink` `(-n)`: no symbolic links are followed, only works if -r is active
 
 ## Examples
 

--- a/commands/docs/date_format.md
+++ b/commands/docs/date_format.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `format string`: the desired date format
- -  `--list`: lists strftime cheatsheet
+ -  `--list` `(-l)`: lists strftime cheatsheet
 
 ## Examples
 

--- a/commands/docs/debug.md
+++ b/commands/docs/debug.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--raw`: Prints the raw value representation
+ -  `--raw` `(-r)`: Prints the raw value representation
 
 ## Examples
 

--- a/commands/docs/decode_base64.md
+++ b/commands/docs/decode_base64.md
@@ -22,7 +22,7 @@ usage: |
  -  `...rest`: For a data structure input, decode data at the given cell paths
  -  `--character-set {string}`: specify the character rules for encoding the input.
 	Valid values are 'standard', 'standard-no-padding', 'url-safe', 'url-safe-no-padding','binhex', 'bcrypt', 'crypt', 'mutf7'
- -  `--binary`: Output a binary value instead of decoding payload as UTF-8
+ -  `--binary` `(-b)`: Output a binary value instead of decoding payload as UTF-8
 
 ## Notes
 Will attempt to decode binary payload as an UTF-8 string by default. Use the `--binary(-b)` argument to force binary output.

--- a/commands/docs/describe.md
+++ b/commands/docs/describe.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--no-collect`: do not collect streams of structured data
+ -  `--no-collect` `(-n)`: do not collect streams of structured data
 
 ## Examples
 

--- a/commands/docs/detect_columns.md
+++ b/commands/docs/detect_columns.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `--skip {int}`: number of rows to skip before detecting
- -  `--no-headers`: don't detect headers
+ -  `--no-headers` `(-n)`: don't detect headers
 
 ## Examples
 

--- a/commands/docs/do.md
+++ b/commands/docs/do.md
@@ -21,10 +21,10 @@ usage: |
 
  -  `closure`: the closure to run
  -  `...rest`: the parameter(s) for the closure
- -  `--ignore-errors`: ignore errors as the closure runs
- -  `--ignore-shell-errors`: ignore shell errors as the closure runs
- -  `--ignore-program-errors`: ignore external program errors as the closure runs
- -  `--capture-errors`: catch errors as the closure runs, and return them
+ -  `--ignore-errors` `(-i)`: ignore errors as the closure runs
+ -  `--ignore-shell-errors` `(-s)`: ignore shell errors as the closure runs
+ -  `--ignore-program-errors` `(-p)`: ignore external program errors as the closure runs
+ -  `--capture-errors` `(-c)`: catch errors as the closure runs, and return them
 
 ## Examples
 

--- a/commands/docs/du.md
+++ b/commands/docs/du.md
@@ -20,8 +20,8 @@ usage: |
 ## Parameters
 
  -  `path`: starting directory
- -  `--all`: Output file sizes as well as directory sizes
- -  `--deref`: Dereference symlinks to their targets for size
+ -  `--all` `(-a)`: Output file sizes as well as directory sizes
+ -  `--deref` `(-r)`: Dereference symlinks to their targets for size
  -  `--exclude {glob}`: Exclude these file names
  -  `--max-depth {int}`: Directory recursion limit
  -  `--min-size {int}`: Exclude files below this size

--- a/commands/docs/each.md
+++ b/commands/docs/each.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `closure`: the closure to run
- -  `--keep-empty`: keep empty result cells
+ -  `--keep-empty` `(-k)`: keep empty result cells
 
 ## Notes
 Since tables are lists of records, passing a table into 'each' will

--- a/commands/docs/encode.md
+++ b/commands/docs/encode.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `encoding`: the text encoding to use
- -  `--ignore-errors`: when a character isn't in the given encoding, replace with a HTML entity (like `&#127880;`)
+ -  `--ignore-errors` `(-i)`: when a character isn't in the given encoding, replace with a HTML entity (like `&#127880;`)
 
 ## Notes
 Multiple encodings are supported; here are a few:

--- a/commands/docs/error_make.md
+++ b/commands/docs/error_make.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `error_struct`: the error to create
- -  `--unspanned`: remove the origin label from the error
+ -  `--unspanned` `(-u)`: remove the origin label from the error
 
 ## Examples
 

--- a/commands/docs/every.md
+++ b/commands/docs/every.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `stride`: how many rows to skip between (and including) each row returned
- -  `--skip`: skip the rows that would be returned, instead of selecting them
+ -  `--skip` `(-s)`: skip the rows that would be returned, instead of selecting them
 
 ## Examples
 

--- a/commands/docs/exit.md
+++ b/commands/docs/exit.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `exit_code`: Exit code to return immediately with
- -  `--now`: Exit out of all shells immediately (exiting Nu)
+ -  `--now` `(-n)`: Exit out of all shells immediately (exiting Nu)
 
 ## Examples
 

--- a/commands/docs/explore.md
+++ b/commands/docs/explore.md
@@ -20,9 +20,9 @@ usage: |
 ## Parameters
 
  -  `--head {bool}`: Show or hide column headers (default true)
- -  `--index`: Show row indexes when viewing a list
- -  `--reverse`: Start with the viewport scrolled to the bottom
- -  `--peek`: When quitting, output the value of the cell the cursor was on
+ -  `--index` `(-i)`: Show row indexes when viewing a list
+ -  `--reverse` `(-r)`: Start with the viewport scrolled to the bottom
+ -  `--peek` `(-p)`: When quitting, output the value of the cell the cursor was on
 
 ## Notes
 Press `:` then `h` to get a help menu.

--- a/commands/docs/find.md
+++ b/commands/docs/find.md
@@ -21,10 +21,10 @@ usage: |
 
  -  `...rest`: terms to search
  -  `--regex {string}`: regex to match with
- -  `--ignore-case`: case-insensitive regex mode; equivalent to (?i)
- -  `--multiline`: multi-line regex mode: ^ and $ match begin/end of line; equivalent to (?m)
- -  `--dotall`: dotall regex mode: allow a dot . to match newlines \n; equivalent to (?s)
- -  `--invert`: invert the match
+ -  `--ignore-case` `(-i)`: case-insensitive regex mode; equivalent to (?i)
+ -  `--multiline` `(-m)`: multi-line regex mode: ^ and $ match begin/end of line; equivalent to (?m)
+ -  `--dotall` `(-s)`: dotall regex mode: allow a dot . to match newlines \n; equivalent to (?s)
+ -  `--invert` `(-v)`: invert the match
 
 ## Examples
 

--- a/commands/docs/flatten.md
+++ b/commands/docs/flatten.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `...rest`: optionally flatten data by column
- -  `--all`: flatten inner table one level out
+ -  `--all` `(-a)`: flatten inner table one level out
 
 ## Examples
 

--- a/commands/docs/for.md
+++ b/commands/docs/for.md
@@ -22,7 +22,7 @@ usage: |
  -  `var_name`: name of the looping variable
  -  `range`: range of the loop
  -  `block`: the block to run
- -  `--numbered`: return a numbered item ($it.index and $it.item)
+ -  `--numbered` `(-n)`: return a numbered item ($it.index and $it.item)
 
 ## Notes
 This command is a parser keyword. For details, check:

--- a/commands/docs/from_csv.md
+++ b/commands/docs/from_csv.md
@@ -20,8 +20,8 @@ usage: |
 ## Parameters
 
  -  `--separator {string}`: a character to separate columns, defaults to ','
- -  `--noheaders`: don't treat the first row as column names
- -  `--no-infer`: no field type inferencing
+ -  `--noheaders` `(-n)`: don't treat the first row as column names
+ -  `--no-infer` `(-)`: no field type inferencing
  -  `--trim {string}`: drop leading and trailing whitespaces around headers names and/or field values
 
 ## Examples

--- a/commands/docs/from_json.md
+++ b/commands/docs/from_json.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--objects`: treat each line as a separate value
+ -  `--objects` `(-o)`: treat each line as a separate value
 
 ## Examples
 

--- a/commands/docs/from_ssv.md
+++ b/commands/docs/from_ssv.md
@@ -19,8 +19,8 @@ usage: |
 
 ## Parameters
 
- -  `--noheaders`: don't treat the first row as column names
- -  `--aligned-columns`: assume columns are aligned
+ -  `--noheaders` `(-n)`: don't treat the first row as column names
+ -  `--aligned-columns` `(-a)`: assume columns are aligned
  -  `--minimum-spaces {int}`: the minimum spaces to separate columns
 
 ## Examples

--- a/commands/docs/from_tsv.md
+++ b/commands/docs/from_tsv.md
@@ -19,8 +19,8 @@ usage: |
 
 ## Parameters
 
- -  `--noheaders`: don't treat the first row as column names
- -  `--no-infer`: no field type inferencing
+ -  `--noheaders` `(-n)`: don't treat the first row as column names
+ -  `--no-infer` `(-)`: no field type inferencing
  -  `--trim {string}`: drop leading and trailing whitespaces around headers names and/or field values
 
 ## Examples

--- a/commands/docs/get.md
+++ b/commands/docs/get.md
@@ -21,8 +21,8 @@ usage: |
 
  -  `cell_path`: the cell path to the data
  -  `...rest`: additional cell paths
- -  `--ignore-errors`: when there are empty cells, instead of erroring out, replace them with nothing
- -  `--sensitive`: get path in a case sensitive manner
+ -  `--ignore-errors` `(-i)`: when there are empty cells, instead of erroring out, replace them with nothing
+ -  `--sensitive` `(-s)`: get path in a case sensitive manner
 
 ## Examples
 

--- a/commands/docs/glob.md
+++ b/commands/docs/glob.md
@@ -21,9 +21,9 @@ usage: |
 
  -  `glob`: the glob expression
  -  `--depth {int}`: directory depth to search
- -  `--no-dir`: Whether to filter out directories from the returned paths
- -  `--no-file`: Whether to filter out files from the returned paths
- -  `--no-symlink`: Whether to filter out symlinks from the returned paths
+ -  `--no-dir` `(-D)`: Whether to filter out directories from the returned paths
+ -  `--no-file` `(-F)`: Whether to filter out files from the returned paths
+ -  `--no-symlink` `(-S)`: Whether to filter out symlinks from the returned paths
 
 ## Notes
 For more glob pattern help, please refer to https://github.com/olson-sean-k/wax

--- a/commands/docs/grid.md
+++ b/commands/docs/grid.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `--width {int}`: number of terminal columns wide (not output columns)
- -  `--color`: draw output with color
+ -  `--color` `(-c)`: draw output with color
  -  `--separator {string}`: character to separate grid with
 
 ## Notes

--- a/commands/docs/hash_md5.md
+++ b/commands/docs/hash_md5.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `...rest`: optionally md5 hash data by cell path
- -  `--binary`: Output binary instead of hexadecimal representation
+ -  `--binary` `(-b)`: Output binary instead of hexadecimal representation
 
 ## Examples
 

--- a/commands/docs/hash_sha256.md
+++ b/commands/docs/hash_sha256.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `...rest`: optionally sha256 hash data by cell path
- -  `--binary`: Output binary instead of hexadecimal representation
+ -  `--binary` `(-b)`: Output binary instead of hexadecimal representation
 
 ## Examples
 

--- a/commands/docs/hide-env.md
+++ b/commands/docs/hide-env.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `...rest`: environment variable names to hide
- -  `--ignore-errors`: do not throw an error if an environment variable was not found
+ -  `--ignore-errors` `(-i)`: do not throw an error if an environment variable was not found
 
 ## Examples
 

--- a/commands/docs/history.md
+++ b/commands/docs/history.md
@@ -19,8 +19,8 @@ usage: |
 
 ## Parameters
 
- -  `--clear`: Clears out the history entries
- -  `--long`: Show long listing of entries for sqlite history
+ -  `--clear` `(-c)`: Clears out the history entries
+ -  `--long` `(-l)`: Show long listing of entries for sqlite history
 
 ## Examples
 

--- a/commands/docs/http_get.md
+++ b/commands/docs/http_get.md
@@ -24,8 +24,8 @@ usage: |
  -  `--password {any}`: the password when authenticating
  -  `--max-time {int}`: timeout period in seconds
  -  `--headers {any}`: custom headers you want to add
- -  `--raw`: fetch contents as text rather than a table
- -  `--insecure`: allow insecure server connections when using SSL
+ -  `--raw` `(-r)`: fetch contents as text rather than a table
+ -  `--insecure` `(-k)`: allow insecure server connections when using SSL
 
 ## Notes
 Performs HTTP GET operation.

--- a/commands/docs/http_post.md
+++ b/commands/docs/http_post.md
@@ -27,8 +27,8 @@ usage: |
  -  `--content-length {any}`: the length of the content being posted
  -  `--max-time {int}`: timeout period in seconds
  -  `--headers {any}`: custom headers you want to add
- -  `--raw`: return values as a string instead of a table
- -  `--insecure`: allow insecure server connections when using SSL
+ -  `--raw` `(-r)`: return values as a string instead of a table
+ -  `--insecure` `(-k)`: allow insecure server connections when using SSL
 
 ## Notes
 Performs HTTP POST operation.

--- a/commands/docs/input.md
+++ b/commands/docs/input.md
@@ -21,7 +21,7 @@ usage: |
 
  -  `prompt`: prompt to show the user
  -  `--bytes-until {string}`: read bytes (not text) until a stop byte
- -  `--suppress-output`: don't print keystroke values
+ -  `--suppress-output` `(-s)`: don't print keystroke values
 
 ## Examples
 

--- a/commands/docs/into_datetime.md
+++ b/commands/docs/into_datetime.md
@@ -23,7 +23,7 @@ usage: |
  -  `--timezone {string}`: Specify timezone if the input is a Unix timestamp. Valid options: 'UTC' ('u') or 'LOCAL' ('l')
  -  `--offset {int}`: Specify timezone by offset from UTC if the input is a Unix timestamp, like '+8', '-4'
  -  `--format {string}`: Specify an expected format for parsing strings to datetimes. Use --list to see all possible options
- -  `--list`: Show all possible variables for use with the --format flag
+ -  `--list` `(-l)`: Show all possible variables for use with the --format flag
 
 ## Examples
 

--- a/commands/docs/into_int.md
+++ b/commands/docs/into_int.md
@@ -21,7 +21,7 @@ usage: |
 
  -  `...rest`: for a data structure input, convert data at the given cell paths
  -  `--radix {number}`: radix of integer
- -  `--little-endian`: use little-endian byte decoding
+ -  `--little-endian` `(-)`: use little-endian byte decoding
 
 ## Examples
 

--- a/commands/docs/keybindings_list.md
+++ b/commands/docs/keybindings_list.md
@@ -19,11 +19,11 @@ usage: |
 
 ## Parameters
 
- -  `--modifiers`: list of modifiers
- -  `--keycodes`: list of keycodes
- -  `--modes`: list of edit modes
- -  `--events`: list of reedline event
- -  `--edits`: list of edit commands
+ -  `--modifiers` `(-m)`: list of modifiers
+ -  `--keycodes` `(-k)`: list of keycodes
+ -  `--modes` `(-o)`: list of edit modes
+ -  `--events` `(-e)`: list of reedline event
+ -  `--edits` `(-d)`: list of edit commands
 
 ## Examples
 

--- a/commands/docs/kill.md
+++ b/commands/docs/kill.md
@@ -15,15 +15,14 @@ usage: |
 
 ## Signature
 
-```> kill (pid) ...rest --force --quiet --signal```
+```> kill (pid) ...rest --force --quiet```
 
 ## Parameters
 
  -  `pid`: process id of process that is to be killed
  -  `...rest`: rest of processes to kill
- -  `--force`: forcefully kill the process
- -  `--quiet`: won't print anything to the console
- -  `--signal {int}`: signal decimal number to be sent instead of the default 15 (unsupported on Windows)
+ -  `--force` `(-f)`: forcefully kill the process
+ -  `--quiet` `(-q)`: won't print anything to the console
 
 ## Examples
 
@@ -35,9 +34,4 @@ Kill the pid using the most memory
 Force kill a given pid
 ```shell
 > kill --force 12345
-```
-
-Send INT signal
-```shell
-> kill -s 2 12345
 ```

--- a/commands/docs/length.md
+++ b/commands/docs/length.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--column`: Show the number of columns in a table
+ -  `--column` `(-c)`: Show the number of columns in a table
 
 ## Examples
 

--- a/commands/docs/lines.md
+++ b/commands/docs/lines.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--skip-empty`: skip empty lines
+ -  `--skip-empty` `(-s)`: skip empty lines
 
 ## Examples
 

--- a/commands/docs/ls.md
+++ b/commands/docs/ls.md
@@ -20,13 +20,13 @@ usage: |
 ## Parameters
 
  -  `pattern`: the glob pattern to use
- -  `--all`: Show hidden files
- -  `--long`: Get all available columns for each entry (slower; columns are platform-dependent)
- -  `--short-names`: Only print the file names, and not the path
- -  `--full-paths`: display paths as absolute paths
- -  `--du`: Display the apparent directory size ("disk usage") in place of the directory metadata size
- -  `--directory`: List the specified directory itself instead of its contents
- -  `--mime-type`: Show mime-type in type column instead of 'file' (based on filenames only; files' contents are not examined)
+ -  `--all` `(-a)`: Show hidden files
+ -  `--long` `(-l)`: Get all available columns for each entry (slower; columns are platform-dependent)
+ -  `--short-names` `(-s)`: Only print the file names, and not the path
+ -  `--full-paths` `(-f)`: display paths as absolute paths
+ -  `--du` `(-d)`: Display the apparent directory size ("disk usage") in place of the directory metadata size
+ -  `--directory` `(-D)`: List the specified directory itself instead of its contents
+ -  `--mime-type` `(-m)`: Show mime-type in type column instead of 'file' (based on filenames only; files' contents are not examined)
 
 ## Examples
 

--- a/commands/docs/math_arccos.md
+++ b/commands/docs/math_arccos.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--degrees`: Return degrees instead of radians
+ -  `--degrees` `(-d)`: Return degrees instead of radians
 
 ## Examples
 

--- a/commands/docs/math_arcsin.md
+++ b/commands/docs/math_arcsin.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--degrees`: Return degrees instead of radians
+ -  `--degrees` `(-d)`: Return degrees instead of radians
 
 ## Examples
 

--- a/commands/docs/math_arctan.md
+++ b/commands/docs/math_arctan.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--degrees`: Return degrees instead of radians
+ -  `--degrees` `(-d)`: Return degrees instead of radians
 
 ## Examples
 

--- a/commands/docs/math_cos.md
+++ b/commands/docs/math_cos.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--degrees`: Use degrees instead of radians
+ -  `--degrees` `(-d)`: Use degrees instead of radians
 
 ## Examples
 

--- a/commands/docs/math_sin.md
+++ b/commands/docs/math_sin.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--degrees`: Use degrees instead of radians
+ -  `--degrees` `(-d)`: Use degrees instead of radians
 
 ## Examples
 

--- a/commands/docs/math_stddev.md
+++ b/commands/docs/math_stddev.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--sample`: calculate sample standard deviation (i.e. using N-1 as the denominator)
+ -  `--sample` `(-s)`: calculate sample standard deviation (i.e. using N-1 as the denominator)
 
 ## Examples
 

--- a/commands/docs/math_tan.md
+++ b/commands/docs/math_tan.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--degrees`: Use degrees instead of radians
+ -  `--degrees` `(-d)`: Use degrees instead of radians
 
 ## Examples
 

--- a/commands/docs/math_variance.md
+++ b/commands/docs/math_variance.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--sample`: calculate sample variance (i.e. using N-1 as the denominator)
+ -  `--sample` `(-s)`: calculate sample variance (i.e. using N-1 as the denominator)
 
 ## Examples
 

--- a/commands/docs/mkdir.md
+++ b/commands/docs/mkdir.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `...rest`: the name(s) of the path(s) to create
- -  `--verbose`: print created path(s).
+ -  `--verbose` `(-v)`: print created path(s).
 
 ## Examples
 

--- a/commands/docs/mv.md
+++ b/commands/docs/mv.md
@@ -21,9 +21,9 @@ usage: |
 
  -  `source`: the location to move files/directories from
  -  `destination`: the location to move files/directories to
- -  `--verbose`: make mv to be verbose, showing files been moved.
- -  `--force`: overwrite the destination.
- -  `--interactive`: ask user to confirm action
+ -  `--verbose` `(-v)`: make mv to be verbose, showing files been moved.
+ -  `--force` `(-f)`: overwrite the destination.
+ -  `--interactive` `(-i)`: ask user to confirm action
 
 ## Examples
 

--- a/commands/docs/nu-check.md
+++ b/commands/docs/nu-check.md
@@ -20,9 +20,9 @@ usage: |
 ## Parameters
 
  -  `path`: File path to parse
- -  `--as-module`: Parse content as module
- -  `--debug`: Show error messages
- -  `--all`: Parse content as script first, returns result if success, otherwise, try with module
+ -  `--as-module` `(-m)`: Parse content as module
+ -  `--debug` `(-d)`: Show error messages
+ -  `--all` `(-a)`: Parse content as script first, returns result if success, otherwise, try with module
 
 ## Examples
 

--- a/commands/docs/open.md
+++ b/commands/docs/open.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `filename`: the filename to use
- -  `--raw`: open file as raw binary
+ -  `--raw` `(-r)`: open file as raw binary
 
 ## Examples
 

--- a/commands/docs/overlay_hide.md
+++ b/commands/docs/overlay_hide.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `name`: Overlay to hide
- -  `--keep-custom`: Keep all newly added commands and aliases in the next activated overlay
+ -  `--keep-custom` `(-k)`: Keep all newly added commands and aliases in the next activated overlay
  -  `--keep-env {list<string>}`: List of environment variables to keep in the next activated overlay
 
 ## Notes

--- a/commands/docs/overlay_use.md
+++ b/commands/docs/overlay_use.md
@@ -21,8 +21,8 @@ usage: |
 
  -  `name`: Module name to use overlay for
  -  `as`: as keyword followed by a new name
- -  `--prefix`: Prepend module name to the imported commands and aliases
- -  `--reload`: If the overlay already exists, reload its definitions and environment.
+ -  `--prefix` `(-p)`: Prepend module name to the imported commands and aliases
+ -  `--reload` `(-r)`: If the overlay already exists, reload its definitions and environment.
 
 ## Notes
 This command is a parser keyword. For details, check:

--- a/commands/docs/parse.md
+++ b/commands/docs/parse.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `pattern`: the pattern to match. Eg) "{foo}: {bar}"
- -  `--regex`: use full regex syntax for patterns
+ -  `--regex` `(-r)`: use full regex syntax for patterns
 
 ## Examples
 

--- a/commands/docs/path_basename.md
+++ b/commands/docs/path_basename.md
@@ -26,15 +26,20 @@ usage: |
 
 Get basename of a path
 ```shell
-> '/home/joe/test.txt' | path basename
+> 'C:\Users\joe\test.txt' | path basename
 ```
 
-Get basename of a path by column
+Get basename of a path in a column
 ```shell
-> [[name];[/home/joe]] | path basename -c [ name ]
+> ls .. | path basename -c [ name ]
+```
+
+Get basename of a path in a column
+```shell
+> [[name];[C:\Users\Joe]] | path basename -c [ name ]
 ```
 
 Replace basename of a path
 ```shell
-> '/home/joe/test.txt' | path basename -r 'spam.png'
+> 'C:\Users\joe\test.txt' | path basename -r 'spam.png'
 ```

--- a/commands/docs/path_dirname.md
+++ b/commands/docs/path_dirname.md
@@ -27,7 +27,7 @@ usage: |
 
 Get dirname of a path
 ```shell
-> '/home/joe/code/test.txt' | path dirname
+> 'C:\Users\joe\code\test.txt' | path dirname
 ```
 
 Get dirname of a path in a column
@@ -37,10 +37,10 @@ Get dirname of a path in a column
 
 Walk up two levels
 ```shell
-> '/home/joe/code/test.txt' | path dirname -n 2
+> 'C:\Users\joe\code\test.txt' | path dirname -n 2
 ```
 
 Replace the part that would be returned with a custom path
 ```shell
-> '/home/joe/code/test.txt' | path dirname -n 2 -r /home/viking
+> 'C:\Users\joe\code\test.txt' | path dirname -n 2 -r C:\Users\viking
 ```

--- a/commands/docs/path_exists.md
+++ b/commands/docs/path_exists.md
@@ -28,7 +28,7 @@ If you need to distinguish dirs and files, please use `path type`.
 
 Check if a file exists
 ```shell
-> '/home/joe/todo.txt' | path exists
+> 'C:\Users\joe\todo.txt' | path exists
 ```
 
 Check if a file exists in a column

--- a/commands/docs/path_expand.md
+++ b/commands/docs/path_expand.md
@@ -19,15 +19,15 @@ usage: |
 
 ## Parameters
 
- -  `--strict`: Throw an error if the path could not be expanded
- -  `--no-symlink`: Do not resolve symbolic links
+ -  `--strict` `(-s)`: Throw an error if the path could not be expanded
+ -  `--no-symlink` `(-n)`: Do not resolve symbolic links
  -  `--columns {table}`: For a record or table input, expand strings at the given columns
 
 ## Examples
 
 Expand an absolute path
 ```shell
-> '/home/joe/foo/../bar' | path expand
+> 'C:\Users\joe\foo\..\bar' | path expand
 ```
 
 Expand a path in a column
@@ -37,5 +37,10 @@ Expand a path in a column
 
 Expand a relative path
 ```shell
-> 'foo/../bar' | path expand
+> 'foo\..\bar' | path expand
+```
+
+Expand an absolute path without following symlink
+```shell
+> 'foo\..\bar' | path expand -n
 ```

--- a/commands/docs/path_join.md
+++ b/commands/docs/path_join.md
@@ -29,12 +29,12 @@ the output of 'path parse' and 'path split' subcommands.
 
 Append a filename to a path
 ```shell
-> '/home/viking' | path join spam.txt
+> 'C:\Users\viking' | path join spam.txt
 ```
 
 Append a filename to a path
 ```shell
-> '/home/viking' | path join spams this_spam.txt
+> 'C:\Users\viking' | path join spams this_spam.txt
 ```
 
 Append a filename to a path inside a column
@@ -44,10 +44,10 @@ Append a filename to a path inside a column
 
 Join a list of parts into a path
 ```shell
-> [ '/' 'home' 'viking' 'spam.txt' ] | path join
+> [ 'C:' '\' 'Users' 'viking' 'spam.txt' ] | path join
 ```
 
 Join a structured path into a path
 ```shell
-> [[ parent stem extension ]; [ '/home/viking' 'spam' 'txt' ]] | path join
+> [ [parent stem extension]; ['C:\Users\viking' 'spam' 'txt']] | path join
 ```

--- a/commands/docs/path_parse.md
+++ b/commands/docs/path_parse.md
@@ -27,19 +27,19 @@ Each path is split into a table with 'parent', 'stem' and 'extension' fields.
 On Windows, an extra 'prefix' column is added.
 ## Examples
 
-Parse a path
+Parse a single path
 ```shell
-> '/home/viking/spam.txt' | path parse
+> 'C:\Users\viking\spam.txt' | path parse
 ```
 
 Replace a complex extension
 ```shell
-> '/home/viking/spam.tar.gz' | path parse -e tar.gz | upsert extension { 'txt' }
+> 'C:\Users\viking\spam.tar.gz' | path parse -e tar.gz | upsert extension { 'txt' }
 ```
 
 Ignore the extension
 ```shell
-> '/etc/conf.d' | path parse -e ''
+> 'C:\Users\viking.d' | path parse -e ''
 ```
 
 Parse all paths under the 'name' column

--- a/commands/docs/path_relative-to.md
+++ b/commands/docs/path_relative-to.md
@@ -30,7 +30,7 @@ path.
 
 Find a relative path from two absolute paths
 ```shell
-> '/home/viking' | path relative-to '/home'
+> 'C:\Users\viking' | path relative-to 'C:\Users'
 ```
 
 Find a relative path from two absolute paths in a column
@@ -40,5 +40,5 @@ Find a relative path from two absolute paths in a column
 
 Find a relative path from two relative paths
 ```shell
-> 'eggs/bacon/sausage/spam' | path relative-to 'eggs/bacon/sausage'
+> 'eggs\bacon\sausage\spam' | path relative-to 'eggs\bacon\sausage'
 ```

--- a/commands/docs/path_split.md
+++ b/commands/docs/path_split.md
@@ -25,7 +25,7 @@ usage: |
 
 Split a path into parts
 ```shell
-> '/home/viking/spam.txt' | path split
+> 'C:\Users\viking\spam.txt' | path split
 ```
 
 Split all paths under the 'name' column

--- a/commands/docs/print.md
+++ b/commands/docs/print.md
@@ -20,8 +20,8 @@ usage: |
 ## Parameters
 
  -  `...rest`: the values to print
- -  `--no-newline`: print without inserting a newline for the line ending
- -  `--stderr`: print to stderr instead of stdout
+ -  `--no-newline` `(-n)`: print without inserting a newline for the line ending
+ -  `--stderr` `(-e)`: print to stderr instead of stdout
 
 ## Notes
 Unlike `echo`, this command does not return any value (`print | describe` will return "nothing").

--- a/commands/docs/profile.md
+++ b/commands/docs/profile.md
@@ -20,8 +20,8 @@ usage: |
 ## Parameters
 
  -  `closure`: the closure to run
- -  `--source`: Collect source code in the report
- -  `--values`: Collect values in the report
+ -  `--source` `(-)`: Collect source code in the report
+ -  `--values` `(-)`: Collect values in the report
  -  `--max-depth {int}`: How many levels of blocks to step into (default: 1)
 
 ## Notes

--- a/commands/docs/ps.md
+++ b/commands/docs/ps.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--long`: list all available columns for each entry
+ -  `--long` `(-l)`: list all available columns for each entry
 
 ## Examples
 

--- a/commands/docs/registry_query.md
+++ b/commands/docs/registry_query.md
@@ -21,16 +21,16 @@ usage: |
 
  -  `key`: registry key to query
  -  `value`: optionally supply a registry value to query
- -  `--hkcr`: query the hkey_classes_root hive
- -  `--hkcu`: query the hkey_current_user hive
- -  `--hklm`: query the hkey_local_machine hive
- -  `--hku`: query the hkey_users hive
- -  `--hkpd`: query the hkey_performance_data hive
- -  `--hkpt`: query the hkey_performance_text hive
- -  `--hkpnls`: query the hkey_performance_nls_text hive
- -  `--hkcc`: query the hkey_current_config hive
- -  `--hkdd`: query the hkey_dyn_data hive
- -  `--hkculs`: query the hkey_current_user_local_settings hive
+ -  `--hkcr` `(-)`: query the hkey_classes_root hive
+ -  `--hkcu` `(-)`: query the hkey_current_user hive
+ -  `--hklm` `(-)`: query the hkey_local_machine hive
+ -  `--hku` `(-)`: query the hkey_users hive
+ -  `--hkpd` `(-)`: query the hkey_performance_data hive
+ -  `--hkpt` `(-)`: query the hkey_performance_text hive
+ -  `--hkpnls` `(-)`: query the hkey_performance_nls_text hive
+ -  `--hkcc` `(-)`: query the hkey_current_config hive
+ -  `--hkdd` `(-)`: query the hkey_dyn_data hive
+ -  `--hkculs` `(-)`: query the hkey_current_user_local_settings hive
 
 ## Notes
 Currently supported only on Windows systems.

--- a/commands/docs/rm.md
+++ b/commands/docs/rm.md
@@ -21,13 +21,13 @@ usage: |
 
  -  `filename`: the path of the file you want to remove
  -  `...rest`: additional file path(s) to remove
- -  `--trash`: move to the platform's trash instead of permanently deleting
- -  `--permanent`: delete permanently, ignoring the 'always_trash' config option
- -  `--recursive`: delete subdirectories recursively
- -  `--force`: suppress error when no file
- -  `--verbose`: print names of deleted files
- -  `--interactive`: ask user to confirm action
- -  `--interactive-once`: ask user to confirm action only once
+ -  `--trash` `(-t)`: move to the platform's trash instead of permanently deleting
+ -  `--permanent` `(-p)`: delete permanently, ignoring the 'always_trash' config option
+ -  `--recursive` `(-r)`: delete subdirectories recursively
+ -  `--force` `(-f)`: suppress error when no file
+ -  `--verbose` `(-v)`: print names of deleted files
+ -  `--interactive` `(-i)`: ask user to confirm action
+ -  `--interactive-once` `(-I)`: ask user to confirm action only once
 
 ## Examples
 

--- a/commands/docs/roll_left.md
+++ b/commands/docs/roll_left.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `--by {int}`: Number of columns to roll
- -  `--cells-only`: rotates columns leaving headers fixed
+ -  `--cells-only` `(-c)`: rotates columns leaving headers fixed
 
 ## Examples
 

--- a/commands/docs/roll_right.md
+++ b/commands/docs/roll_right.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `--by {int}`: Number of columns to roll
- -  `--cells-only`: rotates columns leaving headers fixed
+ -  `--cells-only` `(-c)`: rotates columns leaving headers fixed
 
 ## Examples
 

--- a/commands/docs/rotate.md
+++ b/commands/docs/rotate.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `...rest`: the names to give columns once rotated
- -  `--ccw`: rotate counter clockwise
+ -  `--ccw` `(-)`: rotate counter clockwise
 
 ## Examples
 

--- a/commands/docs/run-external.md
+++ b/commands/docs/run-external.md
@@ -21,9 +21,9 @@ usage: |
 
  -  `command`: external command to run
  -  `...rest`: arguments for external command
- -  `--redirect-stdout`: redirect stdout to the pipeline
- -  `--redirect-stderr`: redirect stderr to the pipeline
- -  `--trim-end-newline`: trimming end newlines
+ -  `--redirect-stdout` `(-)`: redirect stdout to the pipeline
+ -  `--redirect-stderr` `(-)`: redirect stderr to the pipeline
+ -  `--trim-end-newline` `(-)`: trimming end newlines
 
 ## Examples
 

--- a/commands/docs/save.md
+++ b/commands/docs/save.md
@@ -21,10 +21,10 @@ usage: |
 
  -  `filename`: the filename to use
  -  `--stderr {path}`: the filename used to save stderr, only works with `-r` flag
- -  `--raw`: save file as raw binary
- -  `--append`: append input to the end of the file
- -  `--force`: overwrite the destination
- -  `--progress`: enable progress bar
+ -  `--raw` `(-r)`: save file as raw binary
+ -  `--append` `(-a)`: append input to the end of the file
+ -  `--force` `(-f)`: overwrite the destination
+ -  `--progress` `(-p)`: enable progress bar
 
 ## Examples
 

--- a/commands/docs/select.md
+++ b/commands/docs/select.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `...rest`: the columns to select from the table
- -  `--ignore-errors`: when an error occurs, instead of erroring out, suppress the error message
+ -  `--ignore-errors` `(-i)`: when an error occurs, instead of erroring out, suppress the error message
 
 ## Examples
 

--- a/commands/docs/seq_date.md
+++ b/commands/docs/seq_date.md
@@ -25,7 +25,7 @@ usage: |
  -  `--end-date {string}`: ending date
  -  `--increment {int}`: increment dates by this number
  -  `--days {int}`: number of days to print
- -  `--reverse`: print dates in reverse
+ -  `--reverse` `(-r)`: print dates in reverse
 
 ## Examples
 

--- a/commands/docs/sort-by.md
+++ b/commands/docs/sort-by.md
@@ -20,9 +20,9 @@ usage: |
 ## Parameters
 
  -  `...rest`: the column(s) to sort by
- -  `--reverse`: Sort in reverse order
- -  `--ignore-case`: Sort string-based columns case-insensitively
- -  `--natural`: Sort alphanumeric string-based columns naturally (1, 9, 10, 99, 100, ...)
+ -  `--reverse` `(-r)`: Sort in reverse order
+ -  `--ignore-case` `(-i)`: Sort string-based columns case-insensitively
+ -  `--natural` `(-n)`: Sort alphanumeric string-based columns naturally (1, 9, 10, 99, 100, ...)
 
 ## Examples
 

--- a/commands/docs/sort.md
+++ b/commands/docs/sort.md
@@ -19,10 +19,10 @@ usage: |
 
 ## Parameters
 
- -  `--reverse`: Sort in reverse order
- -  `--ignore-case`: Sort string-based data case-insensitively
- -  `--values`: If input is a single record, sort the record by values; ignored if input is not a single record
- -  `--natural`: Sort alphanumeric string-based values naturally (1, 9, 10, 99, 100, ...)
+ -  `--reverse` `(-r)`: Sort in reverse order
+ -  `--ignore-case` `(-i)`: Sort string-based data case-insensitively
+ -  `--values` `(-v)`: If input is a single record, sort the record by values; ignored if input is not a single record
+ -  `--natural` `(-n)`: Sort alphanumeric string-based values naturally (1, 9, 10, 99, 100, ...)
 
 ## Examples
 

--- a/commands/docs/split_chars.md
+++ b/commands/docs/split_chars.md
@@ -19,8 +19,8 @@ usage: |
 
 ## Parameters
 
- -  `--grapheme-clusters`: split on grapheme clusters
- -  `--code-points`: split on code points (default; splits combined characters)
+ -  `--grapheme-clusters` `(-g)`: split on grapheme clusters
+ -  `--code-points` `(-c)`: split on code points (default; splits combined characters)
 
 ## Examples
 

--- a/commands/docs/split_column.md
+++ b/commands/docs/split_column.md
@@ -21,7 +21,7 @@ usage: |
 
  -  `separator`: the character or string that denotes what separates columns
  -  `...rest`: column names to give the new columns
- -  `--collapse-empty`: remove empty columns
+ -  `--collapse-empty` `(-c)`: remove empty columns
 
 ## Examples
 

--- a/commands/docs/split_words.md
+++ b/commands/docs/split_words.md
@@ -20,8 +20,8 @@ usage: |
 ## Parameters
 
  -  `--min-word-length {int}`: The minimum word length
- -  `--grapheme-clusters`: measure word length in grapheme clusters (requires -l)
- -  `--utf-8-bytes`: measure word length in UTF-8 bytes (default; requires -l; non-ASCII chars are length 2+)
+ -  `--grapheme-clusters` `(-g)`: measure word length in grapheme clusters (requires -l)
+ -  `--utf-8-bytes` `(-b)`: measure word length in UTF-8 bytes (default; requires -l; non-ASCII chars are length 2+)
 
 ## Examples
 

--- a/commands/docs/str_contains.md
+++ b/commands/docs/str_contains.md
@@ -21,8 +21,8 @@ usage: |
 
  -  `string`: the substring to find
  -  `...rest`: For a data structure input, check strings at the given cell paths, and replace with result
- -  `--ignore-case`: search is case insensitive
- -  `--not`: does not contain
+ -  `--ignore-case` `(-i)`: search is case insensitive
+ -  `--not` `(-n)`: does not contain
 
 ## Examples
 

--- a/commands/docs/str_index-of.md
+++ b/commands/docs/str_index-of.md
@@ -21,10 +21,10 @@ usage: |
 
  -  `string`: the string to find in the input
  -  `...rest`: For a data structure input, search strings at the given cell paths, and replace with result
- -  `--grapheme-clusters`: count indexes using grapheme clusters (all visible chars have length 1)
- -  `--utf-8-bytes`: count indexes using UTF-8 bytes (default; non-ASCII chars have length 2+)
+ -  `--grapheme-clusters` `(-g)`: count indexes using grapheme clusters (all visible chars have length 1)
+ -  `--utf-8-bytes` `(-b)`: count indexes using UTF-8 bytes (default; non-ASCII chars have length 2+)
  -  `--range {any}`: optional start and/or end index
- -  `--end`: search from the end of the input
+ -  `--end` `(-e)`: search from the end of the input
 
 ## Examples
 

--- a/commands/docs/str_length.md
+++ b/commands/docs/str_length.md
@@ -20,8 +20,8 @@ usage: |
 ## Parameters
 
  -  `...rest`: For a data structure input, replace strings at the given cell paths with their length
- -  `--grapheme-clusters`: count length using grapheme clusters (all visible chars have length 1)
- -  `--utf-8-bytes`: count length using UTF-8 bytes (default; all non-ASCII chars have length 2+)
+ -  `--grapheme-clusters` `(-g)`: count length using grapheme clusters (all visible chars have length 1)
+ -  `--utf-8-bytes` `(-b)`: count length using UTF-8 bytes (default; all non-ASCII chars have length 2+)
 
 ## Examples
 

--- a/commands/docs/str_replace.md
+++ b/commands/docs/str_replace.md
@@ -22,9 +22,9 @@ usage: |
  -  `find`: the pattern to find
  -  `replace`: the replacement string
  -  `...rest`: For a data structure input, operate on strings at the given cell paths
- -  `--all`: replace all occurrences of the pattern
- -  `--no-expand`: do not expand capture groups (like $name) in the replacement string
- -  `--string`: match the pattern as a substring of the input, instead of a regular expression
+ -  `--all` `(-a)`: replace all occurrences of the pattern
+ -  `--no-expand` `(-n)`: do not expand capture groups (like $name) in the replacement string
+ -  `--string` `(-s)`: match the pattern as a substring of the input, instead of a regular expression
 
 ## Examples
 

--- a/commands/docs/str_substring.md
+++ b/commands/docs/str_substring.md
@@ -21,8 +21,8 @@ usage: |
 
  -  `range`: the indexes to substring [start end]
  -  `...rest`: For a data structure input, turn strings at the given cell paths into substrings
- -  `--grapheme-clusters`: count indexes and split using grapheme clusters (all visible chars have length 1)
- -  `--utf-8-bytes`: count indexes and split using UTF-8 bytes (default; non-ASCII chars have length 2+)
+ -  `--grapheme-clusters` `(-g)`: count indexes and split using grapheme clusters (all visible chars have length 1)
+ -  `--utf-8-bytes` `(-b)`: count indexes and split using UTF-8 bytes (default; non-ASCII chars have length 2+)
 
 ## Examples
 

--- a/commands/docs/str_trim.md
+++ b/commands/docs/str_trim.md
@@ -21,11 +21,11 @@ usage: |
 
  -  `...rest`: For a data structure input, trim strings at the given cell paths
  -  `--char {string}`: character to trim (default: whitespace)
- -  `--left`: trims characters only from the beginning of the string (default: whitespace)
- -  `--right`: trims characters only from the end of the string (default: whitespace)
- -  `--all`: trims all characters from both sides of the string *and* in the middle (default: whitespace)
- -  `--both`: trims all characters from left and right side of the string (default: whitespace)
- -  `--format`: trims spaces replacing multiple characters with singles in the middle (default: whitespace)
+ -  `--left` `(-l)`: trims characters only from the beginning of the string (default: whitespace)
+ -  `--right` `(-r)`: trims characters only from the end of the string (default: whitespace)
+ -  `--all` `(-a)`: trims all characters from both sides of the string *and* in the middle (default: whitespace)
+ -  `--both` `(-b)`: trims all characters from left and right side of the string (default: whitespace)
+ -  `--format` `(-f)`: trims spaces replacing multiple characters with singles in the middle (default: whitespace)
 
 ## Examples
 

--- a/commands/docs/table.md
+++ b/commands/docs/table.md
@@ -20,13 +20,13 @@ usage: |
 ## Parameters
 
  -  `--start-number {int}`: row number to start viewing from
- -  `--list`: list available table modes/themes
+ -  `--list` `(-l)`: list available table modes/themes
  -  `--width {int}`: number of terminal columns wide (not output columns)
- -  `--expand`: expand the table structure in a light mode
+ -  `--expand` `(-e)`: expand the table structure in a light mode
  -  `--expand-deep {int}`: an expand limit of recursion which will take place
- -  `--flatten`: Flatten simple arrays
+ -  `--flatten` `(-)`: Flatten simple arrays
  -  `--flatten-separator {string}`: sets a separator when 'flatten' used
- -  `--collapse`: expand the table structure in collapse mode.
+ -  `--collapse` `(-c)`: expand the table structure in collapse mode.
 Be aware collapse mode currently doesn't support width control
 
 ## Notes

--- a/commands/docs/to_csv.md
+++ b/commands/docs/to_csv.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `--separator {string}`: a character to separate columns, defaults to ','
- -  `--noheaders`: do not output the columns names as the first row
+ -  `--noheaders` `(-n)`: do not output the columns names as the first row
 
 ## Examples
 

--- a/commands/docs/to_html.md
+++ b/commands/docs/to_html.md
@@ -19,12 +19,12 @@ usage: |
 
 ## Parameters
 
- -  `--html-color`: change ansi colors to html colors
- -  `--no-color`: remove all ansi colors in output
- -  `--dark`: indicate your background color is a darker color
- -  `--partial`: only output the html for the content itself
+ -  `--html-color` `(-c)`: change ansi colors to html colors
+ -  `--no-color` `(-n)`: remove all ansi colors in output
+ -  `--dark` `(-d)`: indicate your background color is a darker color
+ -  `--partial` `(-p)`: only output the html for the content itself
  -  `--theme {string}`: the name of the theme to use (github, blulocolight, ...)
- -  `--list`: produce a color table of all available themes
+ -  `--list` `(-l)`: produce a color table of all available themes
 
 ## Notes
 Screenshots of the themes can be browsed here: https://github.com/mbadolato/iTerm2-Color-Schemes

--- a/commands/docs/to_json.md
+++ b/commands/docs/to_json.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--raw`: remove all of the whitespace
+ -  `--raw` `(-r)`: remove all of the whitespace
  -  `--indent {number}`: specify indentation width
  -  `--tabs {number}`: specify indentation tab quantity
 

--- a/commands/docs/to_md.md
+++ b/commands/docs/to_md.md
@@ -19,8 +19,8 @@ usage: |
 
 ## Parameters
 
- -  `--pretty`: Formats the Markdown table to vertically align items
- -  `--per-element`: treat each row as markdown syntax element
+ -  `--pretty` `(-p)`: Formats the Markdown table to vertically align items
+ -  `--per-element` `(-e)`: treat each row as markdown syntax element
 
 ## Examples
 

--- a/commands/docs/to_tsv.md
+++ b/commands/docs/to_tsv.md
@@ -19,7 +19,7 @@ usage: |
 
 ## Parameters
 
- -  `--noheaders`: do not output the column names as the first row
+ -  `--noheaders` `(-n)`: do not output the column names as the first row
 
 ## Examples
 

--- a/commands/docs/touch.md
+++ b/commands/docs/touch.md
@@ -22,9 +22,9 @@ usage: |
  -  `filename`: the path of the file you want to create
  -  `...rest`: additional files to create
  -  `--reference {string}`: change the file or directory time to the time of the reference file/directory
- -  `--modified`: change the modification time of the file or directory. If no timestamp, date or reference file/directory is given, the current time is used
- -  `--access`: change the access time of the file or directory. If no timestamp, date or reference file/directory is given, the current time is used
- -  `--no-create`: do not create the file if it does not exist
+ -  `--modified` `(-m)`: change the modification time of the file or directory. If no timestamp, date or reference file/directory is given, the current time is used
+ -  `--access` `(-a)`: change the access time of the file or directory. If no timestamp, date or reference file/directory is given, the current time is used
+ -  `--no-create` `(-c)`: do not create the file if it does not exist
 
 ## Examples
 

--- a/commands/docs/transpose.md
+++ b/commands/docs/transpose.md
@@ -20,11 +20,11 @@ usage: |
 ## Parameters
 
  -  `...rest`: the names to give columns once transposed
- -  `--header-row`: treat the first row as column names
- -  `--ignore-titles`: don't transpose the column names into values
- -  `--as-record`: transfer to record if the result is a table and contains only one row
- -  `--keep-last`: on repetition of record fields due to `header-row`, keep the last value obtained
- -  `--keep-all`: on repetition of record fields due to `header-row`, keep all the values obtained
+ -  `--header-row` `(-r)`: treat the first row as column names
+ -  `--ignore-titles` `(-i)`: don't transpose the column names into values
+ -  `--as-record` `(-d)`: transfer to record if the result is a table and contains only one row
+ -  `--keep-last` `(-l)`: on repetition of record fields due to `header-row`, keep the last value obtained
+ -  `--keep-all` `(-a)`: on repetition of record fields due to `header-row`, keep all the values obtained
 
 ## Examples
 

--- a/commands/docs/uniq-by.md
+++ b/commands/docs/uniq-by.md
@@ -20,10 +20,10 @@ usage: |
 ## Parameters
 
  -  `...rest`: the column(s) to filter by
- -  `--count`: Return a table containing the distinct input values together with their counts
- -  `--repeated`: Return the input values that occur more than once
- -  `--ignore-case`: Ignore differences in case when comparing input values
- -  `--unique`: Return the input values that occur once only
+ -  `--count` `(-c)`: Return a table containing the distinct input values together with their counts
+ -  `--repeated` `(-d)`: Return the input values that occur more than once
+ -  `--ignore-case` `(-i)`: Ignore differences in case when comparing input values
+ -  `--unique` `(-u)`: Return the input values that occur once only
 
 ## Examples
 

--- a/commands/docs/uniq.md
+++ b/commands/docs/uniq.md
@@ -19,10 +19,10 @@ usage: |
 
 ## Parameters
 
- -  `--count`: Return a table containing the distinct input values together with their counts
- -  `--repeated`: Return the input values that occur more than once
- -  `--ignore-case`: Compare input values case-insensitively
- -  `--unique`: Return the input values that occur once only
+ -  `--count` `(-c)`: Return a table containing the distinct input values together with their counts
+ -  `--repeated` `(-d)`: Return the input values that occur more than once
+ -  `--ignore-case` `(-i)`: Compare input values case-insensitively
+ -  `--unique` `(-u)`: Return the input values that occur once only
 
 ## Examples
 

--- a/commands/docs/url_encode.md
+++ b/commands/docs/url_encode.md
@@ -20,7 +20,7 @@ usage: |
 ## Parameters
 
  -  `...rest`: For a data structure input, check strings at the given cell paths, and replace with result
- -  `--all`: encode all non-alphanumeric chars including `/`, `.`, `:`
+ -  `--all` `(-a)`: encode all non-alphanumeric chars including `/`, `.`, `:`
 
 ## Examples
 

--- a/commands/docs/watch.md
+++ b/commands/docs/watch.md
@@ -24,7 +24,7 @@ usage: |
  -  `--debounce-ms {int}`: Debounce changes for this many milliseconds (default: 100). Adjust if you find that single writes are reported as multiple events
  -  `--glob {string}`: Only report changes for files that match this glob pattern (default: all files)
  -  `--recursive {bool}`: Watch all directories under `<path>` recursively. Will be ignored if `<path>` is a file (default: true)
- -  `--verbose`: Operate in verbose mode (default: false)
+ -  `--verbose` `(-v)`: Operate in verbose mode (default: false)
 
 ## Examples
 

--- a/commands/docs/which.md
+++ b/commands/docs/which.md
@@ -21,7 +21,7 @@ usage: |
 
  -  `application`: application
  -  `...rest`: additional applications
- -  `--all`: list all executables
+ -  `--all` `(-a)`: list all executables
 
 ## Examples
 

--- a/commands/docs/window.md
+++ b/commands/docs/window.md
@@ -21,7 +21,7 @@ usage: |
 
  -  `window_size`: the size of each window
  -  `--stride {int}`: the number of rows to slide over between windows
- -  `--remainder`: yield last chunks even if they have fewer elements than size
+ -  `--remainder` `(-r)`: yield last chunks even if they have fewer elements than size
 
 ## Examples
 

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -97,7 +97,7 @@ def command-doc [command] {
       if $param.parameter_type == "positional" {
         $" -  `($param.parameter_name)`: ($param.description)"
       } else if $param.parameter_type == "switch" {
-        $" -  `--($param.parameter_name)`: ($param.description)"
+        $" -  `--($param.parameter_name)\(-($param.short_flag)\)`: ($param.description)"
       } else if $param.parameter_type == "named" {
         $" -  `--($param.parameter_name) {($param.syntax_shape)}`: ($param.description)"
       } else if $param.parameter_type == "rest" {

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -2,7 +2,7 @@ def main [] {
   # Old commands are currently not deleted because some of them
   # are platform-specific (currently `exec`, `registry query`), and a single run of this script will not regenerate
   # all of them.
-  #do -i { rm book/commands/docs/*.md }
+  #do -i { rm commands/docs/*.md }
 
   let commands = ($nu.scope.commands | where is_custom == false and is_extern == false | sort-by category)
   let commands_group = ($commands | group-by name)
@@ -111,8 +111,8 @@ def command-doc [command] {
   let ex = $command.extra_usage
   # Certain commands' extra_usage is wrapped in code block markup to prevent their code from
   # being interpreted as markdown. This is strictly hard-coded for now.
-  let extra_usage = if $ex == "" { 
-    "" 
+  let extra_usage = if $ex == "" {
+    ""
   } else if $command.name in ['def-env' 'export def-env' 'as-date' 'as-datetime' ansi] {
     $"## Notes(char newline)```text(char newline)($ex)(char newline)```(char newline)"
   } else {
@@ -132,8 +132,8 @@ $"($example.description)
     } | str join)
 
     $example_top + $examples
-  } else { 
-    "" 
+  } else {
+    ""
   }
 
   let doc = (
@@ -148,10 +148,10 @@ $"($example.description)
 def generate-category-sidebar [unique_categories] {
   let sidebar_path = (['.', '.vuepress', 'configs', "sidebar", "command_categories.ts"] | path join)
   let list_content = (
-    $unique_categories |
-    each { safe-path } |
-    each { |category| $"  '/commands/categories/($category).md',"} |
-    str join (char newline)
+    $unique_categories
+      | each { safe-path }
+      | each { |category| $"  '/commands/categories/($category).md',"}
+      | str join (char newline)
   )
   $"export const commandCategories = [
 ($list_content)

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -97,7 +97,7 @@ def command-doc [command] {
       if $param.parameter_type == "positional" {
         $" -  `($param.parameter_name)`: ($param.description)"
       } else if $param.parameter_type == "switch" {
-        $" -  `--($param.parameter_name)\(-($param.short_flag)\)`: ($param.description)"
+        $" -  `--($param.parameter_name)` `\(-($param.short_flag)\)`: ($param.description)"
       } else if $param.parameter_type == "named" {
         $" -  `--($param.parameter_name) {($param.syntax_shape)}`: ($param.description)"
       } else if $param.parameter_type == "rest" {


### PR DESCRIPTION
Add short flags to command docs, fix #509

Before, `ls` for example:
```markdown
## Parameters

 -  `pattern`: the glob pattern to use
 -  `--all`: Show hidden files
 -  `--long`: Get all available columns for each entry (slower; columns are platform-dependent)
 -  `--short-names`: Only print the file names, and not the path
 -  `--full-paths`: display paths as absolute paths
 -  `--du`: Display the apparent directory size ("disk usage") in place of the directory metadata size
 -  `--directory`: List the specified directory itself instead of its contents
 -  `--mime-type`: Show mime-type in type column instead of 'file' (based on filenames only; files' contents are not examined)
```

After, `ls` for example:
```markdown
## Parameters

 -  `pattern`: the glob pattern to use
 -  `--all(-a)`: Show hidden files
 -  `--long(-l)`: Get all available columns for each entry (slower; columns are platform-dependent)
 -  `--short-names(-s)`: Only print the file names, and not the path
 -  `--full-paths(-f)`: display paths as absolute paths
 -  `--du(-d)`: Display the apparent directory size ("disk usage") in place of the directory metadata size
 -  `--directory(-D)`: List the specified directory itself instead of its contents
 -  `--mime-type(-m)`: Show mime-type in type column instead of 'file' (based on filenames only; files' contents are not examined)
```