### PR TITLE
Rename $env.PATH to $env.Path to reflect actual shell behavior

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -44,7 +44,7 @@ Note: this table assumes Nu 0.60.0 or later.
 | `stat $(which git)`                  | `stat (which git).path`                          | Use command output as argument for other command                  |
 | `echo /tmp/$RANDOM`                  | `$"/tmp/(random integer)"`                       | Use command output in a string                                    |
 | `cargo b --jobs=$(nproc)`            | `cargo b $"--jobs=(sys \| get cpu \| length)"`   | Use command output in an option                                   |
-| `echo $PATH`                         | `$env.PATH`                                      | See the current path                                              |
+| `echo $PATH`                         | `$env.PATH` (Non-Windows) or `$env.Path` (Windows) | See the current path                                            |
 | `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Update PATH permanently                                           |
 | `export PATH = $PATH:/usr/other/bin` | `let-env PATH = ($env.PATH \| append /usr/other/bin)` | Update PATH temporarily                                      |
 | `export`                             | `$env`                                           | List the current environment variables                            |


### PR DESCRIPTION
The documentation states that `$env.PATH` lets the user quote "See the current path". This is not what happens though, the command errors out.

```
❯ $env.PATH
Error: nu::shell::name_not_found (link)

  × Name not found
   ╭─[entry #16:1:1]
 1 │ $env.PATH
   ·      ──┬─
   ·        ╰── did you mean 'Path'?
   ╰────
```

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/35022953/221650175-f6efc961-91e2-4664-b6f2-9231ff45e55a.png)

</details>

The correct command *in Windows* to get the current path is `$env.Path`, not `$env.PATH`.