### PR TITLE
FIX: remove mentions to old and deprecated `&&` and `||` logic operators

### DIFF
--- a/book/dataframes.md
+++ b/book/dataframes.md
@@ -728,7 +728,7 @@ The masks can also be created from Nushell lists, for example:
 To create complex masks, we have the `AND`
 
 ```shell
-> $mask && $mask1
+> $mask and $mask1
 
 ───┬──────────────────
  # │ and_new_col_mask
@@ -742,7 +742,7 @@ To create complex masks, we have the `AND`
 and `OR` operations
 
 ```shell
-> $mask || $mask1
+> $mask or $mask1
 
 ───┬─────────────────
  # │ or_new_col_mask

--- a/book/nushell_operator_map.md
+++ b/book/nushell_operator_map.md
@@ -21,5 +21,5 @@ Note: this table assumes Nu 0.14.1 or later.
 | \*\*    | pow      | \*\*               | Power                | Pow                    | \*\*               |
 | in      | in       | re, in, startswith | Contains, StartsWith | -In                    | case in            |
 | not-in  | not in   | not in             | Except               | -NotIn                 |                    |
-| &&      | and      | and                | &&                   | -And, &&               | -a, &&             |
-| \|\|    | or       | or                 | \|\|                 | -Or, \|\|              | -o, \|\|           |
+| and     | and      | and                | &&                   | -And, &&               | -a, &&             |
+| or      | or       | or                 | \|\|                 | -Or, \|\|              | -o, \|\|           |

--- a/cookbook/git.md
+++ b/cookbook/git.md
@@ -11,7 +11,7 @@ Nu can help with common `Git` tasks like removing all local branches which have 
 **Warning**: This command will hard delete the merged branches from your machine. You may want to check the branches selected for deletion by omitting the last git command.
 
 ```shell
-> git branch --merged | lines | where ($it != "* master" && $it != "* main") | each {|br| git branch -D ($br | str trim) } | str trim
+> git branch --merged | lines | where ($it != "* master" and $it != "* main") | each {|br| git branch -D ($br | str trim) } | str trim
 ```
 
 Output

--- a/es/book/instalacion.md
+++ b/es/book/instalacion.md
@@ -157,7 +157,7 @@ Git nos clonará el repositorio principal de Nu. Partiendo de ahí podemos contr
 ```
 
 > cd nushell
-> nushell> cargo build --workspace --features=stable && cargo run --features=stable
+> nushell> cargo build --workspace --features=stable; cargo run --features=stable
 
 ```
 
@@ -165,7 +165,7 @@ También puedes construir y arrancar Nu en modo release:
 
 ```
 
-nushell> cargo build --release --workspace --features=stable && cargo run --release --features=stable
+nushell> cargo build --release --workspace --features=stable; cargo run --release --features=stable
 
 ```
 Gente familiarizada con Rust se preguntará la razón por la que hacemos un paso "build" y otro paso "run" si "run" construye por defecto. Esto es para evitar una deficiencia de la nueva opción `default-run` en Cargo y asegurar que todos los plugins se construyan aunque puede que esto no sea necesario en el futuro.

--- a/es/book/mapa_operador_nushell.md
+++ b/es/book/mapa_operador_nushell.md
@@ -20,5 +20,5 @@ Nota: esta tabla asume Nu 0.14.1 o posterior.
 | /       | /        | /                  | /                    | /                      | /                  |
 | in      | in       | re, in, startswith | Contains, StartsWith | -In                    | case in            |
 | not-in  | not in   | not in             | Except               | -NotIn                 |                    |
-| &&      | and      | and                | &&                   | -And                   | -a, &&             |
-| \|\|    | or       | or                 | \|\|                 | -Or                    | -o, \|\|           |
+| and     | and      | and                | &&                   | -And                   | -a, &&             |
+| or      | or       | or                 | \|\|                 | -Or                    | -o, \|\|           |

--- a/ja/book/nushell_operator_map.md
+++ b/ja/book/nushell_operator_map.md
@@ -20,5 +20,5 @@
 | /       | /        | /                  | /                    | /                      | /                  |
 | in      | in       | re, in, startswith | Contains, StartsWith | -In                    | case in            |
 | not-in  | not in   | not in             | Except               | -NotIn                 |                    |
-| &&      | and      | and                | &&                   | -And                   | -a, &&             |
-| \|\|    | or       | or                 | \|\|                 | -Or                    | -o, \|\|           |
+| and     | and      | and                | &&                   | -And                   | -a, &&             |
+| or      | or       | or                 | \|\|                 | -Or                    | -o, \|\|           |

--- a/pt-BR/book/instalacao.md
+++ b/pt-BR/book/instalacao.md
@@ -127,13 +127,13 @@ O Git vai clonar o repositório principal do nushell e daí podemos fazer o buil
 
 ```bash
 > cd nushell
-nushell> cargo build --workspace --features=stable && cargo run --features=stable
+nushell> cargo build --workspace --features=stable; cargo run --features=stable
 ```
 
 Você também pode fazer o build e rodar o Nu em modo release:
 
 ```bash
-nushell> cargo build --release --workspace --features=stable && cargo run --release --features=stable
+nushell> cargo build --release --workspace --features=stable; cargo run --release --features=stable
 ```
 
 Pessoas mais acostumadas com Rust podem se perguntar por que fazemos tanto o "build" como o "run" se o "run" já faz o build por padrão. Isso serve para contornar uma falha da nova opção `default-run` no Cargo e assegurar que será feito o build de todos os plugins, embora possa não ser necessário no futuro.

--- a/snippets/installation/build_nu_from_source.sh
+++ b/snippets/installation/build_nu_from_source.sh
@@ -1,2 +1,2 @@
 > cd nushell
-nushell> cargo build --workspace && cargo run
+nushell> cargo build --workspace; cargo run

--- a/snippets/installation/build_nu_from_source_release.sh
+++ b/snippets/installation/build_nu_from_source_release.sh
@@ -1,1 +1,1 @@
-nushell> cargo build --release --workspace && cargo run --release
+nushell> cargo build --release --workspace; cargo run --release

--- a/zh-CN/book/dataframes.md
+++ b/zh-CN/book/dataframes.md
@@ -627,7 +627,7 @@ Nushell 的管道系统可以帮助你创建非常有趣的工作流程。
 为了创建复杂的掩码，我们可以使用`AND`：
 
 ```shell
-> $mask && $mask1
+> $mask and $mask1
 
 ───┬──────────────────
  # │ and_new_col_mask
@@ -641,7 +641,7 @@ Nushell 的管道系统可以帮助你创建非常有趣的工作流程。
 或者 `OR` 操作：
 
 ```shell
-> $mask || $mask1
+> $mask or $mask1
 
 ───┬─────────────────
  # │ or_new_col_mask

--- a/zh-CN/book/nushell_operator_map.md
+++ b/zh-CN/book/nushell_operator_map.md
@@ -21,5 +21,5 @@
 | \*\*    | pow      | \*\*               | Power                | Pow                    | \*\*               |
 | in      | in       | re, in, startswith | Contains, StartsWith | -In                    | case in            |
 | not-in  | not in   | not in             | Except               | -NotIn                 |                    |
-| &&      | and      | and                | &&                   | -And, &&               | -a, &&             |
-| \|\|    | or       | or                 | \|\|                 | -Or, \|\|              | -o, \|\|           |
+| and     | and      | and                | &&                   | -And, &&               | -a, &&             |
+| or      | or       | or                 | \|\|                 | -Or, \|\|              | -o, \|\|           |


### PR DESCRIPTION
hello there :wave: :yum: 

i did notice, in the installation page, that there were remaining mentions to the old and deprecated `&&` and `||` operators

> **Note**
> this is what we get now
> ```bash
> >_ true && true
> Error: nu::parser::shell_andand
> 
>   × The '&&' operator is not supported in Nushell
>    ╭─[entry #12:1:1]
>  1 │ true && true
>    ·      ─┬
>    ·       ╰── instead of '&&', use ';' or 'and'
>    ╰────
>   help: use ';' instead of the shell '&&', or 'and' instead of the boolean
>         '&&'
> ```
> and
> ```bash
> >_ false || true
> Error: nu::parser::shell_oror
> 
>   × The '||' operator is not supported in Nushell
>    ╭─[entry #13:1:1]
>  1 │ false || true
>    ·       ─┬
>    ·        ╰── instead of '||', use 'try' or 'or'
>    ╰────
>   help: use 'try' instead of the shell '||', or 'or' instead of the boolean
>         '||'
> ```
> and the output of `help operators` does not contain them anymore

### this PR removes the old `&&` and `||` or replaces them by `and` and `or` when possible

## the changes
i've used `rg '&&'` and `rg '\|\|'` to track the files with bad operators
- only focused on the book => it is ok to keep these bad operators in the old blog post

i hope i did not miss any of them and i did not edit things that were ok :relieved: 

## disclaimer
i've got the following pending change i do not know what to do with, i'm not fluent enough in any of these languages to know if the `&&` and `||` are legit or not :eyes: 
```diff
diff --git a/de/book/mathematik.md b/de/book/mathematik.md
index 37b9b121c1..c54396db01 100644
--- a/de/book/mathematik.md
+++ b/de/book/mathematik.md
@@ -56,7 +56,7 @@ Die folgenden Vergleichsoperatoren sind ebenfalls verfügbar:
 
 ## Verknüpfungsoperatoren
 
-Nushell unterstützt auch die Operatoren `&&` ("und") und `||` ("oder") um zwei Operationen die Bool-Werte zurückgeben zu verbinden. Zum Beispiel: `ls | where name in ["one" "two" "three"] && size > 10kb`
+Nushell unterstützt auch die Operatoren `and` ("und") und `or` ("oder") um zwei Operationen die Bool-Werte zurückgeben zu verbinden. Zum Beispiel: `ls | where name in ["one" "two" "three"] and size > 10kb`
 
 ## Reihenfolge von Operationen
 
diff --git a/es/book/matematicas.md b/es/book/matematicas.md
index fdbe6e4097..0e08a01ac2 100644
--- a/es/book/matematicas.md
+++ b/es/book/matematicas.md
@@ -56,7 +56,7 @@ Los siguientes comparadores también se encuentran disponibles:
 
 ## Operadores Compuestos
 
-Nushell también soporta `&&` y `||` para unir dos operaciones que regresen valores booleanos, usando `y` y `o` respectivamente. Por ejemplo: `ls | where name in ["uno" "dos" "tres"] && size > 10kb`
+Nushell también soporta `and` y `or` para unir dos operaciones que regresen valores booleanos, usando `y` y `o` respectivamente. Por ejemplo: `ls | where name in ["uno" "dos" "tres"] and size > 10kb`
 
 ## Orden de operaciones
 
diff --git a/ja/book/math.md b/ja/book/math.md
index 1db1c656e6..80a4ecdf01 100644
--- a/ja/book/math.md
+++ b/ja/book/math.md
@@ -58,4 +58,4 @@ true
 
 ## 複合演算子
 
-`&&`と`||`を使ってブーリアンを返す２つの操作を結合できます。例えば: `ls | where name in ["one" "two" "three"] && size > 10kb`
+`and`と`or`を使ってブーリアンを返す２つの操作を結合できます。例えば: `ls | where name in ["one" "two" "three"] and size > 10kb`
```