### PR TITLE
REFACTOR: add documentation to and clean up the `make_docs.nu` script

### DIFF
--- a/make_docs.nu
+++ b/make_docs.nu
@@ -1,3 +1,13 @@
+# remove invalid characters from a path
+#
+# # Examples
+# using the standard library
+# ```nushell
+# use std.nu
+#
+# std assert eq ("foo/bar baz/foooo" | safe-path) "foo/bar_baz/foooo"
+# std assert eq ("invalid ? path" | safe-path) "invalid__path"
+# ```
 def safe-path [] {
   $in | str replace --all '\?' '' | str replace --all ' ' '_'
 }

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -141,6 +141,18 @@ def generate-command [commands_group command_name] {
 }
 
 
+# generate the list of all categories in a TS file used by `vuepress`
+#
+# # Example
+# the sidebar file has following format
+# ```typescript
+# export const commandCategories = [
+#   '/commands/categories/<categ_1>.md',
+#   '/commands/categories/<categ_2>.md',
+#   ...
+# ];
+# ```
+# and contains all the categories given by `$nu.scope.commands.category | uniq`
 def generate-category-sidebar [unique_categories] {
     let sidebar_path = (['.', '.vuepress', 'configs', "sidebar", "command_categories.ts"] | path join)
     let list_content = (

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -25,7 +25,7 @@ def command-frontmatter [commands_group, command_name] {
   let indented_usage = ($commands_list | get usage | each {|it| $"  ($it)"} | str join (char newline))
 
   # This is going in the frontmatter as a multiline YAML string, so indentation matters
-  $"---
+$"---
 title: ($command_name)
 categories: |
 ($category_list)
@@ -33,8 +33,7 @@ version: ($nu_version)
 ($category_matter)
 usage: |
 ($indented_usage)
----
-"
+---"
 }
 
 
@@ -136,7 +135,7 @@ def generate-command [commands_group command_name] {
         | str join
     )
 
-    [$frontmatter $doc] | str join | save --raw --force $doc_path
+    [$frontmatter $doc] | str join "\n" | save --raw --force $doc_path
     $doc_path
 }
 

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -166,6 +166,17 @@ $"($example.description)
 }
 
 
+# generate the full documentation page of a given command
+#
+# this command will
+# 1. compute the frontmatter of the command, i.e. the YAML header
+# 2. compute the actual content of the documentation
+# 3. concatenate them
+# 4. save that to `commands/docs/<command>.md`
+#
+# # Examples
+# - the `bits` command at https://nushell.sh/commands/docs/bits.html
+# - the `bits and` subcommand at https://nushell.sh/commands/docs/bits_and.html
 def generate-command [commands_group command_name] {
     let safe_name = ($command_name | safe-path)
     let doc_path = (['.', 'commands', 'docs', $'($safe_name).md'] | path join)

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -185,6 +185,7 @@ def main [] {
     )
     let commands_group = ($commands | group-by name)
     let unique_commands = ($commands_group | columns)
+    let unique_categories = ($commands | get category | uniq)
 
     let number_generated_commands = (
         $unique_commands
@@ -195,7 +196,6 @@ def main [] {
     )
     print $"($number_generated_commands) commands written"
 
-    let unique_categories = ($commands | get category | uniq)
     generate-category-sidebar $unique_categories
 
     let number_generated_categories = (

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -1,29 +1,3 @@
-def main [] {
-  # Old commands are currently not deleted because some of them
-  # are platform-specific (currently `exec`, `registry query`), and a single run of this script will not regenerate
-  # all of them.
-  #do -i { rm commands/docs/*.md }
-
-  let commands = ($nu.scope.commands | where is_custom == false and is_extern == false | sort-by category)
-  let commands_group = ($commands | group-by name)
-  let unique_commands = ($commands_group | columns)
-
-  let number_generated_commands = ($unique_commands | each { |command_name|
-    generate-command $commands_group $command_name
-  } | length)
-  print $"($number_generated_commands) commands written"
-
-  let unique_categories = ($commands | get category | uniq)
-  generate-category-sidebar $unique_categories
-
-  let number_generated_categories = ($unique_categories | each { |category|
-    generate-category $category
-  } | length)
-  print $"($number_generated_categories) categories written"
-
-}
-
-
 def generate-command [commands_group command_name] {
   let safe_name = ($command_name | safe-path)
   let doc_path = (['.', 'commands', 'docs', $'($safe_name).md'] | path join)
@@ -195,4 +169,30 @@ def generate-category [category] {
 
 def safe-path [] {
   $in | str replace --all '\?' '' | str replace --all ' ' '_'
+}
+
+
+def main [] {
+  # Old commands are currently not deleted because some of them
+  # are platform-specific (currently `exec`, `registry query`), and a single run of this script will not regenerate
+  # all of them.
+  #do -i { rm commands/docs/*.md }
+
+  let commands = ($nu.scope.commands | where is_custom == false and is_extern == false | sort-by category)
+  let commands_group = ($commands | group-by name)
+  let unique_commands = ($commands_group | columns)
+
+  let number_generated_commands = ($unique_commands | each { |command_name|
+    generate-command $commands_group $command_name
+  } | length)
+  print $"($number_generated_commands) commands written"
+
+  let unique_categories = ($commands | get category | uniq)
+  generate-category-sidebar $unique_categories
+
+  let number_generated_categories = ($unique_categories | each { |category|
+    generate-category $category
+  } | length)
+  print $"($number_generated_categories) categories written"
+
 }

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -170,9 +170,10 @@ $"export const commandCategories = [
 
 
 def generate-category [category] {
-  let safe_name = ($category | safe-path)
-  let doc_path = (['.', 'commands', 'categories', $'($safe_name).md'] | path join)
-  $"# ($category | str title-case)
+    let safe_name = ($category | safe-path)
+    let doc_path = (['.', 'commands', 'categories', $'($safe_name).md'] | path join)
+
+$"# ($category | str title-case)
 
 <script>
   import pages from '@temp/pages'
@@ -198,8 +199,10 @@ def generate-category [category] {
    <td style=\"white-space: pre-wrap;\">{{ command.frontmatter.usage }}</td>
   </tr>
 </table>
-" | save --raw --force $doc_path
-  $doc_path
+"
+    | save --raw --force $doc_path
+
+    $doc_path
 }
 
 

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -1,17 +1,5 @@
-def generate-command [commands_group command_name] {
-    let safe_name = ($command_name | safe-path)
-    let doc_path = (['.', 'commands', 'docs', $'($safe_name).md'] | path join)
-
-    let frontmatter = (command-frontmatter $commands_group $command_name)
-    let doc = (
-        $commands_group
-        | get $command_name
-        | each { |command| command-doc $command }
-        | str join
-    )
-
-    [$frontmatter $doc] | str join | save --raw --force $doc_path
-    $doc_path
+def safe-path [] {
+  $in | str replace --all '\?' '' | str replace --all ' ' '_'
 }
 
 
@@ -140,6 +128,23 @@ def generate-category-sidebar [unique_categories] {
 }
 
 
+def generate-command [commands_group command_name] {
+    let safe_name = ($command_name | safe-path)
+    let doc_path = (['.', 'commands', 'docs', $'($safe_name).md'] | path join)
+
+    let frontmatter = (command-frontmatter $commands_group $command_name)
+    let doc = (
+        $commands_group
+        | get $command_name
+        | each { |command| command-doc $command }
+        | str join
+    )
+
+    [$frontmatter $doc] | str join | save --raw --force $doc_path
+    $doc_path
+}
+
+
 def generate-category [category] {
   let safe_name = ($category | safe-path)
   let doc_path = (['.', 'commands', 'categories', $'($safe_name).md'] | path join)
@@ -171,10 +176,6 @@ def generate-category [category] {
 </table>
 " | save --raw --force $doc_path
   $doc_path
-}
-
-def safe-path [] {
-  $in | str replace --all '\?' '' | str replace --all ' ' '_'
 }
 
 

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -1,11 +1,17 @@
 def generate-command [commands_group command_name] {
-  let safe_name = ($command_name | safe-path)
-  let doc_path = (['.', 'commands', 'docs', $'($safe_name).md'] | path join)
+    let safe_name = ($command_name | safe-path)
+    let doc_path = (['.', 'commands', 'docs', $'($safe_name).md'] | path join)
 
-  let frontmatter = (command-frontmatter $commands_group $command_name)
-  let doc = ($commands_group | get $command_name | each { |command| command-doc $command } | str join)
-  [$frontmatter $doc] | str join | save --raw --force $doc_path
-  $doc_path
+    let frontmatter = (command-frontmatter $commands_group $command_name)
+    let doc = (
+        $commands_group
+        | get $command_name
+        | each { |command| command-doc $command }
+        | str join
+    )
+
+    [$frontmatter $doc] | str join | save --raw --force $doc_path
+    $doc_path
 }
 
 

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -173,26 +173,37 @@ def safe-path [] {
 
 
 def main [] {
-  # Old commands are currently not deleted because some of them
-  # are platform-specific (currently `exec`, `registry query`), and a single run of this script will not regenerate
-  # all of them.
-  #do -i { rm commands/docs/*.md }
+    # Old commands are currently not deleted because some of them
+    # are platform-specific (currently `exec`, `registry query`), and a single run of this script will not regenerate
+    # all of them.
+    #do -i { rm commands/docs/*.md }
 
-  let commands = ($nu.scope.commands | where is_custom == false and is_extern == false | sort-by category)
-  let commands_group = ($commands | group-by name)
-  let unique_commands = ($commands_group | columns)
+    let commands = (
+        $nu.scope.commands
+        | where is_custom == false and is_extern == false
+        | sort-by category
+    )
+    let commands_group = ($commands | group-by name)
+    let unique_commands = ($commands_group | columns)
 
-  let number_generated_commands = ($unique_commands | each { |command_name|
-    generate-command $commands_group $command_name
-  } | length)
-  print $"($number_generated_commands) commands written"
+    let number_generated_commands = (
+        $unique_commands
+        | each { |command_name|
+            generate-command $commands_group $command_name
+        }
+        | length
+    )
+    print $"($number_generated_commands) commands written"
 
-  let unique_categories = ($commands | get category | uniq)
-  generate-category-sidebar $unique_categories
+    let unique_categories = ($commands | get category | uniq)
+    generate-category-sidebar $unique_categories
 
-  let number_generated_categories = ($unique_categories | each { |category|
-    generate-category $category
-  } | length)
-  print $"($number_generated_categories) categories written"
-
+    let number_generated_categories = (
+        $unique_categories
+        | each { |category|
+            generate-category $category
+        }
+        | length
+    )
+    print $"($number_generated_categories) categories written"
 }

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -14,21 +14,31 @@ def safe-path [] {
 
 
 def command-frontmatter [commands_group, command_name] {
-  let commands_list = ($commands_group | get $command_name)
+    let commands_list = ($commands_group | get $command_name)
 
-  let category_list = "  " + ($commands_list | get category | str join $"(char newline)  " )
-  let nu_version = (version).version
-  let category_matter = ($commands_list | get category | each { |category|
-    let usage = ($commands_list | where category == $category | get usage | str join (char newline))
-    $'($category | str snake-case): |(char newline)  ($usage)'
-  } | str join (char newline))
-  let indented_usage = ($commands_list | get usage | each {|it| $"  ($it)"} | str join (char newline))
+    let category_list = ($commands_list | get category | str join $"(char newline)  " )
+    let nu_version = (version).version
+    let category_matter = (
+        $commands_list
+        | get category
+        | each { |category|
+            let usage = ($commands_list | where category == $category | get usage | str join (char newline))
+            $'($category | str snake-case): |(char newline)  ($usage)'
+        }
+        | str join (char newline)
+    )
+    let indented_usage = (
+        $commands_list
+        | get usage
+        | each {|it| $"  ($it)"}
+        | str join (char newline)
+    )
 
   # This is going in the frontmatter as a multiline YAML string, so indentation matters
 $"---
 title: ($command_name)
 categories: |
-($category_list)
+  ($category_list)
 version: ($nu_version)
 ($category_matter)
 usage: |

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -175,6 +175,12 @@ $"export const commandCategories = [
 }
 
 
+# generate one category file in `commands/categories/`
+#
+# # Example
+# for the `bits` category, that might look, once rendered, like
+#
+#    https://nushell.sh/commands/categories/bits.html
 def generate-category [category] {
     let safe_name = ($category | safe-path)
     let doc_path = (['.', 'commands', 'categories', $'($safe_name).md'] | path join)

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -81,88 +81,107 @@ usage: |
 
 
 def command-doc [command] {
-  let top = $"
+    let top = $"
 # <code>{{ $frontmatter.title }}</code> for ($command.category)
 
 <div class='command-title'>{{ $frontmatter.($command.category | str snake-case) }}</div>
 
 "
 
-  let param_type = ['switch', 'named', 'rest', 'positional']
-  let columns = ($command.signatures | columns)
-  let no_sig = ($command | get signatures | is-empty)
-  let no_param = if $no_sig { true } else {
-    $command.signatures | get $columns.0 | where parameter_type in $param_type | is-empty
-  }
-  let sig = if $no_sig { '' } else {
-    ($command.signatures | get $columns.0 | each { |param|
-      if $param.parameter_type == "positional" {
-        $"('(')($param.parameter_name)(')')"
-      } else if $param.parameter_type == "switch" {
-        $"--($param.parameter_name)"
-      } else if $param.parameter_type == "named" {
-        $"--($param.parameter_name)"
-      } else if $param.parameter_type == "rest" {
-        $"...rest"
-      }
-    } | str join " ")
-  }
+    let param_type = ['switch', 'named', 'rest', 'positional']
+    let columns = ($command.signatures | columns)
+    let no_sig = ($command | get signatures | is-empty)
+    let no_param = if $no_sig { true } else {
+        $command.signatures | get $columns.0 | where parameter_type in $param_type | is-empty
+    }
+    let sig = if $no_sig { '' } else {
+        ($command.signatures | get $columns.0 | each { |param|
+            if $param.parameter_type == "positional" {
+                $"('(')($param.parameter_name)(')')"
+            } else if $param.parameter_type == "switch" {
+                $"--($param.parameter_name)"
+            } else if $param.parameter_type == "named" {
+                $"--($param.parameter_name)"
+            } else if $param.parameter_type == "rest" {
+                $"...rest"
+            }
+        } | str join " ")
+    }
 
-  let signatures = $"## Signature(char newline)(char newline)```> ($command.name) ($sig)```(char newline)(char newline)"
+  let signatures = $"## Signature
 
-  let params = if $no_param {
-    ''
+```> ($command.name) ($sig)```
+
+"
+
+    let params = if $no_param { '' } else {
+        ($command.signatures | get $columns.0 | each { |param|
+            if $param.parameter_type == "positional" {
+                $" -  `($param.parameter_name)`: ($param.description)"
+            } else if $param.parameter_type == "switch" {
+                $" -  `--($param.parameter_name)` `\(-($param.short_flag)\)`: ($param.description)"
+            } else if $param.parameter_type == "named" {
+                $" -  `--($param.parameter_name) {($param.syntax_shape)}`: ($param.description)"
+            } else if $param.parameter_type == "rest" {
+                $" -  `...rest`: ($param.description)"
+            }
+        } | str join (char newline))
+    }
+
+    let parameters = if $no_param { "" } else {
+$"## Parameters
+
+($params)
+
+"
+}
+
+    let ex = $command.extra_usage
+
+    # Certain commands' extra_usage is wrapped in code block markup to prevent their code from
+    # being interpreted as markdown. This is strictly hard-coded for now.
+    let extra_usage = if $ex == "" {
+        ""
+    } else if $command.name in ['def-env' 'export def-env' 'as-date' 'as-datetime' ansi] {
+$"## Notes
+```text
+($ex)
+```
+"
     } else {
-    ($command.signatures | get $columns.0 | each { |param|
-      if $param.parameter_type == "positional" {
-        $" -  `($param.parameter_name)`: ($param.description)"
-      } else if $param.parameter_type == "switch" {
-        $" -  `--($param.parameter_name)` `\(-($param.short_flag)\)`: ($param.description)"
-      } else if $param.parameter_type == "named" {
-        $" -  `--($param.parameter_name) {($param.syntax_shape)}`: ($param.description)"
-      } else if $param.parameter_type == "rest" {
-        $" -  `...rest`: ($param.description)"
-      }
-    } | str join (char newline))
-  }
+$"## Notes
+($ex)
+"
+    }
 
-  let parameters = if $no_param { "" } else { $"## Parameters(char newline)(char newline)($params)(char newline)(char newline)" }
+    let examples = if ($command.examples | length) > 0 {
+        let example_top = $"## Examples(char newline)(char newline)"
 
-  let ex = $command.extra_usage
-  # Certain commands' extra_usage is wrapped in code block markup to prevent their code from
-  # being interpreted as markdown. This is strictly hard-coded for now.
-  let extra_usage = if $ex == "" {
-    ""
-  } else if $command.name in ['def-env' 'export def-env' 'as-date' 'as-datetime' ansi] {
-    $"## Notes(char newline)```text(char newline)($ex)(char newline)```(char newline)"
-  } else {
-    $"## Notes(char newline)($ex)(char newline)"
-  }
-
-  let examples = if ($command.examples | length) > 0 {
-    let example_top = $"## Examples(char newline)(char newline)"
-
-    let $examples = ($command.examples | each { |example|
+        let $examples = (
+            $command.examples
+            | each { |example|
 $"($example.description)
 ```shell
 > ($example.example)
 ```
 
 "
-    } | str join)
+            } | str join
+        )
 
-    $example_top + $examples
-  } else {
-    ""
-  }
+        $example_top + $examples
+    } else {
+        ""
+    }
 
-  let doc = (
-    ($top + $signatures + $parameters + $extra_usage + $examples ) |
-    lines |
-    each {|it| ($it | str trim -r) } |
-    str join (char newline)
-  )
-  $doc
+    let doc = (
+        ($top + $signatures + $parameters + $extra_usage + $examples )
+        | lines
+        | each {|it| ($it | str trim -r) }
+        | str join (char newline)
+    )
+
+    $doc
 }
 
 

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -143,6 +143,8 @@ def generate-command [commands_group command_name] {
 
 # generate the list of all categories in a TS file used by `vuepress`
 #
+# this will modify `.vuepress/configs/sidebar/command_categories.ts`
+#
 # # Example
 # the sidebar file has following format
 # ```typescript
@@ -153,6 +155,10 @@ def generate-command [commands_group command_name] {
 # ];
 # ```
 # and contains all the categories given by `$nu.scope.commands.category | uniq`
+#
+# this file is responsible for the sidebar containing the categories that one can see in
+#
+#    https://nushell.sh/commands/
 def generate-category-sidebar [unique_categories] {
     let sidebar_path = (['.', '.vuepress', 'configs', "sidebar", "command_categories.ts"] | path join)
     let list_content = (

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -13,6 +13,39 @@ def safe-path [] {
 }
 
 
+# generate the YAML frontmatter of a command
+#
+# # Examples
+# - the `bits` command in `commands/docs/bits.md`
+# ```yaml
+# ---
+# title: bits
+# categories: |
+#   bits
+# version: 0.76.1
+# bits: |
+#   Various commands for working with bits.
+# usage: |
+#   Various commands for working with bits.
+# ---
+# ```
+# - the `dfr min` command in `commands/docs/dfr_min.md`
+# ```yaml
+# ---
+# title: dfr min
+# categories: |
+#   expression
+#   lazyframe
+# version: 0.76.0
+# expression: |
+#   Creates a min expression
+# lazyframe: |
+#   Aggregates columns to their min value
+# usage: |
+#   Creates a min expression
+#   Aggregates columns to their min value
+# ---
+# ```
 def command-frontmatter [commands_group, command_name] {
     let commands_list = ($commands_group | get $command_name)
 

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -123,20 +123,6 @@ $"($example.description)
   $doc
 }
 
-def generate-category-sidebar [unique_categories] {
-  let sidebar_path = (['.', '.vuepress', 'configs', "sidebar", "command_categories.ts"] | path join)
-  let list_content = (
-    $unique_categories
-      | each { safe-path }
-      | each { |category| $"  '/commands/categories/($category).md',"}
-      | str join (char newline)
-  )
-  $"export const commandCategories = [
-($list_content)
-];
-" | save --raw --force $sidebar_path
-}
-
 
 def generate-command [commands_group command_name] {
     let safe_name = ($command_name | safe-path)
@@ -152,6 +138,21 @@ def generate-command [commands_group command_name] {
 
     [$frontmatter $doc] | str join | save --raw --force $doc_path
     $doc_path
+}
+
+
+def generate-category-sidebar [unique_categories] {
+  let sidebar_path = (['.', '.vuepress', 'configs', "sidebar", "command_categories.ts"] | path join)
+  let list_content = (
+    $unique_categories
+      | each { safe-path }
+      | each { |category| $"  '/commands/categories/($category).md',"}
+      | str join (char newline)
+  )
+  $"export const commandCategories = [
+($list_content)
+];
+" | save --raw --force $sidebar_path
 }
 
 

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -80,6 +80,9 @@ usage: |
 }
 
 
+# generate the whole command documentation
+#
+# TODO: be more detailed here
 def command-doc [command] {
     let top = $"
 # <code>{{ $frontmatter.title }}</code> for ($command.category)

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -142,17 +142,18 @@ def generate-command [commands_group command_name] {
 
 
 def generate-category-sidebar [unique_categories] {
-  let sidebar_path = (['.', '.vuepress', 'configs', "sidebar", "command_categories.ts"] | path join)
-  let list_content = (
-    $unique_categories
-      | each { safe-path }
-      | each { |category| $"  '/commands/categories/($category).md',"}
-      | str join (char newline)
-  )
-  $"export const commandCategories = [
+    let sidebar_path = (['.', '.vuepress', 'configs', "sidebar", "command_categories.ts"] | path join)
+    let list_content = (
+      $unique_categories
+        | each { safe-path }
+        | each { |category| $"  '/commands/categories/($category).md',"}
+        | str join (char newline)
+    )
+
+$"export const commandCategories = [
 ($list_content)
-];
-" | save --raw --force $sidebar_path
+];"
+    | save --raw --force $sidebar_path
 }
 
 


### PR DESCRIPTION
hello there :wave: 

i wanted to
- regenerate the website after https://github.com/nushell/nushell/pull/8189
- contribute to the `make_docs.nu` script

however, i had a lot of trouble understanding the script itself and what it was doing...

so i decided i would try to refactor it and add documentation to it :yum: 
### here is my attempt :relieved: 

## :exclamation: the changes
> **Warning**
> there are a lot of changes when looking at the full diff...
> this section explains the new look of the scripts and proves that the features of the script did not change :relieved: 

so, in this PR, i've
- fixed the order of the functions, i.e. the `main` at the bottom and more and more general tools to the top of the file, in the order they appear in the script
- fixed the indentation, i.e. from 2 spaces to 4 spaces for readability
- regrouped some commands together to hopefully make more sense
- broken up long commands into multiple lines
- tried to make the string templates as clear as possible, e.g. by writing
```bash
let foo = $"
foo
($bar)
baz
"
```
and being explicit about the newlines
- added documentation for all the commands with examples, except for `command-doc` for now

### :test_tube: prove that the script did not change apart from style and refactoring
on the current `main` there are changes to be applied, e.g. the version bump.
we can leverage that to make sure that the changes applied by `make_docs.nu` are the same on the base `main` branch and on the PR branch :smirk: 

we'll be using the script below to show that
```bash
# checkout to the revision, run the generation and save the changes in a file
def try_doc [
    revision: string
    output: string
] {
    git co $revision
    nu make_docs.nu
    git diff $revision | save --force $output
}

# clean all the changes generated by `try_doc`, leaving a clean `git` worktree
def clean [] {
    rm commands/docs/*
    rm commands/categories/*
    git restore commands/ .vuepress/
}


def main [] {
    # we start with a clean `git` worktree
    git stash push -m "temporary stash"

    let latest_main = "12e180cca5"
    try_doc $latest_main before.diff
    clean

    let pr_branch = "refactor/add-documentation-to-and-clean-up-make-docs-script"
    try_doc $pr_branch after.diff
    clean

    diff before.diff after.diff -u
}
```

### :heavy_check_mark: the output is the same
> **Note**
> `diff before.diff after.diff -u` gives
> ```diff
> --- after.diff2023-03-04 13:02:45.990354811 +0100
> +++ before.diff2023-03-04 13:02:39.290353033 +0100
> @@ -1,5 +1,5 @@
>  diff --git a/.vuepress/configs/sidebar/command_categories.ts b/.vuepress/configs/sidebar/command_categories.ts
> -index 0ea457c828..e63057a94d 100644
> +index 0ea457c828..d5cfc61b2f 100644
>  --- a/.vuepress/configs/sidebar/command_categories.ts
>  +++ b/.vuepress/configs/sidebar/command_categories.ts
>  @@ -4,21 +4,17 @@ export const commandCategories = [
> @@ -24,13 +24,6 @@
>     '/commands/categories/math.md',
>     '/commands/categories/misc.md',
>     '/commands/categories/network.md',
> -@@ -29,4 +25,4 @@ export const commandCategories = [
> -   '/commands/categories/strings.md',
> -   '/commands/categories/system.md',
> -   '/commands/categories/viewers.md',
> --];
> -+];
> -\ No newline at end of file
>  diff --git a/commands/docs/alias.md b/commands/docs/alias.md
>  index 1f58f1fb0c..76bc52a8b6 100644
>  --- a/commands/docs/alias.md
> ```
> which means only the newline at the end of `.vuepress/configs/sidebar/command_categories.ts` has been removed
> => this has been introduced by 67bd631cbc5726679c555fb18804c4a7e1b42925