### PR TITLE
add the example results to the documentation pages

### DIFF
--- a/make_docs.nu
+++ b/make_docs.nu
@@ -126,7 +126,7 @@ def command-doc [command] {
 $"($example.description)
 ```shell
 > ($example.example)
-($example.result)
+($example.result | try { table --expand } catch { $in })
 ```
 
 "

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -126,6 +126,7 @@ def command-doc [command] {
 $"($example.description)
 ```shell
 > ($example.example)
+($example.result)
 ```
 
 "


### PR DESCRIPTION
Related to
- nushell/nushell#8189
- nushell/nushell#8319

As introduced in nushell/nushell#8189 and nushell/nushell#8319, the `$nu.scope.commands` structure now holds the `result`s of the command `example`s :+1: 

in order to generate accurate documentation pages, the `make_docs.nu` script needs to use `$nu.scope.commands.example.result` in addition to `$nu.scope.commands.example.description` and `$nu.scope.commands.example.example`

this PR uses `$example.result` in the `command-doc` command right after the `> ($example.example)` line, adding the result to the page.
> **Note**
> in order to print real structured data, i could not use `$example.result` only, e.g. it would print raw string data even with tables...
> the easiest i found was to `try` to `--expand` the `$example.result` and `catch` the input as default, i.e. when the result is not `--expand`able :+1: 

## example
on the `merge` command
```bash
>_ nu make_docs.nu
>_ git diff commands/docs/merge.md | str replace --all "```" "``"
```
gives
```diff
diff --git a/commands/docs/merge.md b/commands/docs/merge.md
index 0671dc8e63..68482f9a8a 100644
--- a/commands/docs/merge.md
+++ b/commands/docs/merge.md
@@ -32,14 +32,33 @@ repeating this process with row 1, and so on.
 Add an 'index' column to the input table
 ``shell
 > [a b c] | wrap name | merge ( [1 2 3] | wrap index )
+╭───┬──────╮
+│ # │ name │
+├───┼──────┤
+│ 1 │ a    │
+│ 2 │ b    │
+│ 3 │ c    │
+╰───┴──────╯
+
 ``
 
 Merge two records
 ``shell
 > {a: 1, b: 2} | merge {c: 3}
+╭───┬───╮
+│ a │ 1 │
+│ b │ 2 │
+│ c │ 3 │
+╰───┴───╯
 ``
 
 Merge two tables, overwriting overlapping columns
 ``shell
 > [{columnA: A0 columnB: B0}] | merge [{columnA: 'A0*'}]
+╭───┬─────────┬─────────╮
+│ # │ columnA │ columnB │
+├───┼─────────┼─────────┤
+│ 0 │ A0*     │ B0      │
+╰───┴─────────┴─────────╯
+
 ``
```