### PR TITLE
FIX: remove ANSI escape sequences when the output is a `string`

### DIFF
--- a/make_docs.nu
+++ b/make_docs.nu
@@ -163,10 +163,14 @@ $"## Notes
         let $examples = (
             $command.examples
             | each { |example|
+                let result = (
+                    $example.result
+                    | try { table --expand } catch { $in }
+                )
 $"($example.description)
 ```shell
 > ($example.example)
-($example.result | try { table --expand } catch { $in })
+($result | if ($result | describe) == "string" { ansi strip } else { $in })
 ```
 
 "


### PR DESCRIPTION
Related to #803.


in #803, i've added the example results to the output of `make_docs.nu`.
however, there are ANSI escape sequences all over the place when the output is a string... :scream: 

this PR removes them by using `ansi strip` when the results are `string`s :+1: 