### PR TITLE
Newbie-friendly command reference header

### DIFF
--- a/book/quick_tour.md
+++ b/book/quick_tour.md
@@ -6,7 +6,7 @@ The first thing you'll notice when you run a command like [`ls`](/commands/docs/
 
 @[code](@snippets/introduction/ls_example.sh)
 
-The table is more than just showing the directory in a different way. Just like tables in a spreadsheet, this table allows us to work with the data more interactively.
+The table does more than show the directory in a different way. Just like tables in a spreadsheet, this table allows us to work with the data more interactively.
 
 The first thing we'll do is to sort our table by size. To do this, we'll take the output from [`ls`](/commands/docs/ls.md) and feed it into a command that can sort tables based on the contents of a column.
 
@@ -14,7 +14,7 @@ The first thing we'll do is to sort our table by size. To do this, we'll take th
 
 You can see that to make this work we didn't pass commandline arguments to [`ls`](/commands/docs/ls.md). Instead, we used the [`sort-by`](/commands/docs/sort-by.md) command that Nu provides to do the sorting of the output of the [`ls`](/commands/docs/ls.md) command. To see the biggest files on top, we also used [`reverse`](/commands/docs/reverse.md).
 
-Nu provides many commands that can work on tables. For example, we could filter the contents of the [`ls`](/commands/docs/ls.md) table so that it only shows files over 1 kilobyte:
+Nu provides many commands that can work on tables. For example, we could use [`where`](/commands/docs/where.md) to filter the contents of the [`ls`](/commands/docs/ls.md) table so that it only shows files over 1 kilobyte:
 
 @[code](@snippets/introduction/ls_where_example.sh)
 

--- a/commands/README.md
+++ b/commands/README.md
@@ -1,9 +1,8 @@
 # Command Reference
 
-Nushell provides commands for a variety of use cases.
-You can find the included categories in the sidebar.
+If you're new to Nushell, [the quick tour](/book/quick_tour.md) can show you the most important commands. You don't need to know them all!
 
-To see all commands in Nushell, run [`help commands`](/commands/docs/help.md).
+To see all commands from inside Nushell, run [`help commands`](/commands/docs/help.md).
 
 <script>
   import pages from '@temp/pages'


### PR DESCRIPTION
This PR adds a link to the quick tour at the top of the command reference, as prompted by [this Hacker News comment](https://news.ycombinator.com/item?id=35127105).