### PR TITLE
Add missing space in `Filesystem`/`start` 🚨

### DIFF
--- a/commands/docs/start.md
+++ b/commands/docs/start.md
@@ -4,9 +4,9 @@ categories: |
   filesystem
 version: 0.76.0
 filesystem: |
-  Open a folder,file or website in the default application or viewer.
+  Open a folder, file or website in the default application or viewer.
 usage: |
-  Open a folder,file or website in the default application or viewer.
+  Open a folder, file or website in the default application or viewer.
 ---
 
 # <code>{{ $frontmatter.title }}</code> for filesystem


### PR DESCRIPTION
In order to fix the selected text, below: 
<img width="1252" alt="Screenshot 2023-03-15 at 06 50 25" src="https://user-images.githubusercontent.com/3862051/225218941-7654803f-7b85-490a-9fb0-3de7d666935b.png">
