### PR TITLE
List characters for the char command

### DIFF
--- a/commands/docs/char.md
+++ b/commands/docs/char.md
@@ -72,8 +72,8 @@ Nushell | Equivalent
 `right_bracket`<br />`rbracket`<br /> | `[`
 `single_quote`<br />`squote`<br />`sq` | `\'`
 `double_quote`<br />`dquote`<br />`dq` | `\"`
-`path_sep`<br />`psep`<br />`separator` | TODO
-`esep`<br />`env_sep` | TODO
+`path_sep`<br />`psep`<br />`separator` | `/` on Unix, `\` on Windows
+`esep`<br />`env_sep` | `:` on Unix, `;` on Windows
 `tilde`<br />`twiddle`<br />`squiggly`<br />`home`<br />`pound_sign`<br />`sharp`<br />`root` | `~`
 `hash`<br />`hashtag` | `#`
 

--- a/commands/docs/char.md
+++ b/commands/docs/char.md
@@ -51,3 +51,84 @@ Output multi-byte Unicode character
 ```shell
 > char -u 1F468 200D 1F466 200D 1F466
 ```
+
+## Supported characters
+
+### Standard characters
+
+Nushell | Equivalent
+:-------|:----------
+`newline`<br />`enter`<br />`nl`<br />`line_feed`<br />`lf` | `\n`
+`carriage_return`<br />`cr` | `\r`
+`crlf` | `\r\n`
+`tab` | `\t`
+`sp`<br />`space` | ` `
+`pipe` | `|`
+`left_brace`<br />`lbrace` | `{`
+`right_brace`<br />`rbrace` | `}`
+`left_paren`<br />`lp`<br />`lparen` | `(`
+`right_paren`<br />`rp`<br />`rparen` | `)`
+`left_bracket`<br />`lbracket`<br /> | `[`
+`right_bracket`<br />`rbracket`<br /> | `[`
+`single_quote`<br />`squote`<br />`sq` | `\'`
+`double_quote`<br />`dquote`<br />`dq` | `\"`
+`path_sep`<br />`psep`<br />`separator` | TODO
+`esep`<br />`env_sep` | TODO
+`tilde`<br />`twiddle`<br />`squiggly`<br />`home`<br />`pound_sign`<br />`sharp`<br />`root` | `~`
+`hash`<br />`hashtag` | `#`
+
+### Unicode
+
+Unicode character names are derived from [this source](https://www.compart.com/en/unicode).
+
+Nushell | Equivalent
+:-------|:----------
+`nf_branch` | `\u{e0a0}`
+`nf_segment`<br />`nf_left_segment` | `\u{e0b0}`
+`nf_left_segment_thin` | `\u{e0b1}`
+`nf_right_segment` | `\u{e0b2}`
+`nf_right_segment_thin` | `\u{e0b3}`
+`nf_git` | `\u{f1d3}`
+`nf_git_branch` | `\u{e709}\u{e0a0}`
+`nf_folder1` | `\u{f07c}`
+`nf_folder2` | `\u{f115}`
+`nf_house1` | `\u{f015}`
+`nf_house2` | `\u{f7db}`
+`identical_to`<br />`hamburger` | `\u{2261}` (≡)
+`not_identical_to`<br />`branch_untracked`| `\u{2262}` (≢)
+`strictly_equivalent_to`<br />`branch_identical` | `\u{2263}` (≣)
+`upwards_arrow`<br />`branch_ahead` | `\u{2191}` (↑)
+`downwards_arrow`<br />`branch_behind` | `\u{2193}` (↓)
+`up_down_arrow`<br />`branch_ahead_behind` | `\u{2195}` (↕)
+`black_right_pointing_triangle`<br />`prompt` | `\u{25b6}` (▶)
+`vector_or_cross_product`<br />`failed` | `\u{2a2f}` (⨯)
+`high_voltage_sign`<br />`elevated` | `\u{26a1}` (⚡)
+
+### Emoji
+
+Nushell | Equivalent
+:-------|:----------
+`sun`<br />`sunny`<br />`sunrise` | ☀️
+`moon` | 🌛
+`cloudy`<br />`cloud`<br />`cloud` | ☁️
+`rainy`<br />`rain` | 🌦️
+`foggy`<br />`fog` | 🌫️
+`mist`<br />`haze` | `\u{2591}`
+`snowy`<br />`snow` | ❄️
+`thunderstorm`<br />`thunder` | 🌩️
+
+### Other
+
+Nushell | Equivalent
+:-------|:----------
+`bel` | `\x07`
+`backspace` | `\x08`
+
+### Separators
+
+Nushell | Equivalent
+:-------|:----------
+`file_separator`<br />`file_sep`<br />`fs` | `\x1c`
+`group_separator`<br />`group_sep`<br />`gs` | `\x1d`
+`record_separator`<br />`record_sep`<br />`rs` | `\x1e`
+`unit_separator`<br />`unit_sep`<br />`us` | `\x1f`


### PR DESCRIPTION
This PR provides tables describing the available characters for the `char` command. It seems that the command docs are generated, though, so I'd appreciate instructions on how to provide these within the generation process.