### PR TITLE
DE translation for command_signature

### DIFF
--- a/.vuepress/configs/sidebar/de.ts
+++ b/.vuepress/configs/sidebar/de.ts
@@ -29,6 +29,8 @@ export const sidebarDe: SidebarConfig = {
         'von_bash_kommend',
         'command_reference',
         'coloring_and_theming',
+        'overlays',
+        'command_signature',
       ],
     },
   ],

--- a/de/book/command_signature.md
+++ b/de/book/command_signature.md
@@ -1,0 +1,23 @@
+# Befehls Signatur
+
+Nu Befehle enthalten einen Signatur Abschnitt. Zum Beispiel wie hier in [`str distance`](/commands/docs/str_distance.md):
+
+```
+Signatures(Cell paths are supported):
+  <string> | str distance <string> -> <int>
+```
+
+Der erste Typenname vor dem `|` beschreibt den Typ der Eingangs-Pipeline. Nach dem Befehlsnamen folgt der benötigte Arguments Typ. Der Output-Typ ist in diesem Falle `int` und wird nach dem `->` ausgegeben.
+`(Cell paths are supported)` zeigt an, dass Zell Pfade angegeben werden können für `str distance`. So kann in einer verschachtelten Struktur oder Tabelle einem Zell Pfad eine Operation hinzugefügt und wie hier der Spaltenname ersetzt werden: `ls | str distance 'nushell' 'name'`
+
+Hier ein weiteres Beispiel, [`str join`](/commands/docs/str_join.md):
+
+```
+Signatures:
+  list<string> | str join <string?> -> <string>
+```
+
+Hier bedeutet die Signatur von [`str join`](/commands/docs/str_join.md), dass eine Liste von Texten als Eingang erwartet wird. Der Befehl nimmt ausserdem optionale `string` Typ Argumente entgegen. Schliesslich wird ein `string` als Output generiert.
+
+Einige Befehle akzeptieren oder benötigen keine Daten in einer Pipeline, weshalb ihr Input-Typ `<nothing>` sein wird.
+Dies gilt auch, wenn der Output Typ `null` zurückgiebt (e.g. [`rm`](/commands/docs/rm.md)).

--- a/i18n-meta.json
+++ b/i18n-meta.json
@@ -363,7 +363,7 @@
     "name": "overlays.md",
     "en": "In progress",
     "zh-CN": "51522d5591@hustcer",
-    "de": "-",
+    "de": "2a917adc@petrisch"
     "tr": "-",
     "ja": "-",
     "es": "-",

--- a/i18n-meta.json
+++ b/i18n-meta.json
@@ -103,7 +103,7 @@
     "name": "command_signature.md",
     "en": "In progress",
     "zh-CN": "-",
-    "de": "-",
+    "de": "696cb4fe@petrisch",
     "tr": "-",
     "ja": "-",
     "es": "-",
@@ -363,7 +363,7 @@
     "name": "overlays.md",
     "en": "In progress",
     "zh-CN": "51522d5591@hustcer",
-    "de": "2a917adc@petrisch"
+    "de": "2a917adc@petrisch",
     "tr": "-",
     "ja": "-",
     "es": "-",


### PR DESCRIPTION
I have done another one over the weekend.
But I am curious. The .vuepress/config.js seems to have changed.
Is there somewhere else now, I have to add this to appear on the site?