### PR TITLE
add a note about "value / description" completion

### DIFF
--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -115,6 +115,7 @@ def my_commits [] {
 ```
 
 > **Note**
+>
 > with the following snippet
 >
 > ```nu

--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -114,6 +114,25 @@ def my_commits [] {
 }
 ```
 
+> **Note**
+> with the following snippet
+>
+> ```nu
+> def my-command [commit: string@my_commits] {
+>     print $commit
+> }
+> ```
+>
+> be aware that, even though the completion menu will show you something like
+>
+> ```nu
+> >_ my-command <TAB>
+> 5c2464  Add .gitignore
+> f3a377  Initial commit
+> ```
+>
+> only the value, i.e. "5c2464" or "f3a377", will be used in the command arguments!
+
 ## External completions
 
 External completers can also be integrated, instead of relying solely on Nushell ones.


### PR DESCRIPTION
i love the new "Custom completion" page, it's really great to learn about all that stuff thanks to #836 :relieved: 

i simply thought there could be a little note about `value / description` based completion, about the fact that only the `value` is used in the actual argument when selecting an option :yum: 