### PR TITLE
use || in closures when configuring prompt

### DIFF
--- a/book/3rdpartyprompts.md
+++ b/book/3rdpartyprompts.md
@@ -36,7 +36,7 @@ let posh_theme = $'($posh_dir)/share/oh-my-posh/themes/'
 # Change the theme names to: zash/space/robbyrussel/powerline/powerlevel10k_lean/
 # material/half-life/lambda Or double lines theme: amro/pure/spaceship, etc.
 # For more [Themes demo](https://ohmyposh.dev/docs/themes)
-let-env PROMPT_COMMAND = { oh-my-posh prompt print primary --config $'($posh_theme)/zash.omp.json' }
+let-env PROMPT_COMMAND = { || oh-my-posh prompt print primary --config $'($posh_theme)/zash.omp.json' }
 # Optional
 let-env PROMPT_INDICATOR = $"(ansi y)$> (ansi reset)"
 ```
@@ -61,7 +61,7 @@ def create_left_prompt [] {
 }
 
 # Use nushell functions to define your right and left prompt
-let-env PROMPT_COMMAND = { create_left_prompt }
+let-env PROMPT_COMMAND = { || create_left_prompt }
 let-env PROMPT_COMMAND_RIGHT = ""
 
 # The prompt indicators are environmental variables that represent


### PR DESCRIPTION
As of https://www.nushell.sh/blog/2023-04-04-nushell_0_78.html#now-required-in-closures this is required.

I have tested the starship snippet which works locally for me. Read accross test results for oh-my-posh.