### PR TITLE
Improve misleading text format on note

### DIFF
--- a/book/thinking_in_nu.md
+++ b/book/thinking_in_nu.md
@@ -107,6 +107,6 @@ The [`cd`](/commands/docs/cd.md) command changes the `PWD` environment variables
 
 Having the environment scoped like this makes commands more predictable, easier to read, and when the time comes, easier to debug. Nushell also provides helper commands like [`def-env`](/commands/docs/def-env.md), [`load-env`](/commands/docs/load-env.md), as convenient ways of doing batches of updates to the environment.
 
-`*` - there is one exception here, where [`def-env`](/commands/docs/def-env.md) allows you to create a command that participates in the caller's environment
+*There is one exception here, where [`def-env`](/commands/docs/def-env.md) allows you to create a command that participates in the caller's environment.*
 
 **Thinking in Nushell:** - The coding best practice of no global mutable variables extends to the environment in Nushell. Using the built-in helper commands will let you more easily work with the environment in Nushell. Taking advantage of the fact that environments are scoped to blocks can also help you write more concise scripts and interact with external commands without adding things into a global environment you don't need.


### PR DESCRIPTION
Formatting the asterisk as an inline code block `*` with a `-` dash separator implies that it were a parameter to or syntax to the discussed topic (scope) and mentioned before. However, this is not the case. It is formatted in a misleading manner.

The asterisk seems to be intended as a footnote indicator. But no asterisk exists in the text before, so it does not follow established asterisk footnote practices either.

These issues are solved by removing the asterisk and making it a simple sentence.

To clarify that the paragraph is an additional note the text is formatted in italics.