### PR TITLE
Fix ranges in `str substring` examples

### DIFF
--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -238,7 +238,7 @@ Substrings are slices of a string. They have a startpoint and an endpoint. Here'
 4
 > 'Hello World!' | str index-of 'r'
 8
-> 'Hello World!' | str substring '4,8'
+> 'Hello World!' | str substring 4..8
 o Wo
 ```
 

--- a/de/book/working_with_strings.md
+++ b/de/book/working_with_strings.md
@@ -144,7 +144,7 @@ Hier ein Beispiel eines Substrings:
 4
 > 'Hallo Welt!' | str index-of 'l'
 8
-> 'Hallo Welt!' | str substring '4,8'
+> 'Hallo Welt!' | str substring 4..8
 o We
 ```
 

--- a/zh-CN/book/working_with_strings.md
+++ b/zh-CN/book/working_with_strings.md
@@ -114,7 +114,7 @@ My   string
 4
 > 'Hello World!' | str index-of 'r'
 8
-> 'Hello World!' | str substring '4,8'
+> 'Hello World!' | str substring 4..8
 o Wo
 ```
 


### PR DESCRIPTION
[`str substring` only allows ranges as of 0.78.](https://www.nushell.sh/blog/2023-04-04-nushell_0_78.html#ranges-become-the-standard-range-specifier)
Updates the usage examples for `str substring` in working_with_strings.md for all languages.
Doesn't touch old patch notes.
I couldn't find any other instances of this in the repo (regex: `substring.*\d\s*,\s*\d`), nor any problems with `bytes at`.