### PR TITLE
Improve `insert` and `update` examples in working_with_lists.md

### DIFF
--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -10,15 +10,18 @@ For example, `[foo bar baz]` or `[foo, bar, baz]`.
 
 You can [`update`](/commands/docs/update.md) and [`insert`](/commands/docs/insert.md) values into lists as they flow through the pipeline, for example let's insert the value `10` into the middle of a list:
 
-```
+```bash
 > [1, 2, 3, 4] | insert 2 10
+# [1, 2, 10, 3, 4]
 ```
 
 We can also use [`update`](/commands/docs/update.md) to replace the 2nd element with the value `10`.
 
-```
+```bash
 > [1, 2, 3, 4] | update 1 10
+# [1, 10, 3, 4]
 ```
+
 ## Removing or adding items from list
 In addition to [`insert`](/commands/docs/insert.md) and [`update`](/commands/docs/update.md), we also have [`prepend`](/commands/docs/prepend.md) and [`append`](/commands/docs/append.md). These let you insert to the beginning of a list or at the end of the list, respectively.
 

--- a/de/book/working_with_lists.md
+++ b/de/book/working_with_lists.md
@@ -12,14 +12,16 @@ Zum Beispiel, `[foo bar baz]` oder `[foo, bar, baz]`,
 Mit den zwei Befehlen `update` und `insert` können Listen in einer Pipeline verändert werden,
 zum Beispiel fügt folgende Zeile den Wert `10` in der Mitte, also an Stelle 2 ein.
 
-```
+```bash
 > [1, 2, 3, 4] | insert 2 10
+# [1, 2, 10, 3, 4]
 ```
 
 Mit dem Befehl `update` ersetzen wir hingegen das 2. Element mit dem Wert `10`.
 
-```
+```bash
 > [1, 2, 3, 4] | update 1 10
+# [1, 10, 3, 4]
 ```
 
 Zusätzlich zu `insert` und `update` stehen die Befehle `prepend` und `append` zu Verfügung.


### PR DESCRIPTION
Improves the `insert` and `update` examples in working_with_lists.md by showing their results and adding highlighting.
Copied from the zh-CN version.