### PR TITLE
fix the "`std` import" section of the 0.79 changelog

### DIFF
--- a/blog/2023-04-25-nushell_0_79.md
+++ b/blog/2023-04-25-nushell_0_79.md
@@ -76,13 +76,14 @@ i'm just gonna give some hints and links in this release note, leaving the rest 
 - the library can be used and tested with
 
 ```nushell
-use std  # will load the whole library under the `std` namespace
+use std   # will load the whole library under the `std` namespace
+use std * #   -    -   -    -      -    without the `std` prefix
 ```
 
 or use direct imports, such as
 
 ```nushell
-use std dirs
+use std 'dirs show'
 ```
 
 - one can follow the activity of the library in the [roadmap](https://github.com/nushell/nushell/issues/8450)


### PR DESCRIPTION
a Nushell user has reported issues in the changelog about the standard library, here is a quick fix :ok_hand: 