### PR TITLE
FIX: add prettier `std` commands format in 0.79 changelog

### DIFF
--- a/blog/2023-04-25-nushell_0_79.md
+++ b/blog/2023-04-25-nushell_0_79.md
@@ -56,12 +56,12 @@ and **reachable via the `use` command** without any additional setup.
 With this release, the library comes with the following custom commands:
 | module | description | commands |
 | ----------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`std assert`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/testing.nu) | a set of commands to write tests | assert, assert equal, assert error, assert greater, assert greater or equal, assert length, assert less, assert less or equal, assert not equal, assert skip, assert str contains |
-| [`std dirs`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/dirs.nu) | a re-implementation of the `shells` commands | dirs add, dirs drop, dirs next, dirs prev, dirs show |
-| [`std help`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/help.nu) | a Nushell implementation of the built-in commands | help, help aliases, help commands, help externs, help modules, help operators |
-| [`std iter`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/iter.nu) | an extension of built-in commands to iterate over data | iter filter-map, iter find, iter intersperse, iter scan |
-| [`std log`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/log.nu) | never miss something in your scripts | log critical, log debug, log error, log info, log warning |
-| [`xml` module](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/xml.nu) | tools to interact with Xml data | xaccess, xinsert, xtype, xupdate |
+| [`std assert`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/testing.nu) | a set of commands to write tests | `assert`, `assert equal`, `assert error`, `assert greater`, `assert greater or equal`, `assert length`, `assert less`, `assert less or equal`, `assert not equal`, `assert skip`, `assert str contains` |
+| [`std dirs`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/dirs.nu) | a re-implementation of the `shells` commands | `dirs add`, `dirs drop`, `dirs next`, `dirs prev`, `dirs show` |
+| [`std help`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/help.nu) | a Nushell implementation of the built-in commands | `help`, `help aliases`, `help commands`, `help externs`, `help modules`, `help operators` |
+| [`std iter`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/iter.nu) | an extension of built-in commands to iterate over data | `iter filter-map`, `iter find`, `iter intersperse`, `iter scan` |
+| [`std log`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/log.nu) | never miss something in your scripts | `log critical`, `log debug`, `log error`, `log info`, `log warning` |
+| [`xml` module](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/xml.nu) | tools to interact with Xml data | `xaccess`, `xinsert`, `xtype`, `xupdate` |
 
 - some other commands live under the `std` namespace, without any module: `clip`, `path add` and `run-tests`
 

--- a/blog/2023-04-25-nushell_0_79.md
+++ b/blog/2023-04-25-nushell_0_79.md
@@ -39,8 +39,8 @@ and **reachable via the `use` command** without any additional setup.
 > the _prelude_.
 >
 > As said above, the other commands are available with the `use` command.
-The goal of this library is, as its name suggests, to provide a _standard_ experience and a _standardized_ set of commands and tools to any Nushell user.
-In `std`, one can find things like
+> The goal of this library is, as its name suggests, to provide a _standard_ experience and a _standardized_ set of commands and tools to any Nushell user.
+> In `std`, one can find things like
 
 - a test framework to write robust Nushell scripts, modules and libraries
 - implementation of builtin commands once written in `rust`
@@ -56,11 +56,11 @@ In `std`, one can find things like
 With this release, the library comes with the following custom commands:
 | module | description | commands |
 | ----------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`std assert`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/testing.nu) | a set of commands to write tests | assert, assert, equal, assert, error, assert, greater, assert, greater, or, equal, assert, length, assert, less, assert, less, or, equal, assert, not, equal, assert, skip, assert, str, contains |
-| [`std dirs`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/dirs.nu) | a re-implementation of the `shells` commands | dirs, add, dirs, drop, dirs, next, dirs, prev, dirs, show |
-| [`std help`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/help.nu) | a Nushell implementation of the built-in commands | help, help, aliases, help, commands, help, externs, help, modules, help, operators |
-| [`std iter`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/iter.nu) | an extension of built-in commands to iterate over data | iter, filter-map, iter, find, iter, intersperse, iter, scan |
-| [`std log`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/log.nu) | never miss something in your scripts | log, critical, log, debug, log, error, log, info, log, warning |
+| [`std assert`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/testing.nu) | a set of commands to write tests | assert, assert equal, assert error, assert greater, assert greater or equal, assert length, assert less, assert less or equal, assert not equal, assert skip, assert str contains |
+| [`std dirs`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/dirs.nu) | a re-implementation of the `shells` commands | dirs add, dirs drop, dirs next, dirs prev, dirs show |
+| [`std help`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/help.nu) | a Nushell implementation of the built-in commands | help, help aliases, help commands, help externs, help modules, help operators |
+| [`std iter`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/iter.nu) | an extension of built-in commands to iterate over data | iter filter-map, iter find, iter intersperse, iter scan |
+| [`std log`](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/log.nu) | never miss something in your scripts | log critical, log debug, log error, log info, log warning |
 | [`xml` module](https://github.com/nushell/nushell/blob/main/crates/nu-std/lib/xml.nu) | tools to interact with Xml data | xaccess, xinsert, xtype, xupdate |
 
 - some other commands live under the `std` namespace, without any module: `clip`, `path add` and `run-tests`
@@ -95,7 +95,7 @@ use std 'dirs show'
 
 [stdlib PRs]: https://github.com/nushell/nushell/pulls?q=is%3Aclosed+is%3Apr+label%3Astd-library
 
-If, for some reason, you want to load Nushell without the standard library, start `nu` with the `--no-std-lib`. This can be the case if you find the startup times much longer than before. We're aiming to improve the loading speed in the future. 
+If, for some reason, you want to load Nushell without the standard library, start `nu` with the `--no-std-lib`. This can be the case if you find the startup times much longer than before. We're aiming to improve the loading speed in the future.
 
 ## enhanced IDE support in our VS code extension ([JT](https://github.com/nushell/nushell/pull/8745), [fdncred](https://github.com/nushell/vscode-nushell-lang/pull/89))
 
@@ -118,14 +118,15 @@ We listened to your feedback around the syntax changes introduced with 0.78 and 
 While there are still some missing pieces, we removed the old alias implementation. This means that `old-alias` is no longer available. We decided to remove it to clean up the code. It makes further fixes to aliases easier as you do not need to remember which alias implementation a piece of code belongs to.
 
 There are two notable missing features from the old aliases:
-* Missing completions with external completers. 
-* Most parser keywords (such as `source`) cannot be aliased but adding support for aliasing them should be possible in most cases.
-* Not possible to alias with environment shorthands (e.g., `alias foo = FOO=bar spam`)
-* Some presentation issues, such as the output of `which` and the alias `usage` pointing at the aliased call instead of the alias itself.
+
+- Missing completions with external completers.
+- Most parser keywords (such as `source`) cannot be aliased but adding support for aliasing them should be possible in most cases.
+- Not possible to alias with environment shorthands (e.g., `alias foo = FOO=bar spam`)
+- Some presentation issues, such as the output of `which` and the alias `usage` pointing at the aliased call instead of the alias itself.
 
 ## Changes to default files locations ([ito](https://github.com/nushell/nushell/pull/8792)-[hiroki](https://github.com/nushell/nushell/issues/8887))
 
-`$nu.config-path` and `$nu.env-path` are now set based on `--config` and `--env-config` flags passed to Nushell and also use the path after resolving symlinks. This means that they no longer guarantee pointing at the default Nushell's config directory. To be able to refere to the default config directory, `$nu.default-config-dir` was added and used in default `env.nu` to always point `NU_LIB_DIRS` to the `scripts` directory under the default config directory. 
+`$nu.config-path` and `$nu.env-path` are now set based on `--config` and `--env-config` flags passed to Nushell and also use the path after resolving symlinks. This means that they no longer guarantee pointing at the default Nushell's config directory. To be able to refere to the default config directory, `$nu.default-config-dir` was added and used in default `env.nu` to always point `NU_LIB_DIRS` to the `scripts` directory under the default config directory.
 
 Related to that, [`$env.CURRENT_FILE`](https://github.com/nushell/nushell/pull/8861) was added to be able to show the currently evaluated file.
 
@@ -139,6 +140,7 @@ Related to that, [`$env.CURRENT_FILE`](https://github.com/nushell/nushell/pull/8
 - [#8887](https://github.com/nushell/nushell/pull/8887) `NU_LIB_DIRS` definition in `env.nu` changed
 
 # Full changelog
+
 ## Nushell
 
 - sholderbach created [Bump to `0.79.1` dev version](https://github.com/nushell/nushell/pull/8998), and [Pin `reedline` to `0.19.0` release](https://github.com/nushell/nushell/pull/8996), and [Bump version for `0.79.0` release](https://github.com/nushell/nushell/pull/8980), and [Run coverage immediately](https://github.com/nushell/nushell/pull/8876), and [Reenable CI coverage](https://github.com/nushell/nushell/pull/8867), and [Fix span of multibyte short flags](https://github.com/nushell/nushell/pull/8866), and [Move CLI related commands to `nu-cli`](https://github.com/nushell/nushell/pull/8832), and [Follow up #8758 with a style fix](https://github.com/nushell/nushell/pull/8822)


### PR DESCRIPTION
This was reported by @skelly37 in https://discord.com/channels/601130461678272522/988303282931912704/1101797140356935801.

## the changes
- only the `std` table
- plus some `npm` auto format