### PR TITLE
Fixed link in design_notes to how_nushell_code_gets_run

### DIFF
--- a/book/design_notes.md
+++ b/book/design_notes.md
@@ -4,4 +4,4 @@ This chapter intends to give more in-depth overview of certain aspects of Nushel
 
 We intend to expand this chapter in the future. If there is some sopic that you find confusing and hard to understand, let us know. It might be a good candidate for a page here.
 
-[How Nushell Code Gets Run](book/how_nushell_code_gets_run.md) explains what happens when you run Nushell source code. It explains how Nushell is in many ways closer to classic compiled languages, like C or Rust, than to other shells and dynamic languages and hopefully clears some confusion that stems from that.
+[How Nushell Code Gets Run](how_nushell_code_gets_run.md) explains what happens when you run Nushell source code. It explains how Nushell is in many ways closer to classic compiled languages, like C or Rust, than to other shells and dynamic languages and hopefully clears some confusion that stems from that.


### PR DESCRIPTION
Link used to point to book/how_nushell_code_gets_run but since both files are in the same directory, specifying the directory **both** files are in breaks it.