### PR TITLE
Fix heading for ebook building

### DIFF
--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -33,7 +33,7 @@ However, they can be 'shadowed'. Shadowing means that they are redeclared and th
 A mutable variable is allowed to change its value by assignment. These are declared using the `mut` keyword.
 
 ```
-> mut val = 42 
+> mut val = 42
 > $val += 27
 > $val
 69
@@ -41,22 +41,23 @@ A mutable variable is allowed to change its value by assignment. These are decla
 
 There are a couple of assignment operators used with mutable variables
 
-|   Operator  |                              Description                                   |
-| ----------- | -------------------------------------------------------------------------- |
-| `=`         | Assigns a new value to the variable                                        |
-| `+=`        | Adds a value to the variable and makes the sum its new value               |
-| `-=`        | Subtracts a value from the variable and makes the difference its new value |
-| `*=`        | Multiplies the variable by a value and makes the product its new value     |
-| `/=`        | Divides the variable by a value and makes the quotient its new value       |
-| `**=`       | Concatenates the variable with a list making the new list its new value    |
+| Operator | Description                                                                |
+| -------- | -------------------------------------------------------------------------- |
+| `=`      | Assigns a new value to the variable                                        |
+| `+=`     | Adds a value to the variable and makes the sum its new value               |
+| `-=`     | Subtracts a value from the variable and makes the difference its new value |
+| `*=`     | Multiplies the variable by a value and makes the product its new value     |
+| `/=`     | Divides the variable by a value and makes the quotient its new value       |
+| `**=`    | Concatenates the variable with a list making the new list its new value    |
 
 > **Note**
+>
 > 1. `+=`, `-=`, `*=` and `/=` are only valid in the contexts where their root operations
-> are expected to work. For example, `+=` uses addition, so it can not be used for contexts
-> where addition would normally fail
+>    are expected to work. For example, `+=` uses addition, so it can not be used for contexts
+>    where addition would normally fail
 > 2. `**=` requires a variable representing a list **and** a list argument
 
-###### More on Mutability
+##### More on Mutability
 
 Closures and nested `def`s cannot capture mutable variables from their environment. For example
 


### PR DESCRIPTION
`######` will cause an error while rendering ebooks, use `#####` instead
Other changes were caused by code formatting