### PR TITLE
FIX: add `| table` to folded tables

### DIFF
--- a/book/loading_data.md
+++ b/book/loading_data.md
@@ -7,7 +7,7 @@ Earlier, we saw how you can use commands like [`ls`](/commands/docs/ls.md), [`ps
 One of Nu's most powerful assets in working with data is the [`open`](/commands/docs/open.md) command. It is a multi-tool that can work with a number of different data formats. To see what this means, let's try opening a json file:
 
 ```
-> open editors/vscode/package.json
+> open editors/vscode/package.json | table
 ──────────────────┬───────────────────────────────────────────────────────────────────────────────
  name             │ lark
  description      │ Lark support for VS Code
@@ -214,7 +214,7 @@ version = "0.1.2"
 The "Cargo.lock" file is actually a .toml file, but the file extension isn't .toml. That's okay, we can use the [`from`](/commands/docs/from.md) command using the `toml` subcommand:
 
 ```
-> open Cargo.lock | from toml
+> open Cargo.lock | from toml | table
 ──────────┬───────────────────
  metadata │ [row 107 columns]
  package  │ [table 130 rows]
@@ -263,8 +263,10 @@ Or run any SQL query you like:
 In addition to loading files from your filesystem, you can also load URLs by using the [`http get`](/commands/docs/fetch.md) command. This will fetch the contents of the URL from the internet and return it:
 
 ```
-> http get https://blog.rust-lang.org/feed.xml
-──────┬───────────────────
- feed │ {record 2 fields}
-──────┴───────────────────
+> http get https://blog.rust-lang.org/feed.xml | table
+╭────────────┬──────────────────╮
+│ tag        │ feed             │
+│ attributes │ {record 1 field} │
+│ content    │ [table 18 rows]  │
+╰────────────┴──────────────────╯
 ```

--- a/book/loading_data.md
+++ b/book/loading_data.md
@@ -6,26 +6,7 @@ Earlier, we saw how you can use commands like [`ls`](/commands/docs/ls.md), [`ps
 
 One of Nu's most powerful assets in working with data is the [`open`](/commands/docs/open.md) command. It is a multi-tool that can work with a number of different data formats. To see what this means, let's try opening a json file:
 
-```
-> open editors/vscode/package.json | table
-──────────────────┬───────────────────────────────────────────────────────────────────────────────
- name             │ lark
- description      │ Lark support for VS Code
- author           │ Lark developers
- license          │ MIT
- version          │ 1.0.0
- repository       │ [row type url]
- publisher        │ vscode
- categories       │ [table 0 rows]
- keywords         │ [table 1 rows]
- engines          │ [row vscode]
- activationEvents │ [table 1 rows]
- main             │ ./out/extension
- contributes      │ [row configuration grammars languages]
- scripts          │ [row compile postinstall test vscode:prepublish watch]
- devDependencies  │ [row @types/mocha @types/node tslint typescript vscode vscode-languageclient]
-──────────────────┴───────────────────────────────────────────────────────────────────────────────
-```
+@[code](@snippets/loading_data/vscode.sh)
 
 In a similar way to [`ls`](/commands/docs/ls.md), opening a file type that Nu understands will give us back something that is more than just text (or a stream of bytes). Here we open a "package.json" file from a JavaScript project. Nu can recognize the JSON text and parse it to a table of data.
 
@@ -213,13 +194,7 @@ version = "0.1.2"
 
 The "Cargo.lock" file is actually a .toml file, but the file extension isn't .toml. That's okay, we can use the [`from`](/commands/docs/from.md) command using the `toml` subcommand:
 
-```
-> open Cargo.lock | from toml | table
-──────────┬───────────────────
- metadata │ [row 107 columns]
- package  │ [table 130 rows]
-──────────┴───────────────────
-```
+@[code](@snippets/loading_data/cargo-toml.sh)
 
 The [`from`](/commands/docs/from.md) command can be used for each of the structured data text formats that Nu can open and understand by passing it the supported format as a subcommand.
 
@@ -262,11 +237,4 @@ Or run any SQL query you like:
 
 In addition to loading files from your filesystem, you can also load URLs by using the [`http get`](/commands/docs/fetch.md) command. This will fetch the contents of the URL from the internet and return it:
 
-```
-> http get https://blog.rust-lang.org/feed.xml | table
-╭────────────┬──────────────────╮
-│ tag        │ feed             │
-│ attributes │ {record 1 field} │
-│ content    │ [table 18 rows]  │
-╰────────────┴──────────────────╯
-```
+@[code](@snippets/loading_data/rust-lang-feed.sh)

--- a/book/metadata.md
+++ b/book/metadata.md
@@ -20,20 +20,20 @@ Values that flow through a pipeline in Nu often have a set of additional informa
 Let's run the [`open`](/commands/docs/open.md) command again, but this time, we'll look at the tags it gives back:
 
 ```
-> open Cargo.toml | metadata
-────────┬───────────────────────────────────────────
- span   │ {record 2 fields}
-────────┴───────────────────────────────────────────
+> metadata (open Cargo.toml) | table
+╭──────┬───────────────────╮
+│ span │ {record 2 fields} │
+╰──────┴───────────────────╯
 ```
 
 Currently, we track only the span of where values come from. Let's take a closer look at that:
 
 ```
-> open Cargo.toml | metadata | get span
-───────┬────
- start │ 5
- end   │ 15
-───────┴────
+> metadata (open Cargo.toml) | get span
+╭───────┬────────╮
+│ start │ 212970 │
+│ end   │ 212987 │
+╰───────┴────────╯
 ```
 
 The span "start" and "end" here refer to where the underline will be in the line. If you count over 5, and then count up to 15, you'll see it lines up with the "Cargo.toml" filename. This is how the error we saw earlier knew what to underline.

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -348,15 +348,7 @@ You can combine list and record data access syntax to navigate tables. When used
 
 You can access individual rows by number to obtain records:
 
-```sh
-> [{langs:[Rust JS Python], releases:60}].0 | table
-╭──────────┬────────────────╮
-│ langs    │ [list 3 items] │
-│ releases │ 60             │
-╰──────────┴────────────────╯
-> [{langs:[Rust JS Python], releases:60}].0.langs.2
-Python
-```
+@[code](@snippets/types_of_data/cell-paths.sh)
 
 Moreover, you can also access entire columns of a table by name, to obtain lists:
 

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -349,7 +349,7 @@ You can combine list and record data access syntax to navigate tables. When used
 You can access individual rows by number to obtain records:
 
 ```sh
-> [{langs:[Rust JS Python], releases:60}].0
+> [{langs:[Rust JS Python], releases:60}].0 | table
 ╭──────────┬────────────────╮
 │ langs    │ [list 3 items] │
 │ releases │ 60             │

--- a/de/book/loading_data.md
+++ b/de/book/loading_data.md
@@ -228,8 +228,10 @@ Zusätzlich zum Laden von Dateien vom Dateisystem, können auch URLs mit dem [`h
 Befehl geladen werden. Dies wird den Inhalt der URL aus dem Netz abrufen und zurückgeben:
 
 ```
-> http get https://blog.rust-lang.org/feed.xml
-──────┬───────────────────
- feed │ {record 2 fields}
-──────┴───────────────────
+> http get https://blog.rust-lang.org/feed.xml | table
+╭────────────┬──────────────────╮
+│ tag        │ feed             │
+│ attributes │ {record 1 field} │
+│ content    │ [table 18 rows]  │
+╰────────────┴──────────────────╯
 ```

--- a/de/book/loading_data.md
+++ b/de/book/loading_data.md
@@ -12,26 +12,7 @@ Einer der mächtigsten Befehle in Nu um mir Daten zu arbeite ist der [`open`](/c
 Er ist ein Multi-Werkzeug, welcher mit verschiedensten Datenformaten umgehen kann.
 Hier zum Beispiel was passiert, wenn eine json Datei geöffnet wird:
 
-```
-> open editors/vscode/package.json
-──────────────────┬───────────────────────────────────────────────────────────────────────────────
- name             │ lark
- description      │ Lark support for VS Code
- author           │ Lark developers
- license          │ MIT
- version          │ 1.0.0
- repository       │ [row type url]
- publisher        │ vscode
- categories       │ [table 0 rows]
- keywords         │ [table 1 rows]
- engines          │ [row vscode]
- activationEvents │ [table 1 rows]
- main             │ ./out/extension
- contributes      │ [row configuration grammars languages]
- scripts          │ [row compile postinstall test vscode:prepublish watch]
- devDependencies  │ [row @types/mocha @types/node tslint typescript vscode vscode-languageclient]
-──────────────────┴───────────────────────────────────────────────────────────────────────────────
-```
+@[code](@snippets/loading_data/vscode.sh)
 
 Ähnlich wie beim [`ls`](/commands/docs/ls.md) Befehl, bekommen wir mehr als nur Text
 (oder einen Stream von bytes) zurück, wenn wir einen Dateityp öffnen, den Nu versteht.
@@ -196,13 +177,7 @@ version = "0.1.2"
 Eine "Cargo.lock" Datei ist eigentlich eine .toml Datei, aber die Dateiendung ist nicht .toml.
 Das ist ok, denn mit dem `from` und seinem Unterbefehl `toml` können wir dies explizit angeben:
 
-```
-> open Cargo.lock | from toml
-──────────┬───────────────────
- metadata │ [row 107 columns]
- package  │ [table 130 rows]
-──────────┴───────────────────
-```
+@[code](@snippets/loading_data/cargo-toml.sh)
 
 Der `from` Befehl kann für jedes strukturierte Datenformat, welches Nu versteht, verwendet werden,
 indem das Format als entsprechender Unterbefehl verwendet wird.
@@ -227,11 +202,4 @@ license = "MIT"
 Zusätzlich zum Laden von Dateien vom Dateisystem, können auch URLs mit dem [`http get`](/commands/docs/fetch.md)
 Befehl geladen werden. Dies wird den Inhalt der URL aus dem Netz abrufen und zurückgeben:
 
-```
-> http get https://blog.rust-lang.org/feed.xml | table
-╭────────────┬──────────────────╮
-│ tag        │ feed             │
-│ attributes │ {record 1 field} │
-│ content    │ [table 18 rows]  │
-╰────────────┴──────────────────╯
-```
+@[code](@snippets/loading_data/rust-lang-feed.sh)

--- a/ja/book/loading_data.md
+++ b/ja/book/loading_data.md
@@ -6,26 +6,7 @@
 
 データを操作するための Nu の最も強力なコマンドのひとつが`open`コマンドです。これは様々なデータ形式に対応したマルチツールです。これがなにを意味するかをみるために、json ファイルを開いてみましょう。
 
-```
-> open editors/vscode/package.json
-──────────────────┬───────────────────────────────────────────────────────────────────────────────
- name             │ lark
- description      │ Lark support for VS Code
- author           │ Lark developers
- license          │ MIT
- version          │ 1.0.0
- repository       │ [row type url]
- publisher        │ vscode
- categories       │ [table 0 rows]
- keywords         │ [table 1 rows]
- engines          │ [row vscode]
- activationEvents │ [table 1 rows]
- main             │ ./out/extension
- contributes      │ [row configuration grammars languages]
- scripts          │ [row compile postinstall test vscode:prepublish watch]
- devDependencies  │ [row @types/mocha @types/node tslint typescript vscode vscode-languageclient]
-──────────────────┴───────────────────────────────────────────────────────────────────────────────
-```
+@[code](@snippets/loading_data/vscode.sh)
 
 `ls`と同様、Nu が理解できるタイプのファイルを開くと、単なるテキスト(またはバイトストリーム)以上のものが返ってきます。ここでは、JavaScript プロジェクト内の"package.json"ファイルを開いています。Nu は JSON テキストを認識し、テーブルデータを返すことができます。
 
@@ -163,13 +144,7 @@ version = "0.1.2"
 
 "Cargo.lock"ファイルは実際には.toml ファイルですが、ファイル拡張子が.toml ではありません。でも大丈夫です、`from toml`コマンドが使えます。
 
-```
-> open Cargo.lock | from toml
-──────────┬───────────────────
- metadata │ [row 107 columns]
- package  │ [table 130 rows]
-──────────┴───────────────────
-```
+@[code](@snippets/loading_data/cargo-toml.sh)
 
 `from`コマンドはサポートされているテキストフォーマットをサブコマンドとして渡すことで Nu が扱える構造化データごとに利用できます。
 
@@ -191,9 +166,4 @@ license = "MIT"
 ファイルシステムからファイルを読み込むことに加えて、`http get`コマンドを利用して URL からリソースを取得できます。
 これはインターネットから URL の内容をフェッチして返してくれます。
 
-```
-> http get https://www.jonathanturner.org/feed.xml
-─────┬───────────────────────────
- rss │ [row attributes children]
-─────┴───────────────────────────
-```
+@[code](@snippets/loading_data/rust-lang-feed.sh)

--- a/snippets/introduction/sys_example.sh
+++ b/snippets/introduction/sys_example.sh
@@ -1,4 +1,4 @@
-> sys
+> sys | table
 ╭───────┬───────────────────╮
 │ host  │ {record 6 fields} │
 │ cpu   │ [table 4 rows]    │

--- a/snippets/loading_data/cargo-toml.sh
+++ b/snippets/loading_data/cargo-toml.sh
@@ -1,0 +1,5 @@
+> open Cargo.lock | from toml | table
+──────────┬───────────────────
+ metadata │ [row 107 columns]
+ package  │ [table 130 rows]
+──────────┴───────────────────

--- a/snippets/loading_data/rust-lang-feed.sh
+++ b/snippets/loading_data/rust-lang-feed.sh
@@ -1,0 +1,6 @@
+> http get https://blog.rust-lang.org/feed.xml | table
+╭────────────┬──────────────────╮
+│ tag        │ feed             │
+│ attributes │ {record 1 field} │
+│ content    │ [table 18 rows]  │
+╰────────────┴──────────────────╯

--- a/snippets/loading_data/vscode.sh
+++ b/snippets/loading_data/vscode.sh
@@ -1,0 +1,18 @@
+> open editors/vscode/package.json | table
+──────────────────┬───────────────────────────────────────────────────────────────────────────────
+ name             │ lark
+ description      │ Lark support for VS Code
+ author           │ Lark developers
+ license          │ MIT
+ version          │ 1.0.0
+ repository       │ [row type url]
+ publisher        │ vscode
+ categories       │ [table 0 rows]
+ keywords         │ [table 1 rows]
+ engines          │ [row vscode]
+ activationEvents │ [table 1 rows]
+ main             │ ./out/extension
+ contributes      │ [row configuration grammars languages]
+ scripts          │ [row compile postinstall test vscode:prepublish watch]
+ devDependencies  │ [row @types/mocha @types/node tslint typescript vscode vscode-languageclient]
+──────────────────┴───────────────────────────────────────────────────────────────────────────────

--- a/snippets/types_of_data/cell-paths.sh
+++ b/snippets/types_of_data/cell-paths.sh
@@ -1,0 +1,7 @@
+> [{langs:[Rust JS Python], releases:60}].0 | table
+╭──────────┬────────────────╮
+│ langs    │ [list 3 items] │
+│ releases │ 60             │
+╰──────────┴────────────────╯
+> [{langs:[Rust JS Python], releases:60}].0.langs.2
+Python

--- a/zh-CN/book/loading_data.md
+++ b/zh-CN/book/loading_data.md
@@ -6,26 +6,7 @@
 
 Nu 在处理数据方面最强大的能力之一是[`open`](/commands/docs/open.md)命令。它是一个多功能命令，可以处理许多不同的数据格式。为了说明这一点让我们试着打开一个 JSON 文件：
 
-```
-> open editors/vscode/package.json
-──────────────────┬───────────────────────────────────────────────────────────────────────────────
- name             │ lark
- description      │ Lark support for VS Code
- author           │ Lark developers
- license          │ MIT
- version          │ 1.0.0
- repository       │ [row type url]
- publisher        │ vscode
- categories       │ [table 0 rows]
- keywords         │ [table 1 rows]
- engines          │ [row vscode]
- activationEvents │ [table 1 rows]
- main             │ ./out/extension
- contributes      │ [row configuration grammars languages]
- scripts          │ [row compile postinstall test vscode:prepublish watch]
- devDependencies  │ [row @types/mocha @types/node tslint typescript vscode vscode-languageclient]
-──────────────────┴───────────────────────────────────────────────────────────────────────────────
-```
+@[code](@snippets/loading_data/vscode.sh)
 
 与[`ls`](/commands/docs/ls.md)类似，打开一个 Nu 支持的文件类型，会返回一些不仅仅是文本（或一个字节流）的东西。这里我们打开了一个来自 JavaScript 项目的 "package.json" 文件。Nu 可以识别 JSON 文本并将其解析为一个数据表。
 
@@ -172,13 +153,7 @@ version = "0.1.2"
 
 "Cargo.lock" 实际上是一个 .toml 文件，但是文件扩展名不是 .toml。没关系，我们可以使用 `from toml` 命令：
 
-```
-> open Cargo.lock | from toml
-──────────┬───────────────────
- metadata │ [row 107 columns]
- package  │ [table 130 rows]
-──────────┴───────────────────
-```
+@[code](@snippets/loading_data/cargo-toml.sh)
 
 每种 Nu 能打开并理解的结构化数据文本格式都有对应的 `from` 命令可以使用，只需要把支持的格式作为子命令传给 `from` 就可以了。
 
@@ -200,11 +175,4 @@ license = "MIT"
 
 除了从文件系统中加载文件，你还可以通过使用[`http get`](/commands/docs/fetch.md)命令来加载 URLs。这将从互联网上获取 URL 的内容并返回：
 
-```
-> http get https://blog.rust-lang.org/feed.xml | table
-╭────────────┬──────────────────╮
-│ tag        │ feed             │
-│ attributes │ {record 1 field} │
-│ content    │ [table 18 rows]  │
-╰────────────┴──────────────────╯
-```
+@[code](@snippets/loading_data/rust-lang-feed.sh)

--- a/zh-CN/book/loading_data.md
+++ b/zh-CN/book/loading_data.md
@@ -201,8 +201,10 @@ license = "MIT"
 除了从文件系统中加载文件，你还可以通过使用[`http get`](/commands/docs/fetch.md)命令来加载 URLs。这将从互联网上获取 URL 的内容并返回：
 
 ```
-> http get https://blog.rust-lang.org/feed.xml
-──────┬───────────────────
- feed │ {record 2 fields}
-──────┴───────────────────
+> http get https://blog.rust-lang.org/feed.xml | table
+╭────────────┬──────────────────╮
+│ tag        │ feed             │
+│ attributes │ {record 1 field} │
+│ content    │ [table 18 rows]  │
+╰────────────┴──────────────────╯
 ```

--- a/zh-CN/book/metadata.md
+++ b/zh-CN/book/metadata.md
@@ -20,20 +20,20 @@ error: Expected a string from pipeline
 让我们再次运行[`open`](/commands/docs/open.md)命令，但这一次，我们将看一下它所反馈的标签：
 
 ```
-> open Cargo.toml | metadata
-────────┬───────────────────────────────────────────
- span   │ {record 2 fields}
-────────┴───────────────────────────────────────────
+> metadata (open Cargo.toml) | table
+╭──────┬───────────────────╮
+│ span │ {record 2 fields} │
+╰──────┴───────────────────╯
 ```
 
 目前，我们只追踪值来自何处的起止范围(span)。让我们进一步仔细看看：
 
 ```bash
-> open Cargo.toml | metadata | get span
-───────┬────
- start │ 5
- end   │ 15
-───────┴────
+> metadata (open Cargo.toml) | get span
+╭───────┬────────╮
+│ start │ 212970 │
+│ end   │ 212987 │
+╰───────┴────────╯
 ```
 
 这里的范围 "start" 和 "end" 指的是下划线将标记在行中的位置。如果你数到 5，然后再数到 15，就会看到它与 "Cargo.toml" 文件名一致。这就是我们之前看到的错误是如何知道在何处标注下划线的。


### PR DESCRIPTION
should fix #917

this PR adds `| table` at the end of pipelines which give folded tables.
this can be ambiguous given the `default_config.nu` which expands the tables automatically with `$env.config.hooks.display_output` :open_mouth: 

with `| table` this is not ambiguous anymore because `| table` overrides the hook :+1: 

> **Note**
> - i've only searched for `{record`, `[table` and `[list`, which are characteristic of a folded table, in the book
> - i've added some cross-language snippets :thinking: 