### PR TITLE
Supply table instead of closure to merge command in tables.md

### DIFF
--- a/cookbook/tables.md
+++ b/cookbook/tables.md
@@ -11,7 +11,7 @@ Examples shown in [`Working with tables`](../book/working_with_tables.md) work f
 ```
 > let first = [[a b]; [1 2] [3 4]]
 > let second = [[c d]; [5 6]]
-> $first | merge { $second }
+> $first | merge $second
 ───┬───┬───┬───┬───
  # │ a │ b │ c │ d
 ───┼───┼───┼───┼───
@@ -28,7 +28,7 @@ Second row in columns `c` and `d` is empty because our `second` table only conta
 > let second = [[c d]; [3 4]]
 > $first | group ($second | length)
   | each {|it|
-    merge {$second}
+    merge $second
   } | flatten
 ───┬───┬───┬───┬───
  # │ a │ b │ c │ d
@@ -50,12 +50,12 @@ We could join all three tables like this:
 ```
 > $first | group ($second|length)
    | each {|it|
-     merge { $second  }
+     merge $second
    }
    | flatten
    | group ($third | length)
    | each {|it|
-     merge { $third }
+     merge $third
    }
    | flatten
 ───┬───┬───┬───┬───┬───┬───
@@ -74,7 +74,7 @@ Or just like last time we could use the [`reduce`](../book/docs/reduce.md) comma
     $acc
     | group ($it | length)
     | each {|x|
-        merge {$it}
+        merge $it
     }
     | flatten
 }


### PR DESCRIPTION
If the merge command is supplied an expression in curly braces, nushell errors out expecting input and argument, to be both record or both table.

Tested on nushell 0.80.0

To reproduce this error, run:

```sh
let first = [[a b]; [1 2]]
let second = [[c d]; [3 4]]
$first | merge { $second }
```

We get:

```
× Pipeline mismatch.
   ╭─[entry #5:1:1]
 1 │ $first | merge { $second }
   · ───┬──   ──┬──
   ·    │       ╰── expected: input, and argument, to be both record or both table
   ·    ╰── value originates from here
   ╰────
```

We don't get errors if we use:

```sh
$first | merge $second
```