### PR TITLE
Fix references to match in the "coming from" pages to reflect its current usage in Nu

### DIFF
--- a/book/nushell_map_functional.md
+++ b/book/nushell_map_functional.md
@@ -19,8 +19,8 @@ Note: this table assumes Nu 0.43 or later.
 | is-empty                  | empty?                       | isEmpty                         |                          |     |
 | last                      | last, peek, take-last        | last                            | last                     |     |
 | lines                     |                              |                                 | lines, words, split-with |     |
-| match                     | re-matches, re-seq, re-find  |                                 |                          |     |
- nth                       | nth                          | Array.get                       | lookup                   |     |
+| match                     |                              | match (Ocaml), case (Elm)       | case                     |     |
+|nth                        | nth                          | Array.get                       | lookup                   |     |
 | open                      | with-open                    |                                 |                          |     |
 | transpose                 | (apply mapv vector matrix)   |                                 | transpose                |     |
 | prepend                   | cons                         | cons, ::                        | ::                       |     |

--- a/book/nushell_map_imperative.md
+++ b/book/nushell_map_imperative.md
@@ -33,7 +33,7 @@ Note: this table assumes Nu 0.43 or later.
 | last         | list[-x:]                     |                                                     |                         | &Vec[Vec.len()-1]                             |
 | lines        | split, splitlines             | split                                               | views::split            | split, split_whitespace, rsplit, lines        |
 | ls           | os.listdir                    |                                                     |                         |                                               |
-| match        | re.findall                    | Regex.matches                                       | regex_match             |                                               |
+| match        | match                         | when                                                |                         | match                                         |
 | merge        | dict.append                   |                                                     |                         |                                               |
 | mkdir        | os.mkdir                      |                                                     |                         |                                               |
 | mv           | shutil.move                   |                                                     |                         |                                               |


### PR DESCRIPTION
I have updated the tables to show what match is equivalent to in other languages. There are a couple places that I simply removed the references since there was no closely equivalent feature.