### PR TITLE
FIX: out of date external completion examples

### DIFF
--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -54,7 +54,7 @@ module commands {
     def animals [] {
         ["cat", "dog", "eel" ]
     }
-    
+
     def animal-names [context: string] {
         {
             cat: ["Missy", "Phoebe"]
@@ -144,19 +144,11 @@ This example should enable carapace external completions:
 
 ```nu
 # config.nu
-let carapace_completer = {|spans|
-    carapace $spans.0 nushell $spans | from json
-}
-
-# The default config record. This is where much of your global configuration is setup.
-let-env config = {
-    # ... your config
-    completions: {
-        external: {
-            enable: true
-            max_results: 100
-            completer: $carapace_completer
-        }
+$env.config.completions.external = {
+    enable: true
+    max_results: 100
+    completer: {|spans|
+        carapace $spans.0 nushell $spans | from json
     }
 }
 ```
@@ -164,7 +156,7 @@ let-env config = {
 Multiple completers can be defined as such:
 
 ```nu
-let external_completer = {|spans| 
+{|spans|
   {
     $spans.0: { default_completer $spans | from json } # default
     ls: { ls_completer $spans | from json }
@@ -176,19 +168,12 @@ let external_completer = {|spans|
 This example shows an external completer that uses the `fish` shell's `complete` command. (You must have the fish shell installed for this example to work.)
 
 ```nu
-let fish_completer = {|spans|
-    fish --command $'complete "--do-complete=($spans | str join " ")"' | str trim | split row "\n" | each { |line| $line | split column "\t" value description } | flatten
-}
-
-let-env config = {
-    # ... your config
-    completions: {
-        external: {
-            enable: true
-            max_results: 100
-            completer: $fish_completer
-        }
-    }
+$env.config.completions.external.completer = {|spans|
+    fish --command $'complete "--do-complete=($spans | str join " ")"'
+    | str trim
+    | split row "\n"
+    | each { |line| $line | split column "\t" value description }
+    | flatten
 }
 ```
 

--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -169,7 +169,7 @@ let external_completer = {|spans|
     $spans.0: { default_completer $spans | from json } # default
     ls: { ls_completer $spans | from json }
     git: { git_completer $spans | from json }
-  } | get $spans.0 | each {|it| do $it}
+  } | each {|it| do $it}
 }
 ```
 

--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -157,11 +157,11 @@ Multiple completers can be defined as such:
 
 ```nu
 {|spans|
-  {
-    $spans.0: { default_completer $spans | from json } # default
-    ls: { ls_completer $spans | from json }
-    git: { git_completer $spans | from json }
-  } | each {|it| do $it}
+    {
+        $spans.0: { default_completer $spans | from json } # default
+        ls: { ls_completer $spans | from json }
+        git: { git_completer $spans | from json }
+    } | each {|it| do $it}
 }
 ```
 

--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -140,23 +140,31 @@ External completers can also be integrated, instead of relying solely on Nushell
 For this set the `external_completer` field in `config.nu` to a block which will be evaluated if no Nushell completions were found.
 You can configure the block to run an external completer, such as [carapace](https://github.com/rsteube/carapace-bin).
 
+> **Note**  
+> in the following, we define a bunch of different completers.
+>
+> one can configure them in `$nu.config-path` as follows:
+>
+> ```nu
+> $env.config.completions.external = {
+>     enable: true
+>     max_results: 100
+>     completer: $completer
+> }
+> ```
+
 This example should enable carapace external completions:
 
 ```nu
-# config.nu
-$env.config.completions.external = {
-    enable: true
-    max_results: 100
-    completer: {|spans|
-        carapace $spans.0 nushell $spans | from json
-    }
+let carapace_completer = {|spans|
+    carapace $spans.0 nushell $spans | from json
 }
 ```
 
 Multiple completers can be defined as such:
 
 ```nu
-{|spans|
+let multiple_completers = {|spans|
     {
         $spans.0: { default_completer $spans | from json } # default
         ls: { ls_completer $spans | from json }
@@ -168,7 +176,7 @@ Multiple completers can be defined as such:
 This example shows an external completer that uses the `fish` shell's `complete` command. (You must have the fish shell installed for this example to work.)
 
 ```nu
-$env.config.completions.external.completer = {|spans|
+let fish_completer = {|spans|
     fish --command $'complete "--do-complete=($spans | str join " ")"'
     | str trim
     | split row "\n"


### PR DESCRIPTION
trying to fix #922 

cc/ @MrFoxPro

in this PR i've
- fixed the multi-completer example
- fixed some formatting
- used the new `$env.* = ...` syntax to simplify the examples 

does the following work better @MrFoxPro?
```bash
{|spans|
    {
        $spans.0: { default_completer $spans | from json } # default
        ls: { ls_completer $spans | from json }
        git: { git_completer $spans | from json }
    } | each {|it| do $it}
}
```