### PR TITLE
Modernize and add additional info to plugin tutorial

### DIFF
--- a/contributor-book/plugins.md
+++ b/contributor-book/plugins.md
@@ -213,7 +213,7 @@ Signatures:
 
 ## Under the hood
 
-Writing Nu plugins in Rust is convenient because we can make use of the `nu-plugin` and `nu-protocl` crates, which are part of Nu itself and define the interface protocol. To write a plugin in another language you will need to implement that protocol yourself. If you're goal is to write Nu plugins in Rust you can stop here. If you'd like to explore the low level plugin interface or write plugins in other languages such as Python, keep reading.
+Writing Nu plugins in Rust is convenient because we can make use of the `nu-plugin` and `nu-protocol` crates, which are part of Nu itself and define the interface protocol. To write a plugin in another language you will need to implement that protocol yourself. If you're goal is to write Nu plugins in Rust you can stop here. If you'd like to explore the low level plugin interface or write plugins in other languages such as Python, keep reading.
 
 Ordinarily, Nu will execute the plugin and knows what data to pass to it and how to interpret the responses. Here we'll be doing it manually. Note that we'll be playing with our plugin using a conventional shell (like bash or zsh) as in Nu all of this happens under the hood.
 

--- a/contributor-book/plugins.md
+++ b/contributor-book/plugins.md
@@ -14,19 +14,7 @@ The second stage is the actual doing of work. Here the plugins are executed and 
 
 ## Discovery
 
-Nu discovers plugins by checking all directories specified by `plugin_dirs` config entry and the directory where `nu` executable lies. You can change the configuration by executing `config set plugin_dirs ["/path","/to","/search"]` in Nu.
-In each directory, Nu is looking for executable files that match the pattern `nu_plugin_*` where `*` is a minimum of one alphanumeric character.
-
-On Windows, this has a similar pattern of `nu_plugin_*.exe` or `nu_plugin_*.bat`.
-
-Once a matching file has been discovered, Nu will invoke the file and pass to it the first command: `Signature`.
-The plugin then replies with the signature of the plugin, which, once deserialized, is identical to the signature commands use.
-
-Nu continues in this way until it has traveled across all directories in the path.
-
-After it has traversed the path, it will look in two more directories: the target/debug and the target/release directories. It will pick one or the other depending whether Nu was compiled in debug mode or release mode, respectively. This allows for easier testing of plugins during development.
-
-Additionally you may manually register a plugin by executing `register <path_to_plugin_executable>`.
+Nu keeps a registry of plugins at the file system location defined by configuration variable `$nu.plugin-path`. To register a plugin, execute `register <path_to_plugin_executable>` in a Nu shell.
 
 ## Creating a plugin (in Rust)
 


### PR DESCRIPTION
In my [previous update](https://github.com/nushell/nushell.github.io/pull/921) to the plugin tutorial a number of other issues were flagged as not fixed. I believe this addresses those as well as expands a section on the low-level protocol that I think is helpful for understanding the Python section.

I've learned a lot while working on these docs but I'm still not super familiar with the technology so I'm very open to feedback on this. I think it addresses the issues flagged as unresolved in the earlier PR.