### PR TITLE
Remove mentioning ZB and ZiB

### DIFF
--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -483,7 +483,7 @@ let config = {
   animate_prompt: false
   float_precision: 2
   use_ansi_coloring: true
-  filesize_format: "b" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
+  filesize_format: "b" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
   edit_mode: emacs # vi
   max_history_size: 10000
   log_level: error

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -135,14 +135,12 @@ The full list of filesize units are:
 - `tb`: terabytes
 - `pb`: petabytes
 - `eb`: exabytes
-- `zb`: zettabyte
 - `kib`: kibibytes (aka 1024 bytes)
 - `mib`: mebibytes
 - `gib`: gibibytes
 - `tib`: tebibytes
 - `pib`: pebibytes
 - `eib`: exbibyte
-- `zib`: zebibyte
 
 As with durations, you can make fractional file sizes, and do calculations:
 

--- a/de/book/coloring_and_theming.md
+++ b/de/book/coloring_and_theming.md
@@ -487,7 +487,7 @@ let config = {
   animate_prompt: false
   float_precision: 2
   use_ansi_coloring: true
-  filesize_format: "b" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
+  filesize_format: "b" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
   edit_mode: emacs # vi
   max_history_size: 10000
   log_level: error

--- a/zh-CN/book/coloring_and_theming.md
+++ b/zh-CN/book/coloring_and_theming.md
@@ -475,7 +475,7 @@ let config = {
   animate_prompt: false
   float_precision: 2
   use_ansi_coloring: true
-  filesize_format: "b" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
+  filesize_format: "b" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
   edit_mode: emacs # vi
   max_history_size: 10000
   log_level: error

--- a/zh-CN/book/types_of_data.md
+++ b/zh-CN/book/types_of_data.md
@@ -185,14 +185,12 @@ Eg) `1wk`是一个星期的时间间隔。
 - `tb`: terabytes
 - `pb`: petabytes
 - `eb`: exabytes
-- `zb`: zettabyte
 - `kib`: kibibytes (aka 1024 bytes)
 - `mib`: mebibytes
 - `gib`: gibibytes
 - `tib`: tebibytes
 - `pib`: pebibytes
 - `eib`: exbibyte
-- `zib`: zebibyte
 
 ## 二进制数据
 


### PR DESCRIPTION
See also: nushell/nushell#9337, nushell/nushell#9427

To be consistent with nushell, this PR removes mention of ZB and ZiB.