### PR TITLE
Bring shells documentation up to date

### DIFF
--- a/commands/docs/dexit.md
+++ b/commands/docs/dexit.md
@@ -1,0 +1,27 @@
+---
+title: dexit
+categories: |
+  shells
+version: 0.80.0
+shells: |
+  Exits the current Nu shell, and go to the next one
+usage: |
+  Exits the current Nu shell, and go to the next one
+---
+
+# <code>{{ $frontmatter.title }}</code> for shells
+
+<div class='command-title'>{{ $frontmatter.shells }}</div>
+
+## Signature
+
+```> dexit```
+
+
+## Examples
+
+Exits the current shell
+```shell
+> dexit
+
+```

--- a/commands/docs/enter.md
+++ b/commands/docs/enter.md
@@ -15,11 +15,12 @@ usage: |
 
 ## Signature
 
-```> enter (path)```
+```> enter (path)...```
 
 ## Parameters
 
  -  `path`: the path to enter as a new shell
+ -  `...rest`: other paths to add as new shells after this one, but not enter
 
 ## Examples
 
@@ -28,3 +29,7 @@ Enter a new shell at path '../dir-foo'
 > enter ../dir-foo
 
 ```
+
+## Notes
+
+To leave this shell again, use [dexit](dexit.md).

--- a/commands/docs/exit.md
+++ b/commands/docs/exit.md
@@ -1,17 +1,17 @@
 ---
 title: exit
 categories: |
-  shells
+  core
 version: 0.81.0
-shells: |
-  Exit a Nu shell or exit Nu entirely.
+core: |
+  Exit Nu.
 usage: |
-  Exit a Nu shell or exit Nu entirely.
+  Exit Nu.
 ---
 
 # <code>{{ $frontmatter.title }}</code> for shells
 
-<div class='command-title'>{{ $frontmatter.shells }}</div>
+<div class='command-title'>{{ $frontmatter.core }}</div>
 
 ## Signature
 
@@ -23,8 +23,12 @@ usage: |
 
 ## Examples
 
-Exit the current shell
+Exit Nu
 ```shell
 > exit
 
 ```
+
+## Notes
+
+This command used to leave a shell. This function has been taken over by [dexit](dexit.md).

--- a/commands/docs/n.md
+++ b/commands/docs/n.md
@@ -15,7 +15,11 @@ usage: |
 
 ## Signature
 
-```> n ```
+```> n (N)```
+
+## Parameters
+
+ -  `N`: the number of shells to jump forward
 
 ## Examples
 
@@ -28,5 +32,11 @@ Make two directories and enter new shells for them, use `n` to jump to the next 
 Run `n` several times and note the changes of current directory
 ```shell
 > n
+
+```
+
+Jump 2 shells forward
+```shell
+> n 2
 
 ```

--- a/commands/docs/p.md
+++ b/commands/docs/p.md
@@ -15,7 +15,11 @@ usage: |
 
 ## Signature
 
-```> p ```
+```> p (N)```
+
+## Parameters
+
+ -  `N`: the number of shells to jump backward
 
 ## Examples
 
@@ -28,5 +32,11 @@ Make two directories and enter new shells for them, use `p` to jump to the previ
 Run `p` several times and note the changes of current directory
 ```shell
 > p
+
+```
+
+Jump 2 shells backward
+```shell
+> p 2
 
 ```


### PR DESCRIPTION
- `exit` no longer performs shell functions (despite it staying in `crates/nu-command/src/shells/exit.rs` for now)
- Those functions have been moved to `dexit`
- Add numeric argument to `p` and `n`