### PR TITLE
Fix custom completion scripts

### DIFF
--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -166,10 +166,9 @@ Multiple completers can be defined as such:
 ```nu
 let multiple_completers = {|spans|
     {
-        $spans.0: { default_completer $spans | from json } # default
-        ls: { ls_completer $spans | from json }
-        git: { git_completer $spans | from json }
-    } | each {|it| do $it}
+        ls: $ls_completer
+        git: $git_completer
+    } | get -i $spans.0 | default $default_completer | do $in $spans
 }
 ```
 

--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -177,8 +177,8 @@ This example shows an external completer that uses the `fish` shell's `complete`
 ```nu
 let fish_completer = {|spans|
     fish --command $'complete "--do-complete=($spans | str join " ")"'
-    | from tsv --noheaders --no-infer
-    | rename value description
+    | $"value(char tab)description(char newline)" + $in
+    | from tsv --flexible --no-infer
 }
 ```
 

--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -178,10 +178,8 @@ This example shows an external completer that uses the `fish` shell's `complete`
 ```nu
 let fish_completer = {|spans|
     fish --command $'complete "--do-complete=($spans | str join " ")"'
-    | str trim
-    | split row "\n"
-    | each { |line| $line | split column "\t" value description }
-    | flatten
+    | from tsv --noheaders --no-infer
+    | rename value description
 }
 ```
 


### PR DESCRIPTION
This PR fixes two issues I found while setting up and using custom completions.

### `$fish_completer` deleting input

The completer in the docs works mostly fine, but when there are no more valid completions (for example, `ls dir/that/does/not/exist<TAB>` or `nu --invalid-flag<TAB>`) it returned an empty string. This wouldn't normally be an issue, as `from json` would throw an error and the default completer kick in. However, `'' | split row (char newline)` returns `['']`, a valid JSON, and the last span of the completion was being deleted.

I fixed these issue avoiding `split row` and using `from tsv` instead, avoiding some manual parsing in the process. I used the `--no-infer` flag as a technicality, because some commit hashes where being returned as a number instead of a string.

I found another error while testing this fix, but it happens both in the existing version and the new one. Calling `npm` returns an error that makes completions fallback to show the list of files:

![image](https://github.com/nushell/nushell.github.io/assets/1385934/1aa65b62-f59d-412d-bffd-6fe8a22fc27d)

Edit: I tried redirecting stderr to ignore the error but it looks like it's preventing the rest of the output to reach nushell:
```nushell
let fish_completer = {|spans: list<string>|
    fish --command $'complete "--do-complete=($spans | str join " ")"' err> /dev/null
    | from tsv --noheaders --no-infer
    | rename value description
}
```
![image](https://github.com/nushell/nushell.github.io/assets/1385934/bc7ead6b-02df-4fe0-98d4-4231207e9658)
![image](https://github.com/nushell/nushell.github.io/assets/1385934/5c0b4a82-81c7-4f25-aac3-e5464d5d29cd)


### Invalid multiple completer

I couldn't get the `$multiple_completer` example to work, so I fixed it using a record that maps the commands to override to their completer, and after retrieving it it `default`s to the default completer (adding `$spans.0` to the record causes an error when there are duplicated values).

In this example, I also made the values of the override record a closure, to be consistent with the other examples, avoiding repetition and being able to pass them around (the most obvious example is that they can be passed as an external completer).

---

This is my first contribution in an open source project (hopefully there's more to come), so please let me know if I did something wrong :) Thank you for the amazing work you do!
