### PR TITLE
Fix direnv not using transformed values

### DIFF
--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -19,6 +19,12 @@ $env.config = {
     pre_prompt: [{ ||
         let direnv = (direnv export json | from json | default {})
         let env_to_convert = ($direnv | transpose key value | where key in ($env.ENV_CONVERSIONS | columns))
+        let converted_values = ($env_to_convert | each {|it|
+            let convert = ($env.ENV_CONVERSIONS | get $it.key | get from_string)
+            let value = (do $convert $it.value)
+            { $it.key: $value }
+        } | into record)
+        $direnv | merge $converted_values | load-env
     }]
   }
 }

--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -18,7 +18,7 @@ $env.config = {
   hooks: {
     pre_prompt: [{ ||
         let direnv = (direnv export json | from json | default {})
-        let env_to_convert = ($direnv | transpose key value | where key in ($env.ENV_CONVERSIONS | columns))
+        let env_to_convert = ($direnv | transpose key value | where key in $env.ENV_CONVERSIONS)
         let converted_values = ($env_to_convert | each {|it|
             let convert = ($env.ENV_CONVERSIONS | get $it.key | get from_string)
             let value = (do $convert $it.value)

--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -17,8 +17,8 @@ To make direnv work with nushell the way it does with other shells, we can use t
 $env.config = {
   hooks: {
     pre_prompt: [{ ||
-      let direnv = (direnv export json | from json | default {})
-      $direnv | load-env
+        let direnv = (direnv export json | from json | default {})
+        let env_to_convert = ($direnv | transpose key value | where key in ($env.ENV_CONVERSIONS | columns))
     }]
   }
 }

--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -17,8 +17,7 @@ To make direnv work with nushell the way it does with other shells, we can use t
 $env.config = {
   hooks: {
     pre_prompt: [{ ||
-      let direnv = (direnv export json | from json)
-      let direnv = if ($direnv | length) == 1 { $direnv } else { {} }
+      let direnv = (direnv export json | from json | default {})
       $direnv | load-env
     }]
   }


### PR DESCRIPTION
When using `direnv` like the docs indicated I noticed that I no longer had completions for binaries in the `PATH`. Turns out, `direnv` outputs the variables to load as a string (which is normal) and they're being loaded as-is, without undergoing the transformation specified in `$env.ENV_CONVERSIONS`.

The code I changed gets the subset of variables that need to undergo transformation, applies the transformation and merges them with the original values.

I'm not 100% happy with the implementation as it's not that idiomatic, but I couldn't find an easy way to conditionally update a record and returning a new record in the process. I tried the following approaches:

```nushell
# Returns a table with values only in the diagonal
$direnv | items {|key, value| ... { $key: $transformed_value } }
```

```nushell
# Returns a record that maps the index on the table to 1-item record
$direnv | items {|key, value| ... { $key: $transformed_value } } | into record
```

```nushell
# This works! However, it's not very intuitive to read
$direnv | items {|key, value| ... { $key: $transformed_value } } | into record | flatten | into record

# a fully functioning one-liner would look like this
$direnv
    | items {|key,value| { $key: (if $key in ($env.ENV_CONVERSIONS | columns) { do ($env.ENV_CONVERSIONS | get $key | get from_string) $value } else { $value } ) } }
    | into record
    | flatten
    | into record
```

While at it, I also took the chance to change indentation to 4 spaces (the other files I checked used it) and simplify the default value instead of accessing the length of the record.

I'm open to any changes to this, curious to see what other way there might be to achieve this in an easy and readable way! 😁 