### PR TITLE
Remove reference to `build-string` from `working_with_strings.md`

### DIFF
--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -341,7 +341,6 @@ There are multiple ways to convert strings to and from other types.
 
 1. Using [`into string`](/commands/docs/into_string.md). e.g. `123 | into string`
 2. Using string interpolation. e.g. `$'(123)'`
-3. Using [`build-string`](/commands/docs/build-string.md). e.g. `build-string (123)`
 
 ### From string
 


### PR DESCRIPTION
`build-string` was removed in https://github.com/nushell/nushell/pull/7144