### PR TITLE
Added useful example to `http options` documentation

### DIFF
--- a/commands/docs/http_options.md
+++ b/commands/docs/http_options.md
@@ -28,7 +28,9 @@ usage: |
  -  `--allow-errors` `(-e)`: do not fail if the server returns an error code
 
 ## Notes
-Performs HTTP OPTIONS operation.
+
+Performs an HTTP OPTIONS request. Most commonly used for making [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) preflight request.
+
 ## Examples
 
 Get options from example.com
@@ -37,20 +39,8 @@ Get options from example.com
 
 ```
 
-Get options from example.com, with username and password
+Simulate a browser cross-origin preflight request from www.example.com to media.example.com
 ```shell
-> http options -u myuser -p mypass https://www.example.com
-
-```
-
-Get options from example.com, with custom header
-```shell
-> http options -H [my-header-key my-header-value] https://www.example.com
-
-```
-
-Get options from example.com, with custom headers
-```shell
-> http options -H [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com
+> http options https://media.example.com/api/ -H [Origin https://www.example.com Access-Control-Request-Headers "Content-Type, X-Custom-Header" Access-Control-Request-Method GET]
 
 ```


### PR DESCRIPTION
This PR adds a more real-world example of how the new `http options` is used, as well as some additional information in the description, including a link to the MDN CORS page.