### PR TITLE
Automate response to PRs trying to update commands

### DIFF
--- a/.github/workflows/command-block.yml
+++ b/.github/workflows/command-block.yml
@@ -15,13 +15,11 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Awesome that you are trying to improve the documentation of a nushell command!
-
-                As we autogenerate these command pages from the help information defined with the command after each release:
-                 - If you already updated the command help, you are already done!
-                 - Else, please look for the command in the [source tree](https://github.com/nushell/nushell/tree/main/crates) and make your changes directly there.
-
-                Thanks for helping out!`
+              body: 'Awesome that you are trying to improve the documentation of a nushell command!\n\n' +
+                'As we autogenerate these command pages from the help information defined with the command after each release:\n'+
+                '- If you already updated the command help, you are already done!\n'+
+                '- Else, please look for the command in the [source tree](https://github.com/nushell/nushell/tree/main/crates) and make your changes directly there.\n\n'+
+                'Thanks for helping out!'
             })
 
 

--- a/.github/workflows/command-block.yml
+++ b/.github/workflows/command-block.yml
@@ -16,10 +16,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `Awesome that you are trying to improve the documentation of a nushell command!
+
                 As we autogenerate these command pages from the help information defined with the command after each release:
-                  - If you already updated the command help, you are already done!
-                  - Else, please look for the command in the [source tree](https://github.com/nushell/nushell/tree/main/crates) and make your changes directly there.
-                
+                 - If you already updated the command help, you are already done!
+                 - Else, please look for the command in the [source tree](https://github.com/nushell/nushell/tree/main/crates) and make your changes directly there.
+
                 Thanks for helping out!`
             })
 

--- a/.github/workflows/command-block.yml
+++ b/.github/workflows/command-block.yml
@@ -1,0 +1,26 @@
+name: Comment on manual command changes
+on:
+  pull_request:
+    paths:
+      - 'commands/docs/**'
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Awesome that you are trying to improve the documentation of a nushell command!
+                As we autogenerate these command pages from the help information defined with the command after each release:
+                  - If you already updated the command help, you are already done!
+                  - Else, please look for the command in the [source tree](https://github.com/nushell/nushell/tree/main/crates) and make your changes directly there.
+                
+                Thanks for helping out!`
+            })
+
+


### PR DESCRIPTION
We frequently see PRs that try to fix or improve command docs. As the
pages are autogenerated this is a futile endeavour.

We regularly have to respond to them and close the PR.

Attempt to provide a workflow that will react to PRs that affect the
command docs path and send a comment.
I don't autoclose for now, as the autogenerated still come in as a PR.
