### PR TITLE
replace `let-env FOO = ...` by `$env.FOO = ...`

### DIFF
--- a/book/3rdpartyprompts.md
+++ b/book/3rdpartyprompts.md
@@ -21,7 +21,7 @@ If you like [oh-my-posh](https://ohmyposh.dev/), you can use oh-my-posh with Nus
 3. Set the PROMPT_COMMAND in ~/.config/nushell/config.nu(or the path output by `$nu.config-path`), change `M365Princess.omp.json` to whatever you like [Themes demo](https://ohmyposh.dev/docs/themes).
 
 ```shell
-> let-env PROMPT_COMMAND = { oh-my-posh --config ~/.poshthemes/M365Princess.omp.json }
+> $env.PROMPT_COMMAND = { oh-my-posh --config ~/.poshthemes/M365Princess.omp.json }
 ```
 
 For MacOS users:
@@ -36,9 +36,9 @@ let posh_theme = $'($posh_dir)/share/oh-my-posh/themes/'
 # Change the theme names to: zash/space/robbyrussel/powerline/powerlevel10k_lean/
 # material/half-life/lambda Or double lines theme: amro/pure/spaceship, etc.
 # For more [Themes demo](https://ohmyposh.dev/docs/themes)
-let-env PROMPT_COMMAND = { || oh-my-posh prompt print primary --config $'($posh_theme)/zash.omp.json' }
+$env.PROMPT_COMMAND = { || oh-my-posh prompt print primary --config $'($posh_theme)/zash.omp.json' }
 # Optional
-let-env PROMPT_INDICATOR = $"(ansi y)$> (ansi reset)"
+$env.PROMPT_INDICATOR = $"(ansi y)$> (ansi reset)"
 ```
 
 ## Starship
@@ -54,22 +54,22 @@ let-env PROMPT_INDICATOR = $"(ansi y)$> (ansi reset)"
 Here's an example config section for Starship:
 
 ```
-let-env STARSHIP_SHELL = "nu"
+$env.STARSHIP_SHELL = "nu"
 
 def create_left_prompt [] {
     starship prompt --cmd-duration $env.CMD_DURATION_MS $'--status=($env.LAST_EXIT_CODE)'
 }
 
 # Use nushell functions to define your right and left prompt
-let-env PROMPT_COMMAND = { || create_left_prompt }
-let-env PROMPT_COMMAND_RIGHT = ""
+$env.PROMPT_COMMAND = { || create_left_prompt }
+$env.PROMPT_COMMAND_RIGHT = ""
 
 # The prompt indicators are environmental variables that represent
 # the state of the prompt
-let-env PROMPT_INDICATOR = ""
-let-env PROMPT_INDICATOR_VI_INSERT = ": "
-let-env PROMPT_INDICATOR_VI_NORMAL = "〉"
-let-env PROMPT_MULTILINE_INDICATOR = "::: "
+$env.PROMPT_INDICATOR = ""
+$env.PROMPT_INDICATOR_VI_INSERT = ": "
+$env.PROMPT_INDICATOR_VI_NORMAL = "〉"
+$env.PROMPT_MULTILINE_INDICATOR = "::: "
 ```
 
 Now restart Nu.

--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -13,7 +13,7 @@ Many parts of Nushell's interface can have their color customized. All of these 
 Table borders are controlled by the `table_mode` setting in `config.nu`. Here is an example:
 
 ```shell
-> let-env config = {
+> $env.config = {
     table_mode: rounded
 }
 ```
@@ -346,7 +346,7 @@ Here's the current list of flat shapes.
 Here's a small example of how to apply color to these items. Anything not specified will receive the default color.
 
 ```shell
-> let-env config = {
+> $env.config = {
     color_config: {
         shape_garbage: { fg: "#FFFFFF" bg: "#FF0000" attr: b}
         shape_bool: green
@@ -370,13 +370,13 @@ The Nushell prompt is configurable through these environment variables and confi
 Example: For a simple prompt one could do this. Note that `PROMPT_COMMAND` requires a `block` whereas the others require a `string`.
 
 ```shell
-> let-env PROMPT_COMMAND = { build-string (date now | date format '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
+> $env.PROMPT_COMMAND = { build-string (date now | date format '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
 ```
 
 If you don't like the default `PROMPT_INDICATOR` you could change it like this.
 
 ```shell
-> let-env PROMPT_INDICATOR = "> "
+> $env.PROMPT_INDICATOR = "> "
 ```
 
 If you're using `starship`, you'll most likely want to show the right prompt on the last line of the prompt, just like zsh or fish. You could modify the `config.nu` file, just set `render_right_prompt_on_last_line` to true:
@@ -400,7 +400,7 @@ There's an exhaustive list [here](https://github.com/trapd00r/LS_COLORS), which 
 
 I like the `vivid` application and currently have it configured in my `config.nu` like this. You can find `vivid` [here](https://github.com/sharkdp/vivid).
 
-`let-env LS_COLORS = (vivid generate molokai | str trim)`
+`$env.LS_COLORS = (vivid generate molokai | str trim)`
 
 If `LS_COLORS` is not set, nushell will default to a built-in `LS_COLORS` setting, based on 8-bit (extended) ANSI colors.
 
@@ -498,7 +498,7 @@ Nushell's default config file contains a light theme definition, if you are work
 
 ```shell
 # in $nu.config-file
-let-env config = {
+$env.config = {
   ...
   color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
   ...
@@ -509,7 +509,7 @@ You can just change it to light theme by replacing `$dark_theme` to `$light_them
 
 ```shell
 # in $nu.config-file
-let-env config = {
+$env.config = {
   ...
   color_config: $light_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
   ...

--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -4,7 +4,7 @@ If you're coming from `Git Bash` on Windows, then the external commands you're u
 To make these commands available in `nu` as well, add the following line to your `config.nu` with either `append` or `prepend`.
 
 ```
-let-env Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
+$env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 ```
 
 Note: this table assumes Nu 0.60.0 or later.
@@ -48,11 +48,11 @@ Note: this table assumes Nu 0.60.0 or later.
 | `cargo b --jobs=$(nproc)`            | `cargo b $"--jobs=(sys \| get cpu \| length)"`   | Use command output in an option                                   |
 | `echo $PATH`                         | `$env.PATH` (Non-Windows) or `$env.Path` (Windows) | See the current path                                            |
 | `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Update PATH permanently                                           |
-| `export PATH = $PATH:/usr/other/bin` | `let-env PATH = ($env.PATH \| append /usr/other/bin)` | Update PATH temporarily                                      |
+| `export PATH = $PATH:/usr/other/bin` | `$env.PATH = ($env.PATH \| append /usr/other/bin)` | Update PATH temporarily                                      |
 | `export`                             | `$env`                                           | List the current environment variables                            |
 | `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Update environment variables permanently                          |
 | `FOO=BAR ./bin`                      | `FOO=BAR ./bin`                                  | Update environment temporarily                                    |
-| `export FOO=BAR`                     | `let-env FOO = BAR`                              | Set environment variable for current session                      |
+| `export FOO=BAR`                     | `$env.FOO = BAR`                              | Set environment variable for current session                      |
 | `echo $FOO`                          | `$env.FOO`                                       | Use environment variables                                         |
 | `unset FOO`                          | `hide-env FOO`                                   | Unset environment variable for current session                    |
 | `alias s="git status -sb"`           | `alias s = git status -sb`                       | Define an alias temporarily                                       |

--- a/book/coming_from_cmd.md
+++ b/book/coming_from_cmd.md
@@ -2,59 +2,59 @@
 
 This table was last updated for Nu 0.67.0.
 
-| CMD.EXE                              | Nu                                                                                     | Task                                                                  |
-| ------------------------------------ | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `ASSOC`                              |                                                                                        | Displays or modifies file extension associations                      |
-| `BREAK`                              |                                                                                        | Trigger debugger breakpoint                                           |
-| `CALL <filename.bat>`                | `<filename.bat>`                                                                       | Run a batch program                                                   |
-|                                      | `nu <filename>`                                                                        | Run a nu script in a fresh context                                    |
-|                                      | `source <filename>`                                                                    | Run a nu script in this context                                       |
-|                                      | `use <filename>`                                                                       | Run a nu script as a module                                           |
-| `CD` or `CHDIR`                      | `$env.PWD`                                                                             | Get the present working directory                                     |
-| `CD <directory>`                     | `cd <directory>`                                                                       | Change the current directory                                          |
-| `CD /D <drive:directory>`            | `cd <drive:directory>`                                                                 | Change the current directory                                          |
-| `CLS`                                | `clear`                                                                                | Clear the screen                                                      |
-| `COLOR`                              |                                                                                        | Set the console default foreground/background colors                  |
-|                                      | `ansi {flags} (code)`                                                                  | Output ANSI codes to change color                                     |
-| `COPY <source> <destination>`        | `cp <source> <destination>`                                                            | Copy files                                                            |
+| CMD.EXE                              | Nu                                                                                  | Task                                                                  |
+| ------------------------------------ | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `ASSOC`                              |                                                                                     | Displays or modifies file extension associations                      |
+| `BREAK`                              |                                                                                     | Trigger debugger breakpoint                                           |
+| `CALL <filename.bat>`                | `<filename.bat>`                                                                    | Run a batch program                                                   |
+|                                      | `nu <filename>`                                                                     | Run a nu script in a fresh context                                    |
+|                                      | `source <filename>`                                                                 | Run a nu script in this context                                       |
+|                                      | `use <filename>`                                                                    | Run a nu script as a module                                           |
+| `CD` or `CHDIR`                      | `$env.PWD`                                                                          | Get the present working directory                                     |
+| `CD <directory>`                     | `cd <directory>`                                                                    | Change the current directory                                          |
+| `CD /D <drive:directory>`            | `cd <drive:directory>`                                                              | Change the current directory                                          |
+| `CLS`                                | `clear`                                                                             | Clear the screen                                                      |
+| `COLOR`                              |                                                                                     | Set the console default foreground/background colors                  |
+|                                      | `ansi {flags} (code)`                                                               | Output ANSI codes to change color                                     |
+| `COPY <source> <destination>`        | `cp <source> <destination>`                                                         | Copy files                                                            |
 | `COPY <file1>+<file2> <destination>` | `[<file1>, <file2>] \| each { open --raw } \| str join \| save --raw <destination>` | Append multiple files into one                                        |
-| `DATE /T`                            | `date now`                                                                             | Get the current date                                                  |
-| `DATE`                               |                                                                                        | Set the date                                                          |
-| `DEL <file>` or `ERASE <file>`       | `rm <file>`                                                                            | Delete files                                                          |
-| `DIR`                                | `ls`                                                                                   | List files in the current directory                                   |
-| `ECHO <message>`                     | `print <message>`                                                                      | Print the given values to stdout                                      |
-| `ECHO ON`                            |                                                                                        | Echo executed commands to stdout                                      |
-| `ENDLOCAL`                           | `export-env`                                                                           | Change env in the caller                                              |
-| `EXIT`                               | `exit`                                                                                 | Close the prompt or script                                            |
-| `FOR %<var> IN (<set>) DO <command>` | `for $<var> in <set> { <command> }`                                                    | Run a command for each item in a set                                  |
-| `FTYPE`                              |                                                                                        | Displays or modifies file types used in file extension associations   |
-| `GOTO`                               |                                                                                        | Jump to a label                                                       |
-| `IF ERRORLEVEL <number> <command>`   | `if $env.LAST_EXIT_CODE >= <number> { <command> }`                                     | Run a command if the last command returned an error code >= specified |
-| `IF <string> EQU <string> <command>` | `if <string> == <string> { <command> }`                                                | Run a command if strings match                                        |
-| `IF EXIST <filename> <command>`      |                                                                                        | Run a command if the file exists                                      |
-| `IF DEFINED <variable> <command>`    |                                                                                        | Run a command if the variable is defined                              |
-| `MD` or `MKDIR`                      | `mkdir`                                                                                | Create directories                                                    |
-| `MKLINK`                             |                                                                                        | Create symbolic links                                                 |
-| `MOVE`                               | `mv`                                                                                   | Move files                                                            |
-| `PATH`                               | `$env.Path`                                                                            | Display the current path variable                                     |
-| `PATH <path>;%PATH%`                 | `let-env Path = ($env.Path \| prepend <path>`)                                         | Edit the path variable                                                |
-| `PATH %PATH%;<path>`                 | `let-env Path = ($env.Path \| prepend <path>`)                                         | Edit the path variable                                                |
-| `PAUSE`                              | `input "Press any key to continue . . ."`                                              | Pause script execution                                                |
-| `PROMPT <template>`                  | `let-env PROMPT_COMMAND = { <command> }`                                               | Change the terminal prompt                                            |
-| `PUSHD <path>`/`POPD`                | `enter <path>`/`exit`                                                                  | Change working directory temporarily                                  |
-| `REM`                                | `#`                                                                                    | Comments                                                              |
-| `REN` or `RENAME`                    | `mv`                                                                                   | Rename files                                                          |
-| `RD` or `RMDIR`                      | `rm`                                                                                   | Remove directory                                                      |
-| `SET <var>=<string>`                 | `let-env <var> = <string>`                                                             | Set environment variables                                             |
-| `SETLOCAL`                           | (default behavior)                                                                     | Localize environment changes to a script                              |
-| `START <path>`                       | `explorer <path>`                                                                      | Open a file as if double-clicked in File Explorer                     |
-| `TIME /T`                            | `date now \| date format "%H:%M:%S"`                                                   | Get the current time                                                  |
-| `TIME`                               |                                                                                        | Set the current time                                                  |
-| `TITLE`                              |                                                                                        | Set the cmd.exe window name                                           |
-| `TYPE`                               | `open --raw`                                                                           | Display the contents of a text file                                   |
-|                                      | `open`                                                                                 | Open a file as structured data                                        |
-| `VER`                                |                                                                                        | Display the OS version                                                |
-| `VERIFY`                             |                                                                                        | Verify that file writes happen                                        |
-| `VOL`                                |                                                                                        | Show drive information                                                |
+| `DATE /T`                            | `date now`                                                                          | Get the current date                                                  |
+| `DATE`                               |                                                                                     | Set the date                                                          |
+| `DEL <file>` or `ERASE <file>`       | `rm <file>`                                                                         | Delete files                                                          |
+| `DIR`                                | `ls`                                                                                | List files in the current directory                                   |
+| `ECHO <message>`                     | `print <message>`                                                                   | Print the given values to stdout                                      |
+| `ECHO ON`                            |                                                                                     | Echo executed commands to stdout                                      |
+| `ENDLOCAL`                           | `export-env`                                                                        | Change env in the caller                                              |
+| `EXIT`                               | `exit`                                                                              | Close the prompt or script                                            |
+| `FOR %<var> IN (<set>) DO <command>` | `for $<var> in <set> { <command> }`                                                 | Run a command for each item in a set                                  |
+| `FTYPE`                              |                                                                                     | Displays or modifies file types used in file extension associations   |
+| `GOTO`                               |                                                                                     | Jump to a label                                                       |
+| `IF ERRORLEVEL <number> <command>`   | `if $env.LAST_EXIT_CODE >= <number> { <command> }`                                  | Run a command if the last command returned an error code >= specified |
+| `IF <string> EQU <string> <command>` | `if <string> == <string> { <command> }`                                             | Run a command if strings match                                        |
+| `IF EXIST <filename> <command>`      |                                                                                     | Run a command if the file exists                                      |
+| `IF DEFINED <variable> <command>`    |                                                                                     | Run a command if the variable is defined                              |
+| `MD` or `MKDIR`                      | `mkdir`                                                                             | Create directories                                                    |
+| `MKLINK`                             |                                                                                     | Create symbolic links                                                 |
+| `MOVE`                               | `mv`                                                                                | Move files                                                            |
+| `PATH`                               | `$env.Path`                                                                         | Display the current path variable                                     |
+| `PATH <path>;%PATH%`                 | `$env.Path = ($env.Path \| prepend <path>`)                                         | Edit the path variable                                                |
+| `PATH %PATH%;<path>`                 | `$env.Path = ($env.Path \| prepend <path>`)                                         | Edit the path variable                                                |
+| `PAUSE`                              | `input "Press any key to continue . . ."`                                           | Pause script execution                                                |
+| `PROMPT <template>`                  | `$env.PROMPT_COMMAND = { <command> }`                                               | Change the terminal prompt                                            |
+| `PUSHD <path>`/`POPD`                | `enter <path>`/`exit`                                                               | Change working directory temporarily                                  |
+| `REM`                                | `#`                                                                                 | Comments                                                              |
+| `REN` or `RENAME`                    | `mv`                                                                                | Rename files                                                          |
+| `RD` or `RMDIR`                      | `rm`                                                                                | Remove directory                                                      |
+| `SET <var>=<string>`                 | `$env.<var> = <string>`                                                             | Set environment variables                                             |
+| `SETLOCAL`                           | (default behavior)                                                                  | Localize environment changes to a script                              |
+| `START <path>`                       | `explorer <path>`                                                                   | Open a file as if double-clicked in File Explorer                     |
+| `TIME /T`                            | `date now \| date format "%H:%M:%S"`                                                | Get the current time                                                  |
+| `TIME`                               |                                                                                     | Set the current time                                                  |
+| `TITLE`                              |                                                                                     | Set the cmd.exe window name                                           |
+| `TYPE`                               | `open --raw`                                                                        | Display the contents of a text file                                   |
+|                                      | `open`                                                                              | Open a file as structured data                                        |
+| `VER`                                |                                                                                     | Display the OS version                                                |
+| `VERIFY`                             |                                                                                     | Verify that file writes happen                                        |
+| `VOL`                                |                                                                                     | Show drive information                                                |
 
 Before Nu version 0.67, Nu [used to](https://www.nushell.sh/blog/2022-08-16-nushell-0_67.html#windows-cmd-exe-changes-rgwood) use CMD.EXE to launch external commands, which meant that the above builtins could be run as an `^external` command. As of version 0.67, however, Nu no longer uses CMD.EXE to launch externals, meaning the above builtins cannot be run from within Nu, except for `ASSOC`, `DIR`, `ECHO`, `FTYPE`, `MKLINK`, `START`, `VER`, and `VOL`, which are explicitly allowed to be interpreted by CMD if no executable by that name exists.

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -19,7 +19,7 @@ You can browse the default files for default values of environment variables and
 Nushell's main settings are kept in the `config` environment variable as a record. This record can be created using:
 
 ```
-let-env config = {
+$env.config = {
   ...
 }
 ```
@@ -27,7 +27,7 @@ let-env config = {
 You can also shadow `$env.config` and update it:
 
 ```
-let-env config = ($env.config | upsert <field name> <field value>)
+$env.config = ($env.config | upsert <field name> <field value>)
 ```
 
 By convention, this variable is defined in the `config.nu` file.
@@ -37,7 +37,7 @@ By convention, this variable is defined in the `config.nu` file.
 You can set environment variables for the duration of a Nushell session using [`let-env`](/commands/docs/let-env.html) calls inside the `env.nu` file. For example:
 
 ```
-let-env FOO = 'BAR'
+$env.FOO = 'BAR'
 ```
 
 _(Although $env.config is an environment variable, it is still defined by convention inside config.nu.)_
@@ -70,7 +70,7 @@ You can learn more about setting up colors and theming in the [associated chapte
 
 ## Remove Welcome Message
 
-To remove the welcome message, you need to edit your `config.nu` by typing `config nu` in your terminal, then you go to the global configuration `let-env config` and set `show_banner` option to false, like this:
+To remove the welcome message, you need to edit your `config.nu` by typing `config nu` in your terminal, then you go to the global configuration `$env.config` and set `show_banner` option to false, like this:
 
 @[code](@snippets/installation/remove_welcome_message.nu)
 
@@ -83,7 +83,7 @@ To get an idea of which environment variables are set up by your current login s
 You can then configure `let-env` commands that setup the same environment variables in your nu login shell. Use this command to generate `let-env` commands for all the environment variables:
 
 ```nu
-$env | reject config | transpose key val | each {|r| echo $"let-env ($r.key) = '($r.val)'"} | str join (char nl)
+$env | reject config | transpose key val | each {|r| echo $"$env.($r.key) = '($r.val)'"} | str join (char nl)
 ```
 
 This will print out [`let-env`](/commands/docs/let-env.html) lines, one for each environment variable along with its setting. You may not need all of them, for instance the `PS1` variable is bash specific.
@@ -128,7 +128,7 @@ alias open = ^open
 In Nushell, [the PATH environment variable](<https://en.wikipedia.org/wiki/PATH_(variable)>) (Path on Windows) is a list of paths. To append a new path to it, you can use [`let-env`](/commands/docs/let-env.html) and [`append`](/commands/docs/append.html) in `env.nu`:
 
 ```
-let-env PATH = ($env.PATH | split row (char esep) | append '/some/path')
+$env.PATH = ($env.PATH | split row (char esep) | append '/some/path')
 ```
 
 This will append `/some/path` to the end of PATH; you can also use [`prepend`](/commands/docs/prepend.html) to add entries to the start of PATH.
@@ -141,8 +141,8 @@ Note the `split row (char esep)` step. We need to add it because in `env.nu`, th
 
 ```
 # macOS ARM64 (Apple Silicon)
-let-env PATH = ($env.PATH | split row (char esep) | prepend '/opt/homebrew/bin')
+$env.PATH = ($env.PATH | split row (char esep) | prepend '/opt/homebrew/bin')
 
 # Linux
-let-env PATH = ($env.PATH | split row (char esep) | prepend '/home/linuxbrew/.linuxbrew/bin')
+$env.PATH = ($env.PATH | split row (char esep) | prepend '/home/linuxbrew/.linuxbrew/bin')
 ```

--- a/book/environment.md
+++ b/book/environment.md
@@ -38,7 +38,7 @@ There are several ways to set an environment variable:
 Using the [`let-env`](/commands/docs/let-env.md) command is the most straightforward method
 
 ```
-> let-env FOO = 'BAR'
+> $env.FOO = 'BAR'
 ```
 
 'let-env' is similar to the **export** command in Bash.
@@ -46,7 +46,7 @@ Using the [`let-env`](/commands/docs/let-env.md) command is the most straightfor
 So, if you want to extend the Windows `Path` variable, for example, you could do that as follows.
 
 ```
-let-env Path = ($env.Path | prepend 'C:\path\you\want\to\add')
+$env.Path = ($env.Path | prepend 'C:\path\you\want\to\add')
 ```
 
 Here we've prepended our folder to the existing folders in the Path, so it will have the highest priority.
@@ -89,9 +89,9 @@ When you set an environment variable, it will be available only in the current s
 Here is a small example to demonstrate the environment scoping:
 
 ```
-> let-env FOO = "BAR"
+> $env.FOO = "BAR"
 > do {
-    let-env FOO = "BAZ"
+    $env.FOO = "BAZ"
     $env.FOO == "BAZ"
 }
 true
@@ -131,7 +131,7 @@ For example:
 
 ```
 # In config.nu
-let-env FOO = 'BAR'
+$env.FOO = 'BAR'
 ```
 
 ## Defining environment from custom commands
@@ -141,7 +141,7 @@ However, a command defined as [`def-env`](/commands/docs/def-env.html) instead o
 
 ```
 > def-env foo [] {
-    let-env FOO = 'BAR'
+    $env.FOO = 'BAR'
 }
 
 > foo
@@ -162,7 +162,7 @@ Let's illustrate the conversions with an example.
 Put the following in your config.nu:
 
 ```
-let-env ENV_CONVERSIONS = {
+$env.ENV_CONVERSIONS = {
     # ... you might have Path and PATH already there, add:
     FOO : {
         from_string: { |s| $s | split row '-' }
@@ -207,7 +207,7 @@ _(Important! The environment conversion string -> value happens **after** the en
 You can remove an environment variable only if it was set in the current scope via [`hide-env`](/commands/docs/hide_env.html):
 
 ```
-> let-env FOO = 'BAR'
+> $env.FOO = 'BAR'
 ...
 > hide-env FOO
 ```
@@ -215,7 +215,7 @@ You can remove an environment variable only if it was set in the current scope v
 The hiding is also scoped which both allows you to remove an environment variable temporarily and prevents you from modifying a parent environment from within a child scope:
 
 ```
-> let-env FOO = 'BAR'
+> $env.FOO = 'BAR'
 > do {
     hide-env FOO
     # $env.FOO does not exist

--- a/book/hooks.md
+++ b/book/hooks.md
@@ -28,7 +28,7 @@ The steps to evaluate one line in the REPL mode are as follows:
 To enable hooks, define them in your [config](configuration.md):
 
 ```
-let-env config = {
+$env.config = {
     # ...other config...
 
     hooks: {
@@ -47,7 +47,7 @@ When you change a directory, the `PWD` environment variable changes and the chan
 Instead of defining just a single hook per trigger, it is possible to define a **list of hooks** which will run in sequence:
 
 ```
-let-env config = {
+$env.config = {
     ...other config...
 
     hooks: {
@@ -72,7 +72,7 @@ let-env config = {
 Also, it might be more practical to update the existing config with new hooks, instead of defining the whole config from scratch:
 
 ```
-let-env config = ($env.config | upsert hooks {
+$env.config = ($env.config | upsert hooks {
     pre_prompt: ...
     pre_execution: ...
     env_change: {
@@ -88,8 +88,8 @@ Environment variables defined inside the hook **block** will be preserved in a s
 You can test it with the following example:
 
 ```
-> let-env config = ($env.config | upsert hooks {
-    pre_prompt: { let-env SPAM = "eggs" }
+> $env.config = ($env.config | upsert hooks {
+    pre_prompt: { $env.SPAM = "eggs" }
 })
 
 > $env.SPAM
@@ -103,7 +103,7 @@ The hook blocks otherwise follow the general scoping rules, i.e., commands, alia
 One thing you might be tempted to do is to activate an environment whenever you enter a directory:
 
 ```
-let-env config = ($env.config | upsert hooks {
+$env.config = ($env.config | upsert hooks {
     env_change: {
         PWD: [
             {|before, after|
@@ -122,7 +122,7 @@ In this case, you could easily rewrite it as `load-env (if $after == ... { ... }
 To deal with the above problem, we introduce another way to define a hook -- **a record**:
 
 ```
-let-env config = ($env.config | upsert hooks {
+$env.config = ($env.config | upsert hooks {
     env_change: {
         PWD: [
             {
@@ -150,8 +150,8 @@ You can think of it as if you typed the string into the REPL and hit Enter.
 So, the hook from the previous section can be also written as
 
 ```
-> let-env config = ($env.config | upsert hooks {
-    pre_prompt: 'let-env SPAM = "eggs"'
+> $env.config = ($env.config | upsert hooks {
+    pre_prompt: '$env.SPAM = "eggs"'
 })
 
 > $env.SPAM
@@ -161,7 +161,7 @@ eggs
 This feature can be used, for example, to conditionally bring in definitions based on the current directory:
 
 ```
-let-env config = ($env.config | upsert hooks {
+$env.config = ($env.config | upsert hooks {
     env_change: {
         PWD: [
             {
@@ -180,7 +180,7 @@ let-env config = ($env.config | upsert hooks {
 When defining a hook as a string, the `$before` and `$after` variables are set to the previous and current environment variable value, respectively, similarly to the previous examples:
 
 ```
-let-env config = ($env.config | upsert hooks {
+$env.config = ($env.config | upsert hooks {
     env_change: {
         PWD: {
             code: 'print $"changing directory from ($before) to ($after)"'
@@ -196,7 +196,7 @@ let-env config = ($env.config | upsert hooks {
 An example for PWD env change hook:
 
 ```
-let-env config = ($env.config | upsert hooks.env_change.PWD {|config|
+$env.config = ($env.config | upsert hooks.env_change.PWD {|config|
     let val = ($config | get -i hooks.env_change.PWD)
 
     if $val == $nothing {
@@ -214,7 +214,7 @@ let-env config = ($env.config | upsert hooks.env_change.PWD {|config|
 This one looks for `test-env.nu` in a directory
 
 ```
-let-env config = ($env.config | upsert hooks.env_change.PWD {
+$env.config = ($env.config | upsert hooks.env_change.PWD {
     [
         {
             condition: {|_, after|
@@ -245,7 +245,7 @@ This hook can display the output in a separate window,
 perhaps as rich HTML text. Here is the basic idea of how to do that:
 
 ```
-let-env config = ($env.config | upsert hooks {
+$env.config = ($env.config | upsert hooks {
     display_output: { to html --partial --no-color | save --raw /tmp/nu-output.html }
 })
 ```
@@ -257,11 +257,12 @@ a browser that automatically reloads when the file changes.
 Instead of the [`save`](/commands/docs/save.md) command, you would normally customize this
 to send the HTML output to a desired window.
 
-### `command_not_found` hook in *Arch Linux*
-The following hook uses the `pkgfile` command, to find which packages commands belong to in *Arch Linux*.
+### `command_not_found` hook in _Arch Linux_
+
+The following hook uses the `pkgfile` command, to find which packages commands belong to in _Arch Linux_.
 
 ```
-let-env config = {
+$env.config = {
     ...other config...
 
     hooks: {

--- a/book/line_editor.md
+++ b/book/line_editor.md
@@ -17,7 +17,7 @@ mode.
 For example:
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
     edit_mode: emacs
     ...
@@ -126,7 +126,7 @@ edited and sent to Nushell. To configure the max number of records that
 Reedline should store you will need to adjust this value in your config file:
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
     max_history_size: 1000
     ...
@@ -154,8 +154,8 @@ def create_right_prompt [] {
     $time_segment
 }
 
-let-env PROMPT_COMMAND = { create_left_prompt }
-let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
+$env.PROMPT_COMMAND = { create_left_prompt }
+$env.PROMPT_COMMAND_RIGHT = { create_right_prompt }
 ```
 
 ::: tip
@@ -167,10 +167,10 @@ You can also customize the prompt indicator for the line editor by modifying
 the next env variables.
 
 ```bash
-let-env PROMPT_INDICATOR = "〉"
-let-env PROMPT_INDICATOR_VI_INSERT = ": "
-let-env PROMPT_INDICATOR_VI_NORMAL = "〉"
-let-env PROMPT_MULTILINE_INDICATOR = "::: "
+$env.PROMPT_INDICATOR = "〉"
+$env.PROMPT_INDICATOR_VI_INSERT = ": "
+$env.PROMPT_INDICATOR_VI_NORMAL = "〉"
+$env.PROMPT_MULTILINE_INDICATOR = "::: "
 ```
 
 ::: tip
@@ -188,7 +188,7 @@ For example, let's say that you would like to map the completion menu to the
 config file.
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     keybindings: [
@@ -273,7 +273,7 @@ The next keybinding is an example of a series of events sent to the engine. It
 first clears the prompt, inserts a string and then enters that value
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     keybindings: [
@@ -304,7 +304,7 @@ example does the same as the previous one in a simpler way, sending a single
 event to the engine
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     keybindings: [
@@ -449,7 +449,7 @@ one is successful, the event processing is stopped.
 The next keybinding represents this case.
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     keybindings: [
@@ -486,7 +486,7 @@ For example, the next keybinding will always send a `down` because that event
 is always successful
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     keybindings: [
@@ -516,7 +516,7 @@ If you want to remove a certain default keybinding without replacing it with a d
 e.g. to disable screen clearing with `Ctrl + l` for all edit modes
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     keybindings: [
@@ -561,7 +561,7 @@ the line the available command examples.
 The help menu can be configured by modifying the next parameters
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     menus = [
@@ -602,7 +602,7 @@ The completion menu by default is accessed by pressing `tab` and it can be confi
 modifying these values from the config object:
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     menus: [
@@ -640,7 +640,7 @@ chronological order, making it extremely easy to select a previous command.
 The history menu can be configured by modifying these values from the config object:
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     menus = [
@@ -738,7 +738,7 @@ true).
 With that in mind, the desired menu would look like this
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     menus = [
@@ -814,7 +814,7 @@ change that by defining new keybindings. For example, the next two keybindings
 assign the completion and history menu to `Ctrl+t` and `Ctrl+y` respectively
 
 ```bash
-  let-env config = {
+  $env.config = {
     ...
 
     keybindings: [

--- a/book/modules.md
+++ b/book/modules.md
@@ -271,7 +271,7 @@ Modules can also define an environment using [`export-env`](/commands/docs/expor
 # greetings.nu
 
 export-env {
-    let-env MYNAME = "Arthur, King of the Britons"
+    $env.MYNAME = "Arthur, King of the Britons"
 }
 
 export def hello [] {
@@ -321,7 +321,7 @@ If you also want to keep your variables in separate modules and export their env
 ```nushell
 # purpose.nu
 export-env {
-    let-env MYPURPOSE = "to build an empire."
+    $env.MYPURPOSE = "to build an empire."
 }
 
 export def greeting_purpose [] {
@@ -343,7 +343,7 @@ However, this won't work, because the code inside the module is not _evaluated_,
 # purpose.nu
 export-env {
     use greetings.nu
-    let-env MYPURPOSE = "to build an empire."
+    $env.MYPURPOSE = "to build an empire."
 }
 
 export def greeting_purpose [] {

--- a/book/overlays.md
+++ b/book/overlays.md
@@ -214,7 +214,7 @@ One can also keep a list of environment variables that were defined inside an ov
 ```
 (zero)> module spam {
     export def foo [] { "foo" }
-    export-env { let-env FOO = "foo" }
+    export-env { $env.FOO = "foo" }
 }
 
 (zero)> overlay use spam


### PR DESCRIPTION
related to nushell/nushell#9574

this PR moves from using `let-env FOO = ...` to using `$env.FOO = ...` in all the website.

## procedure
this was an automatic commit, i've simply run the following command :+1: 
```nushell
sd --string-mode "let-env " '$env.' book/**/*
```

cc/ @jntrnr 