### PR TITLE
Remove `&&` and `||`

### DIFF
--- a/book/operators.md
+++ b/book/operators.md
@@ -2,37 +2,37 @@
 
 Nushell supports the following operators for common math, logic, and string operations:
 
-| Operator | Description                                             |
-| -------- | ------------------------------------------------------- |
-| `+`      | add                                                     |
-| `-`      | subtract                                                |
-| `*`      | multiply                                                |
-| `/`      | divide                                                  |
-| `//`     | floor division                                          |
-| `mod`    | modulo                                                  |
-| `**`     | exponentiation (power)                                  |
-| `==`     | equal                                                   |
-| `!=`     | not equal                                               |
-| `<`      | less than                                               |
-| `<=`     | less than or equal                                      |
-| `>`      | greater than                                            |
-| `>=`     | greater than or equal                                   |
-| `=~`     | regex match / string contains another                   |
-| `!~`     | inverse regex match / string does *not* contain another |
-| `in`     | value in list                                           |
-| `not-in` | value not in list                                       |
-| `not`    | logical not                                             |
-| `&&`, `and`   | and two Boolean expressions (short-circuits)       |
-| `\|\|`, `or`  | or two Boolean expressions (short-circuits)        |
-| `xor`         | exclusive or two boolean expressions               |
-| `bit-or`      | bitwise or                                         |
-| `bit-xor`     | bitwise xor                                        |
-| `bit-and`     | bitwise and                                        |
-| `bit-shl`     | bitwise shift left                                 |
-| `bit-shr`     | bitwise shift right                                |
-| `starts-with` | string starts with                                 |
-| `ends-with`   | string ends with                                   |
-| `++`          | append lists                                       |
+| Operator      | Description                                             |
+| ------------- | ------------------------------------------------------- |
+| `+`           | add                                                     |
+| `-`           | subtract                                                |
+| `*`           | multiply                                                |
+| `/`           | divide                                                  |
+| `//`          | floor division                                          |
+| `mod`         | modulo                                                  |
+| `**`          | exponentiation (power)                                  |
+| `==`          | equal                                                   |
+| `!=`          | not equal                                               |
+| `<`           | less than                                               |
+| `<=`          | less than or equal                                      |
+| `>`           | greater than                                            |
+| `>=`          | greater than or equal                                   |
+| `=~`          | regex match / string contains another                   |
+| `!~`          | inverse regex match / string does *not* contain another |
+| `in`          | value in list                                           |
+| `not-in`      | value not in list                                       |
+| `not`         | logical not                                             |
+| `and`         | and two Boolean expressions (short-circuits)            |
+| `or`          | or two Boolean expressions (short-circuits)             |
+| `xor`         | exclusive or two boolean expressions                    |
+| `bit-or`      | bitwise or                                              |
+| `bit-xor`     | bitwise xor                                             |
+| `bit-and`     | bitwise and                                             |
+| `bit-shl`     | bitwise shift left                                      |
+| `bit-shr`     | bitwise shift right                                     |
+| `starts-with` | string starts with                                      |
+| `ends-with`   | string ends with                                        |
+| `++`          | append lists                                            |
 
 
 Parentheses can be used for grouping to specify evaluation order or for calling commands and using the results in an expression.

--- a/de/book/mathematik.md
+++ b/de/book/mathematik.md
@@ -56,7 +56,7 @@ Die folgenden Vergleichsoperatoren sind ebenfalls verfügbar:
 
 ## Verknüpfungsoperatoren
 
-Nushell unterstützt auch die Operatoren `&&` ("und") und `||` ("oder") um zwei Operationen die Bool-Werte zurückgeben zu verbinden. Zum Beispiel: `ls | where name in ["one" "two" "three"] && size > 10kb`
+Nushell unterstützt auch die Operatoren `and` ("und") und `or` ("oder") um zwei Operationen die Bool-Werte zurückgeben zu verbinden. Zum Beispiel: `ls | where name in ["one" "two" "three"] && size > 10kb`
 
 ## Reihenfolge von Operationen
 


### PR DESCRIPTION
They have been replaced with `and` and `or`
