### PR TITLE
fix a broken link in plugins page in zh-CN

### DIFF
--- a/zh-CN/book/plugins.md
+++ b/zh-CN/book/plugins.md
@@ -37,7 +37,7 @@ Windows:
 Nu 的主版本中包含了一些插件的例子，这些例子对学习插件协议的工作方式很有帮助：
 
 - [Rust](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_example)
-- [Python](https://github.com/nushell/nushell/blob/main/crates/nu_plugin_python/plugin.py)
+- [Python](https://github.com/nushell/nushell/blob/main/crates/nu_plugin_python)
 
 ## 调试
 


### PR DESCRIPTION
![image](https://github.com/nushell/nushell.github.io/assets/75521101/a075d754-427a-4deb-b5b6-550728da08c8)

fix a broken link in https://www.nushell.sh/zh-CN/book/plugins.html#%E7%A4%BA%E4%BE%8B