### PR TITLE
refactor `ssh-agent` cookbook example

### DIFF
--- a/cookbook/misc.md
+++ b/cookbook/misc.md
@@ -17,8 +17,6 @@ ssh-agent -c
 > **Note**  
 > `transpose -i -r -d` can also be replaced with `transpose --header-row | into record`
 
-Then `ssh-add` will enable to only type your SSH passphrase once.
-
 # Miscellaneous
 
 - To finish or "accept" an autocomplete command, press the right arrow key. This can also be changed by changing the keybindings in the `config.nu` file.

--- a/cookbook/misc.md
+++ b/cookbook/misc.md
@@ -6,8 +6,13 @@ title: Miscellaneous
 
 `eval` is not available in nushell, so run:
 
-```
-ssh-agent -c | lines | first 2 | parse "setenv {name} {value};" | transpose -i -r -d | load-env
+```nushell
+ssh-agent -c
+    | lines
+    | first 2
+    | parse "setenv {name} {value};"
+    | transpose -i -r -d
+    | load-env
 ```
 
 Then `ssh-add` will enable to only type your SSH passphrase once.

--- a/cookbook/misc.md
+++ b/cookbook/misc.md
@@ -11,11 +11,10 @@ ssh-agent -c
     | lines
     | first 2
     | parse "setenv {name} {value};"
-    | transpose -i -r -d
+    | transpose -r
+    | into record
     | load-env
 ```
-> **Note**  
-> `transpose -i -r -d` can also be replaced with `transpose --header-row | into record`
 
 # Miscellaneous
 

--- a/cookbook/misc.md
+++ b/cookbook/misc.md
@@ -14,6 +14,8 @@ ssh-agent -c
     | transpose -i -r -d
     | load-env
 ```
+> **Note**  
+> `transpose -i -r -d` can also be replaced with `transpose --header-row | into record`
 
 Then `ssh-add` will enable to only type your SSH passphrase once.
 


### PR DESCRIPTION
this PR hopefully makes the `ssh-agent` example in the cookbook easier to read :innocent: 

i've also removed the note about `ssh-add` as it does not appear to be useful at all :thinking: 
i use this `ssh-agent` everyday without ever running `ssh-add` :confused: 