### PR TITLE
Expand external completer docs

### DIFF
--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -137,10 +137,13 @@ def my_commits [] {
 ## External completions
 
 External completers can also be integrated, instead of relying solely on Nushell ones.
-For this set the `external_completer` field in `config.nu` to a block which will be evaluated if no Nushell completions were found.
-You can configure the block to run an external completer, such as [carapace](https://github.com/rsteube/carapace-bin).
+For this set the `external_completer` field in `config.nu` to a [closure](types_of_data.md#closures) which will be evaluated if no Nushell completions were found.
+You can configure the closure to run an external completer, such as [carapace](https://github.com/rsteube/carapace-bin).
 
-> **Note**  
+> **Note**
+> This closure will accept the current command as a list. For example, typing `my-command --arg1 <tab>` will receive `[my-command --arg1 " "]`.
+
+> **Note**
 > in the following, we define a bunch of different completers.
 >
 > one can configure them in `$nu.config-path` as follows:

--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -31,3 +31,18 @@ A couple of things to note on this command:
 - The fish completer will return lines of text, each one holding the `value` and `description` separated by a tab. The `description` can be missing, and in that case there won't be a tab after the `value`. If that happens, `from tsv` will fail, so we add the `--flexible` flag.
 - `$"value(char tab)description(char newline)" + $in` exists to fix another edge case. Even with the `--flexible` flag, if the first line of the input doesn't have a second column the parser will skip that column for **all** the input. This is fixed adding a header to the input before-hand.
 - `--no-infer` is optional. `from tsv` will infer the data type of the result, so a numeric value like some git hashes will be inferred as a number. `--no-infer` will keep everything as a string. It doesn't make a difference in practice but it will print a more consistent output if the completer is ran on it's own.
+
+## Autocomplete aliases
+
+Nushell currently has a [bug where autocompletions won't work for aliases](https://github.com/nushell/nushell/issues/8483). This can be worked around adding with the following snippet at the beginning of the completer:
+
+```nu
+# if the current command is an alias, get it's expansion
+let expanded_alias = (scope aliases | where name == $spans.0 | get -i 0 | get -i expansion)
+let spans = (if $expanded_alias != null  {
+    # put the first word of the expanded alias first in the span
+    $spans | skip 1 | prepend ($expanded_alias split words)
+} else { $spans })
+```
+
+This will effectively replace the command with the alias.

--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -1,0 +1,33 @@
+---
+title: External Completers
+---
+
+# External Completers
+
+## Completers
+
+### Carapace completer
+
+```nu
+let carapace_completer = {|spans|
+    carapace $spans.0 nushell $spans | from json
+}
+```
+
+### Fish completer
+
+This completer will use [the fish shell](https://fishshell.com/) to handle completions. Fish handles out of the box completions for many popular tools and commands.
+
+```nu
+let fish_completer = {|spans|
+    fish --command $'complete "--do-complete=($spans | str join " ")"'
+    | $"value(char tab)description(char newline)" + $in
+    | from tsv --flexible --no-infer
+}
+```
+
+A couple of things to note on this command:
+
+- The fish completer will return lines of text, each one holding the `value` and `description` separated by a tab. The `description` can be missing, and in that case there won't be a tab after the `value`. If that happens, `from tsv` will fail, so we add the `--flexible` flag.
+- `$"value(char tab)description(char newline)" + $in` exists to fix another edge case. Even with the `--flexible` flag, if the first line of the input doesn't have a second column the parser will skip that column for **all** the input. This is fixed adding a header to the input before-hand.
+- `--no-infer` is optional. `from tsv` will infer the data type of the result, so a numeric value like some git hashes will be inferred as a number. `--no-infer` will keep everything as a string. It doesn't make a difference in practice but it will print a more consistent output if the completer is ran on it's own.


### PR DESCRIPTION
Following #959, this PR tries to better explain how external completers work, how to integrate them and do a showcase of a possible config that leverages some of the provided examples.

I took the liberty of creating a new cookbook page for the examples, as the size of them was getting out of hand. There are probably some things to improve about clarity, wording and the general structure, so let me know if there's anything that needs changing 😁

---

On an unrelated note, I found [this issue](https://github.com/nushell/nushell/issues/9301). In the troubleshooting section of the cookbook I address how to fix it, so I might redirect them to it after merging 🤔 