### PR TITLE
Add external completers cookbook entry to sidebar

### DIFF
--- a/.vuepress/configs/sidebar/en.ts
+++ b/.vuepress/configs/sidebar/en.ts
@@ -136,6 +136,7 @@ export const sidebarEn: SidebarConfig = {
         'system',
         'parsing',
         'native_shell_programs',
+        'external_completers',
         'files',
         'git',
         'parsing_git_log',


### PR DESCRIPTION
After #984, the cookbook sidebar entry wasn't created. This PR takes care of that 😬 