### PR TITLE
tweak `overlay new` tip

### DIFF
--- a/book/overlays.md
+++ b/book/overlays.md
@@ -135,7 +135,7 @@ The solution can be to create a new empty overlay that would be used just for re
 
 (spam)> module scratchpad { }
 
-(spam)> overlay new scratchpad
+(spam)> overlay use scratchpad
 
 (scratchpad)> def eggs [] { "eggs" }
 ```

--- a/de/book/overlays.md
+++ b/de/book/overlays.md
@@ -132,7 +132,7 @@ Die Lösung dafür ist, eine leere Überlagerung zu erstellen und die Definition
 
 (spam)> module scratchpad { }
 
-(spam)> overlay new scratchpad
+(spam)> overlay use scratchpad
 
 (scratchpad)> def eggs [] { "eggs" }
 ```


### PR DESCRIPTION
In the tip for `Overlays are Recordable` the text shows how to create a scratch overlay to record changes into before showing a less verbose version using `overlay new`.

However the more verbose version also uses `overlay new` before it's introduced, which I presume is meant to be `overlay use` and this change updates it for the English and German translation. The Chinese translation appears to be what I believe to be the correct usage and the other translations don't seem to have that section yet and have been left alone.