### PR TITLE
fix(docs): Link to Command Reference led to HTTP 404

### DIFF
--- a/book/nu_fundamentals.md
+++ b/book/nu_fundamentals.md
@@ -16,5 +16,5 @@ Just like Unix shells, Nushell commands can be composed into [pipelines](pipelin
 Some data types have interesting features that deserve their own sections: [strings](working_with_strings.md), [lists](working_with_lists.md), and [tables](working_with_tables.md).
 Apart from explaining the features, these sections also show how to do some common operations, such as composing strings or updating values in a list.
 
-Finally, [Command Reference](/commands/README.md) lists all the built-in commands with brief descriptions.
+Finally, [Command Reference](/commands/) lists all the built-in commands with brief descriptions.
 Note that you can also access this info from within Nushell using the [`help`](/commands/docs/help.md) command.

--- a/book/nu_fundamentals.md
+++ b/book/nu_fundamentals.md
@@ -16,5 +16,5 @@ Just like Unix shells, Nushell commands can be composed into [pipelines](pipelin
 Some data types have interesting features that deserve their own sections: [strings](working_with_strings.md), [lists](working_with_lists.md), and [tables](working_with_tables.md).
 Apart from explaining the features, these sections also show how to do some common operations, such as composing strings or updating values in a list.
 
-Finally, [Command Reference](command_reference.md) lists all the built-in commands with brief descriptions.
+Finally, [Command Reference](/commands/README.md) lists all the built-in commands with brief descriptions.
 Note that you can also access this info from within Nushell using the [`help`](/commands/docs/help.md) command.

--- a/book/table_of_contents.md
+++ b/book/table_of_contents.md
@@ -37,4 +37,4 @@
 - [Nushell map from imperative languages](nushell_map_imperative.md) - Guide to show how Nushell compares with Python, Kotlin, C++, C#, and Rust
 - [Nushell map from functional languages](nushell_map_functional.md) - Guide to show how Nushell compares with Clojure, Tablecloth (OCaml / Elm) and Haskell
 - [Nushell operator map](nushell_operator_map.md) - Guide to show how Nushell operators compare with those in general purpose programming languages
-- [Command Reference](command_reference.md) - List of all Nushell's commands
+- [Command Reference](/commands/) - List of all Nushell's commands


### PR DESCRIPTION
Hi y'all!

Not sure if this is right. I just noticed that the "Command reference" link at the bottom of  is broken.

I tried fixing it - see diff.

However, there seem to be more places, like in the [table of contents](https://github.com/nushell/nushell.github.io/blob/main/book/table_of_contents.md?plain=1#L40). (Edit: table of contents now also fixed in this PR.)

See also [these search results](https://github.com/search?q=repo%3Anushell%2Fnushell.github.io%20command_reference.md&type=code).

Apparently, in some language versions (japanese, brazilian portugese, german, chinese), `/book/command_reference.md` [exists](https://github.com/nushell/nushell.github.io/blob/main/de/book/command_reference.md?plain=1), while in the default (english) version it [does not exist](https://github.com/nushell/nushell.github.io/tree/main/book) and seems to be placed in [`/commands/README.md`](https://github.com/nushell/nushell.github.io/blob/main/commands/README.md?plain=1) now.

I am confused. :) 