### PR TITLE
Specify alternative to deprecated `str_collect`

### DIFF
--- a/commands/docs/str_collect.md
+++ b/commands/docs/str_collect.md
@@ -4,7 +4,7 @@ categories: |
   deprecated
 version: 0.83.0
 deprecated: |
-  Deprecated command.
+  Deprecated command. Use `str join` instead.
 usage: |
   Deprecated command.
 ---


### PR DESCRIPTION
Added suggestion for using [`str join`](https://www.nushell.sh/commands/docs/str_join.html) instead of [`str collect`](https://www.nushell.sh/commands/docs/str_collect.html).

Wrote this in the same style as the [`let-env`](https://www.nushell.sh/commands/docs/let-env.html) deprecation comment.