### PR TITLE
Use '--locked' in cargo install snippet for dataframe feature

### DIFF
--- a/snippets/installation/cargo_install_nu_more_features.sh
+++ b/snippets/installation/cargo_install_nu_more_features.sh
@@ -1,1 +1,1 @@
-> cargo install nu --features=dataframe
+> cargo install nu --locked --features=dataframe


### PR DESCRIPTION
Update documentation to reflect the requirement for the `--locked` flag when using `cargo install` with the `dataframe` feature.

This problem has been mentioned in the following issues, but was only fixed in the scripts in the nushell repository:
- nushell/nushell#10014
- nushell/nushell#10084
