### PR TITLE
Break down shoutouts to separate sections

### DIFF
--- a/blog/2023-08-22-nushell_0_84_0.md
+++ b/blog/2023-08-22-nushell_0_84_0.md
@@ -33,64 +33,6 @@ As part of this release, we also publish a set of optional plugins you can insta
 > * If you used `str replace` **without** the `-s`/`--string` flag, you used regex matching and you should add `--regex` flag to keep the previous functionality.
 > * If you used `str replace` **with** the `-s`/`--string` flag, you will get a deprecation warning. To get rid of the warning, simply remove the flag.
 
-## Changes to commands
-Since last release, some commands have changed, here is a list of some interesting changed
-- [@jflics6460](https://github.com/jflics6460) in [#9771](https://github.com/nushell/nushell/pull/9771):   `http` commands now accept records as their `-H` argument
-- [@ineu](https://github.com/ineu)             in [#10022](https://github.com/nushell/nushell/pull/10022): Adds an option to display the request headers in `http` commands
-- [@atahabaki](https://github.com/atahabaki)   in [#9841](https://github.com/nushell/nushell/pull/9841), [#9856](https://github.com/nushell/nushell/pull/9856) and [#9940](https://github.com/nushell/nushell/pull/9940): Some refinement of the `str expand` command (it's a really cool command, i recommend you check it out :))
-- [@fdncred](https://github.com/fdncred)       in [#9987](https://github.com/nushell/nushell/pull/9987):   Allow `select` to take a variable with a list of columns
-- [@fdncred](https://github.com/fdncred)       in [#10048](https://github.com/nushell/nushell/pull/10048): Allow `int` as a *cellpath* for `select`
-
-Thanks to [@ayax79](https://github.com/ayax79), some work has started again in the realm of the
-*dataframes*!!
-Here are the changes: [#9860](https://github.com/nushell/nushell/pull/9860),
-[#9951](https://github.com/nushell/nushell/pull/9951) and
-[#10019](https://github.com/nushell/nushell/pull/10019)
-
-## Documentation
-
-Thanks to [@rgwood](https://github.com/rgwood), [@sholderbach](https://github.com/sholderbach),
-[@kubouch](https://github.com/kubouch) and [@fdncred](https://github.com/fdncred) the documentation
-has become a bit better in [#9961](https://github.com/nushell/nushell/pull/9961),
-[#9996](https://github.com/nushell/nushell/pull/9996), [#10004](https://github.com/nushell/nushell/pull/10004)
-and [#10057](https://github.com/nushell/nushell/pull/10057).
-
-## Bugfixes
-
-Thanks to all the contributors who tackled one or more bugs!
-|  Name                                          |  Link                                                   |  Description                                                                       |
-| ---------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| [@mengsuenyan](https://github.com/mengsuenyan) | [#9853](https://github.com/nushell/nushell/pull/9853)   | Fix `~ | path type` returning empty string                                  |
-| [@mengsuenyan](https://github.com/mengsuenyan) | [#9851](https://github.com/nushell/nushell/pull/9851)   | Fix the panic when type a statement similar to `let f = 'f' $` in the nushell    |
-| [@jntrnr](https://github.com/jntrnr)           | [#9893](https://github.com/nushell/nushell/pull/9893)   | Revert [#9693](https://github.com/nushell/nushell/pull/9693) to prevent CPU hangs                                                   |
-| [@NotLebedev](https://github.com/NotLebedev)   | [#9935](https://github.com/nushell/nushell/pull/9935)   | Nothing has the correct return type                                                                |
-| [@amtoine](https://github.com/amtoine)         | [#9947](https://github.com/nushell/nushell/pull/9947)   | Force `version` to update when installing with `toolkit.nu`                               |
-| [@amtoine](https://github.com/amtoine)         | [#9967](https://github.com/nushell/nushell/pull/9967)   | Fix panic with `lines` on an error                                                 |
-| [@rgwood](https://github.com/rgwood)           | [#9990](https://github.com/nushell/nushell/pull/9990)   | Fix `watch` not handling all file changes                                          |
-| [@nibon7](https://github.com/nibon7)           | [#9784](https://github.com/nushell/nushell/pull/9784)   | Fix a crash when moving the cursor after accepting a suggestion from the help menu |
-| [@meskill](https://github.com/meskill)         | [#10007](https://github.com/nushell/nushell/pull/10007) | Fix parser to not update plugin.nu file on nu startup                         |
-| [@zhiburt](https://github.com/zhiburt)         | [#10011](https://github.com/nushell/nushell/pull/10011) | nu-table: Fix padding 0 width issues                                               |
-| [@3lvir4](https://github.com/3lvir4)           | [#10012](https://github.com/nushell/nushell/pull/10012) | Remove potential panic from path join                                              |
-| [@kubouch](https://github.com/kubouch)         | [#10046](https://github.com/nushell/nushell/pull/10046) | Fix wrong path expansion in `save`                                                 |
-| [@zhiburt](https://github.com/zhiburt)         | [#10050](https://github.com/nushell/nushell/pull/10050) | nu-table: Fix issue with truncation and text border                                |
-| [@jntrnr](https://github.com/jntrnr)           | [#10052](https://github.com/nushell/nushell/pull/10052) | Fix default_env.nu after latest changes to `str replace`                                               |
-| [@fdncred](https://github.com/fdncred)         | [#10067](https://github.com/nushell/nushell/pull/10067) | Allow `return` to return any nushell value                                         |
-| [@fdncred](https://github.com/fdncred)         | [#10063](https://github.com/nushell/nushell/pull/10063) | Fix `into datetime` to accept more date/time formats                              |
-
-And also to those who did tackle purely technical challenges!!
-|  Name                                          |  Link                                                   |  Description                                             |
-| ---------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------- |
-| [@IanManske](https://github.com/IanManske)     | [#9909](https://github.com/nushell/nushell/pull/9909)   | Enable macOS foreground process handling                 |
-| [@jntrnr](https://github.com/jntrnr)           | [#9933](https://github.com/nushell/nushell/pull/9933)   | Add tests for script subcommands                         |
-| [@jntrnr](https://github.com/jntrnr)           | [#9936](https://github.com/nushell/nushell/pull/9936)   | Fix a couple clippy warnings                             |
-| [@IanManske](https://github.com/IanManske)     | [#9927](https://github.com/nushell/nushell/pull/9927)   | Make `Value::columns` return slice instead of cloned Vec |
-| [@jntrnr](https://github.com/jntrnr)           | [#9949](https://github.com/nushell/nushell/pull/9949)   | Move `help commands` to use more structure in signatures |
-| [@fdncred](https://github.com/fdncred)         | [#9958](https://github.com/nushell/nushell/pull/9958)   | Update `strip-ansi-escapes` to use new api               |
-| [@rgwood](https://github.com/rgwood)           | [#9971](https://github.com/nushell/nushell/pull/9971)   | Put heavy dataframe dependencies behind feature flag     |
-| [@sholderbach](https://github.com/sholderbach) | [#9974](https://github.com/nushell/nushell/pull/9974)   | Fixup dataframe build after [#9971](https://github.com/nushell/nushell/pull/9971)                        |
-| [@meskill](https://github.com/meskill)         | [#9976](https://github.com/nushell/nushell/pull/9976)   | test: Clear parent environment to prevent leakage to tests      |
-| [@kubouch](https://github.com/kubouch)         | [#10036](https://github.com/nushell/nushell/pull/10036) | Add additional span to IncorrectValue error              |
-
 ## Constants from modules ([WindSoilder](https://github.com/nushell/nushell/pull/9773), [kubouch](https://github.com/nushell/nushell/pull/10049))
 
 You can now use constants in modules and export them. Calling `use` on a module will create record containing all module's constants. You can also import the constants directly, for example with `use module.nu const-name`, without creating the module's record. Example:
@@ -163,6 +105,64 @@ With this release we moved several commands that serve to produce string output 
 * all `scope` commands now list the definition's ID which can be used for reliable tracking of definitions. For example, a command `foo` imported from a module `spam` using `use spam` will be named `spam foo`, therefore, relying solely on names of the definitions can sometimes be misleading.
 * `module_name` field is no longer present
 * `scope variables` now denotes whether a variable is a constant or not
+
+## Changes to commands
+Since last release, some commands have changed, here is a list of some interesting changed
+- [@jflics6460](https://github.com/jflics6460) in [#9771](https://github.com/nushell/nushell/pull/9771):   `http` commands now accept records as their `-H` argument
+- [@ineu](https://github.com/ineu)             in [#10022](https://github.com/nushell/nushell/pull/10022): Adds an option to display the request headers in `http` commands
+- [@atahabaki](https://github.com/atahabaki)   in [#9841](https://github.com/nushell/nushell/pull/9841), [#9856](https://github.com/nushell/nushell/pull/9856) and [#9940](https://github.com/nushell/nushell/pull/9940): Some refinement of the `str expand` command (it's a really cool command, i recommend you check it out :))
+- [@fdncred](https://github.com/fdncred)       in [#9987](https://github.com/nushell/nushell/pull/9987):   Allow `select` to take a variable with a list of columns
+- [@fdncred](https://github.com/fdncred)       in [#10048](https://github.com/nushell/nushell/pull/10048): Allow `int` as a *cellpath* for `select`
+
+Thanks to [@ayax79](https://github.com/ayax79), some work has started again in the realm of the
+*dataframes*!!
+Here are the changes: [#9860](https://github.com/nushell/nushell/pull/9860),
+[#9951](https://github.com/nushell/nushell/pull/9951) and
+[#10019](https://github.com/nushell/nushell/pull/10019)
+
+## Documentation
+
+Thanks to [@rgwood](https://github.com/rgwood), [@sholderbach](https://github.com/sholderbach),
+[@kubouch](https://github.com/kubouch) and [@fdncred](https://github.com/fdncred) the documentation
+has become a bit better in [#9961](https://github.com/nushell/nushell/pull/9961),
+[#9996](https://github.com/nushell/nushell/pull/9996), [#10004](https://github.com/nushell/nushell/pull/10004)
+and [#10057](https://github.com/nushell/nushell/pull/10057).
+
+## Bugfixes
+
+Thanks to all the contributors who tackled one or more bugs!
+|  Name                                          |  Link                                                   |  Description                                                                       |
+| ---------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [@mengsuenyan](https://github.com/mengsuenyan) | [#9853](https://github.com/nushell/nushell/pull/9853)   | Fix `~ | path type` returning empty string                                  |
+| [@mengsuenyan](https://github.com/mengsuenyan) | [#9851](https://github.com/nushell/nushell/pull/9851)   | Fix the panic when type a statement similar to `let f = 'f' $` in the nushell    |
+| [@jntrnr](https://github.com/jntrnr)           | [#9893](https://github.com/nushell/nushell/pull/9893)   | Revert [#9693](https://github.com/nushell/nushell/pull/9693) to prevent CPU hangs                                                   |
+| [@NotLebedev](https://github.com/NotLebedev)   | [#9935](https://github.com/nushell/nushell/pull/9935)   | Nothing has the correct return type                                                                |
+| [@amtoine](https://github.com/amtoine)         | [#9947](https://github.com/nushell/nushell/pull/9947)   | Force `version` to update when installing with `toolkit.nu`                               |
+| [@amtoine](https://github.com/amtoine)         | [#9967](https://github.com/nushell/nushell/pull/9967)   | Fix panic with `lines` on an error                                                 |
+| [@rgwood](https://github.com/rgwood)           | [#9990](https://github.com/nushell/nushell/pull/9990)   | Fix `watch` not handling all file changes                                          |
+| [@nibon7](https://github.com/nibon7)           | [#9784](https://github.com/nushell/nushell/pull/9784)   | Fix a crash when moving the cursor after accepting a suggestion from the help menu |
+| [@meskill](https://github.com/meskill)         | [#10007](https://github.com/nushell/nushell/pull/10007) | Fix parser to not update plugin.nu file on nu startup                         |
+| [@zhiburt](https://github.com/zhiburt)         | [#10011](https://github.com/nushell/nushell/pull/10011) | nu-table: Fix padding 0 width issues                                               |
+| [@3lvir4](https://github.com/3lvir4)           | [#10012](https://github.com/nushell/nushell/pull/10012) | Remove potential panic from path join                                              |
+| [@kubouch](https://github.com/kubouch)         | [#10046](https://github.com/nushell/nushell/pull/10046) | Fix wrong path expansion in `save`                                                 |
+| [@zhiburt](https://github.com/zhiburt)         | [#10050](https://github.com/nushell/nushell/pull/10050) | nu-table: Fix issue with truncation and text border                                |
+| [@jntrnr](https://github.com/jntrnr)           | [#10052](https://github.com/nushell/nushell/pull/10052) | Fix default_env.nu after latest changes to `str replace`                                               |
+| [@fdncred](https://github.com/fdncred)         | [#10067](https://github.com/nushell/nushell/pull/10067) | Allow `return` to return any nushell value                                         |
+| [@fdncred](https://github.com/fdncred)         | [#10063](https://github.com/nushell/nushell/pull/10063) | Fix `into datetime` to accept more date/time formats                              |
+
+And also to those who did tackle purely technical challenges!!
+|  Name                                          |  Link                                                   |  Description                                             |
+| ---------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------- |
+| [@IanManske](https://github.com/IanManske)     | [#9909](https://github.com/nushell/nushell/pull/9909)   | Enable macOS foreground process handling                 |
+| [@jntrnr](https://github.com/jntrnr)           | [#9933](https://github.com/nushell/nushell/pull/9933)   | Add tests for script subcommands                         |
+| [@jntrnr](https://github.com/jntrnr)           | [#9936](https://github.com/nushell/nushell/pull/9936)   | Fix a couple clippy warnings                             |
+| [@IanManske](https://github.com/IanManske)     | [#9927](https://github.com/nushell/nushell/pull/9927)   | Make `Value::columns` return slice instead of cloned Vec |
+| [@jntrnr](https://github.com/jntrnr)           | [#9949](https://github.com/nushell/nushell/pull/9949)   | Move `help commands` to use more structure in signatures |
+| [@fdncred](https://github.com/fdncred)         | [#9958](https://github.com/nushell/nushell/pull/9958)   | Update `strip-ansi-escapes` to use new api               |
+| [@rgwood](https://github.com/rgwood)           | [#9971](https://github.com/nushell/nushell/pull/9971)   | Put heavy dataframe dependencies behind feature flag     |
+| [@sholderbach](https://github.com/sholderbach) | [#9974](https://github.com/nushell/nushell/pull/9974)   | Fixup dataframe build after [#9971](https://github.com/nushell/nushell/pull/9971)                        |
+| [@meskill](https://github.com/meskill)         | [#9976](https://github.com/nushell/nushell/pull/9976)   | test: Clear parent environment to prevent leakage to tests      |
+| [@kubouch](https://github.com/kubouch)         | [#10036](https://github.com/nushell/nushell/pull/10036) | Add additional span to IncorrectValue error              |
 
 ## The standard library
 A simple change for this release in the standard library, [@amtoine](https://github.com/amtoine) made

--- a/blog/2023-08-22-nushell_0_84_0.md
+++ b/blog/2023-08-22-nushell_0_84_0.md
@@ -24,26 +24,22 @@ As part of this release, we also publish a set of optional plugins you can insta
 
 # Themes of this release / New features
 
-## `str replace` matches substring by default ([kubouch](https://github.com/nushell/nushell/pull/10038))
+## (Major Breaking Change!) `str replace` matches substring by default ([kubouch](https://github.com/nushell/nushell/pull/10038))
 
-`str replace` now matches a substring instead of a regular expression by default and the `-s`/`--string` flag is deprecated. Matching a substring by default makes it more consistent with the rest of the Nushell's commands.
+`str replace` now matches a substring instead of a regular expression by default and the `-s`/`--string` flag is deprecated (will be removed altogether in 0.85). Matching a substring by default makes it more consistent with the rest of the Nushell's commands.
 
-> :bulb: **Major breaking change!**
->
+> :bulb: **Note!**
 >  Since `str replace` is a widely used command, many scripts are going to break. Fixing it is easy:
 > * If you used `str replace` **without** the `-s`/`--string` flag, you used regex matching and you should add `--regex` flag to keep the previous functionality.
 > * If you used `str replace` **with** the `-s`/`--string` flag, you will get a deprecation warning. To get rid of the warning, simply remove the flag.
 
-## Shoutouts to the community
+## Changes to commands
 Since last release, some commands have changed, here is a list of some interesting changed
 - [@jflics6460](https://github.com/jflics6460) in [#9771](https://github.com/nushell/nushell/pull/9771):   `http` commands now accept records as their `-H` argument
 - [@ineu](https://github.com/ineu)             in [#10022](https://github.com/nushell/nushell/pull/10022): Adds an option to display the request headers in `http` commands
 - [@atahabaki](https://github.com/atahabaki)   in [#9841](https://github.com/nushell/nushell/pull/9841), [#9856](https://github.com/nushell/nushell/pull/9856) and [#9940](https://github.com/nushell/nushell/pull/9940): Some refinement of the `str expand` command (it's a really cool command, i recommend you check it out :))
 - [@fdncred](https://github.com/fdncred)       in [#9987](https://github.com/nushell/nushell/pull/9987):   Allow `select` to take a variable with a list of columns
-- [@kubouch](https://github.com/kubouch)       in [#10038](https://github.com/nushell/nushell/pull/10038): `str replace` now matches substrings by default, i.e. the `--string` option is now the default, will be removed in the next release and `--regex` is a new option that should be used explicitely to get the previous behaviour as expected
 - [@fdncred](https://github.com/fdncred)       in [#10048](https://github.com/nushell/nushell/pull/10048): Allow `int` as a *cellpath* for `select`
-
-- [@kubouch](https://github.com/kubouch)       in [#10023](https://github.com/nushell/nushell/pull/10023), [#10039](https://github.com/nushell/nushell/pull/10039) and [#10045](https://github.com/nushell/nushell/pull/10045): The `scope` commands have been greatly refactored => if you use them in your scripts, you might want to check them out :)
 
 Thanks to [@ayax79](https://github.com/ayax79), some work has started again in the realm of the
 *dataframes*!!
@@ -51,31 +47,35 @@ Here are the changes: [#9860](https://github.com/nushell/nushell/pull/9860),
 [#9951](https://github.com/nushell/nushell/pull/9951) and
 [#10019](https://github.com/nushell/nushell/pull/10019)
 
+## Documentation
+
 Thanks to [@rgwood](https://github.com/rgwood), [@sholderbach](https://github.com/sholderbach),
 [@kubouch](https://github.com/kubouch) and [@fdncred](https://github.com/fdncred) the documentation
 has become a bit better in [#9961](https://github.com/nushell/nushell/pull/9961),
 [#9996](https://github.com/nushell/nushell/pull/9996), [#10004](https://github.com/nushell/nushell/pull/10004)
 and [#10057](https://github.com/nushell/nushell/pull/10057).
 
+## Bugfixes
+
 Thanks to all the contributors who tackled one or more bugs!
 |  Name                                          |  Link                                                   |  Description                                                                       |
 | ---------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| [@mengsuenyan](https://github.com/mengsuenyan) | [#9853](https://github.com/nushell/nushell/pull/9853)   | fixed the bug `~ | path type` return empty string                                  |
-| [@mengsuenyan](https://github.com/mengsuenyan) | [#9851](https://github.com/nushell/nushell/pull/9851)   | Fixed the panic when type a statement similar to `let f = 'f' $` in the nushell    |
-| [@jntrnr](https://github.com/jntrnr)           | [#9893](https://github.com/nushell/nushell/pull/9893)   | Revert 9693 to prevent CPU hangs                                                   |
-| [@NotLebedev](https://github.com/NotLebedev)   | [#9935](https://github.com/nushell/nushell/pull/9935)   | Nothing return type                                                                |
-| [@amtoine](https://github.com/amtoine)         | [#9947](https://github.com/nushell/nushell/pull/9947)   | force version to update when installing with toolkit                               |
-| [@amtoine](https://github.com/amtoine)         | [#9967](https://github.com/nushell/nushell/pull/9967)   | fix panic with `lines` on an error                                                 |
+| [@mengsuenyan](https://github.com/mengsuenyan) | [#9853](https://github.com/nushell/nushell/pull/9853)   | Fix `~ | path type` returning empty string                                  |
+| [@mengsuenyan](https://github.com/mengsuenyan) | [#9851](https://github.com/nushell/nushell/pull/9851)   | Fix the panic when type a statement similar to `let f = 'f' $` in the nushell    |
+| [@jntrnr](https://github.com/jntrnr)           | [#9893](https://github.com/nushell/nushell/pull/9893)   | Revert [#9693](https://github.com/nushell/nushell/pull/9693) to prevent CPU hangs                                                   |
+| [@NotLebedev](https://github.com/NotLebedev)   | [#9935](https://github.com/nushell/nushell/pull/9935)   | Nothing has the correct return type                                                                |
+| [@amtoine](https://github.com/amtoine)         | [#9947](https://github.com/nushell/nushell/pull/9947)   | Force `version` to update when installing with `toolkit.nu`                               |
+| [@amtoine](https://github.com/amtoine)         | [#9967](https://github.com/nushell/nushell/pull/9967)   | Fix panic with `lines` on an error                                                 |
 | [@rgwood](https://github.com/rgwood)           | [#9990](https://github.com/nushell/nushell/pull/9990)   | Fix `watch` not handling all file changes                                          |
 | [@nibon7](https://github.com/nibon7)           | [#9784](https://github.com/nushell/nushell/pull/9784)   | Fix a crash when moving the cursor after accepting a suggestion from the help menu |
-| [@meskill](https://github.com/meskill)         | [#10007](https://github.com/nushell/nushell/pull/10007) | fix(nu-parser): do not update plugin.nu file on nu startup                         |
+| [@meskill](https://github.com/meskill)         | [#10007](https://github.com/nushell/nushell/pull/10007) | Fix parser to not update plugin.nu file on nu startup                         |
 | [@zhiburt](https://github.com/zhiburt)         | [#10011](https://github.com/nushell/nushell/pull/10011) | nu-table: Fix padding 0 width issues                                               |
 | [@3lvir4](https://github.com/3lvir4)           | [#10012](https://github.com/nushell/nushell/pull/10012) | Remove potential panic from path join                                              |
 | [@kubouch](https://github.com/kubouch)         | [#10046](https://github.com/nushell/nushell/pull/10046) | Fix wrong path expansion in `save`                                                 |
-| [@zhiburt](https://github.com/zhiburt)         | [#10050](https://github.com/nushell/nushell/pull/10050) | nu-table: fix issue with truncation and text border                                |
-| [@jntrnr](https://github.com/jntrnr)           | [#10052](https://github.com/nushell/nushell/pull/10052) | fix default-env after latest changes                                               |
-| [@fdncred](https://github.com/fdncred)         | [#10067](https://github.com/nushell/nushell/pull/10067) | allow `return` to return any nushell value                                         |
-| [@fdncred](https://github.com/fdncred)         | [#10063](https://github.com/nushell/nushell/pull/10063) | try and fix `into datetime` to accept more dt formats                              |
+| [@zhiburt](https://github.com/zhiburt)         | [#10050](https://github.com/nushell/nushell/pull/10050) | nu-table: Fix issue with truncation and text border                                |
+| [@jntrnr](https://github.com/jntrnr)           | [#10052](https://github.com/nushell/nushell/pull/10052) | Fix default_env.nu after latest changes to `str replace`                                               |
+| [@fdncred](https://github.com/fdncred)         | [#10067](https://github.com/nushell/nushell/pull/10067) | Allow `return` to return any nushell value                                         |
+| [@fdncred](https://github.com/fdncred)         | [#10063](https://github.com/nushell/nushell/pull/10063) | Fix `into datetime` to accept more date/time formats                              |
 
 And also to those who did tackle purely technical challenges!!
 |  Name                                          |  Link                                                   |  Description                                             |
@@ -85,10 +85,10 @@ And also to those who did tackle purely technical challenges!!
 | [@jntrnr](https://github.com/jntrnr)           | [#9936](https://github.com/nushell/nushell/pull/9936)   | Fix a couple clippy warnings                             |
 | [@IanManske](https://github.com/IanManske)     | [#9927](https://github.com/nushell/nushell/pull/9927)   | Make `Value::columns` return slice instead of cloned Vec |
 | [@jntrnr](https://github.com/jntrnr)           | [#9949](https://github.com/nushell/nushell/pull/9949)   | Move `help commands` to use more structure in signatures |
-| [@fdncred](https://github.com/fdncred)         | [#9958](https://github.com/nushell/nushell/pull/9958)   | update `strip-ansi-escapes` to use new api               |
+| [@fdncred](https://github.com/fdncred)         | [#9958](https://github.com/nushell/nushell/pull/9958)   | Update `strip-ansi-escapes` to use new api               |
 | [@rgwood](https://github.com/rgwood)           | [#9971](https://github.com/nushell/nushell/pull/9971)   | Put heavy dataframe dependencies behind feature flag     |
-| [@sholderbach](https://github.com/sholderbach) | [#9974](https://github.com/nushell/nushell/pull/9974)   | Fixup dataframe build after #9971                        |
-| [@meskill](https://github.com/meskill)         | [#9976](https://github.com/nushell/nushell/pull/9976)   | test: clear parent envs to prevent leakage to tests      |
+| [@sholderbach](https://github.com/sholderbach) | [#9974](https://github.com/nushell/nushell/pull/9974)   | Fixup dataframe build after [#9971](https://github.com/nushell/nushell/pull/9971)                        |
+| [@meskill](https://github.com/meskill)         | [#9976](https://github.com/nushell/nushell/pull/9976)   | test: Clear parent environment to prevent leakage to tests      |
 | [@kubouch](https://github.com/kubouch)         | [#10036](https://github.com/nushell/nushell/pull/10036) | Add additional span to IncorrectValue error              |
 
 ## Constants from modules ([WindSoilder](https://github.com/nushell/nushell/pull/9773), [kubouch](https://github.com/nushell/nushell/pull/10049))

--- a/blog/2023-08-22-nushell_0_84_0.md
+++ b/blog/2023-08-22-nushell_0_84_0.md
@@ -23,6 +23,17 @@ NOTE: The optional dataframe functionality is available by `cargo install nu --f
 As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
 
 # Themes of this release / New features
+
+## `str replace` matches substring by default ([kubouch](https://github.com/nushell/nushell/pull/10038))
+
+`str replace` now matches a substring instead of a regular expression by default and the `-s`/`--string` flag is deprecated. Matching a substring by default makes it more consistent with the rest of the Nushell's commands.
+
+> :bulb: **Major breaking change!**
+>
+>  Since `str replace` is a widely used command, many scripts are going to break. Fixing it is easy:
+> * If you used `str replace` **without** the `-s`/`--string` flag, you used regex matching and you should add `--regex` flag to keep the previous functionality.
+> * If you used `str replace` **with** the `-s`/`--string` flag, you will get a deprecation warning. To get rid of the warning, simply remove the flag.
+
 ## Shoutouts to the community
 Since last release, some commands have changed, here is a list of some interesting changed
 - [@jflics6460](https://github.com/jflics6460) in [#9771](https://github.com/nushell/nushell/pull/9771):   `http` commands now accept records as their `-H` argument
@@ -33,14 +44,6 @@ Since last release, some commands have changed, here is a list of some interesti
 - [@fdncred](https://github.com/fdncred)       in [#10048](https://github.com/nushell/nushell/pull/10048): Allow `int` as a *cellpath* for `select`
 
 - [@kubouch](https://github.com/kubouch)       in [#10023](https://github.com/nushell/nushell/pull/10023), [#10039](https://github.com/nushell/nushell/pull/10039) and [#10045](https://github.com/nushell/nushell/pull/10045): The `scope` commands have been greatly refactored => if you use them in your scripts, you might want to check them out :)
-
-> :bulb: **Major breaking change!**
->
-> `str replace` [was changed](https://github.com/nushell/nushell/pull/10038) to match a substring instead of a regular expression by default and deprecates the `-s`/`--string` flag. Since `str replace` is a widely used command, many scripts are going to break. Here is what you should do:
-> * If you used `str replace` **without** the `-s`/`--string` flag, you used regex matching and you should add `--regex` flag to keep the previous functionality
-> * If you used `str replace` **with** the `-s`/`--string` flag, you will get a deprecation warning. To get rid of the warning, simply remove the flag.
->
-> Matching a substring by default makes it more consistent with the rest of the Nushell's commands.
 
 Thanks to [@ayax79](https://github.com/ayax79), some work has started again in the realm of the
 *dataframes*!!
@@ -148,7 +151,7 @@ With this release we moved several commands that serve to produce string output 
 
 1. `date format` has been renamed to `format date` ([#9788](https://github.com/nushell/nushell/pull/9788)).
 2. `into duration --convert` was previously used to provide string representations of `duration`s. This option has been removed and you should now use `format duration`. ([#9902](https://github.com/nushell/nushell/pull/9902))
-3. `format filesize` that was previously moved into the `--features extra` set is back in the core ([#9978](https://github.com/nushell/nushell/pull/9978)). 
+3. `format filesize` that was previously moved into the `--features extra` set is back in the core ([#9978](https://github.com/nushell/nushell/pull/9978)).
 
 ## `scope` commands enhancements ([kubouch](https://github.com/nushell/nushell/pull/10023), [kubouch](https://github.com/nushell/nushell/pull/10045))
 


### PR DESCRIPTION
Also makes the `str replace` note a separate section with a fix note.