### PR TITLE
Link to escape when discussing escapes

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -123,6 +123,9 @@ def nuopen [arg, --raw (-r)] { if $raw { open -r $arg } else { open $arg } }
 alias open = ^open
 ```
 
+The `^` symbol _escapes_ the Nushell `open` command, which invokes the operating system's `open` command.
+For more about escape and `^` see the [chapter about escapes](escaping.md).
+
 ## PATH configuration
 
 In Nushell, [the PATH environment variable](<https://en.wikipedia.org/wiki/PATH_(variable)>) (Path on Windows) is a list of paths. To append a new path to it, you can use `$env.<var> = <val>` and [`append`](/commands/docs/append.html) in `env.nu`:


### PR DESCRIPTION
The book chapter on configuration mentions ^ syntax before the chapter on escapes. I think it'd be helpful to link to that chapter so the reader can learn more if they want to.