### PR TITLE
Update loading_data.md, correct link to http command

### DIFF
--- a/book/loading_data.md
+++ b/book/loading_data.md
@@ -235,6 +235,6 @@ Or run any SQL query you like:
 
 ## Fetching URLs
 
-In addition to loading files from your filesystem, you can also load URLs by using the [`http get`](/commands/docs/fetch.md) command. This will fetch the contents of the URL from the internet and return it:
+In addition to loading files from your filesystem, you can also load URLs by using the [`http get`](/commands/docs/http.md) command. This will fetch the contents of the URL from the internet and return it:
 
 @[code](@snippets/loading_data/rust-lang-feed.sh)


### PR DESCRIPTION
The section on http mentions the http get command but the link points to  (probably deprecreated/renamed) fetch instead of http