### PR TITLE
Point from keybindings help to the book's reedline chapter

### DIFF
--- a/commands/docs/keybindings.md
+++ b/commands/docs/keybindings.md
@@ -27,6 +27,8 @@ usage: |
 ## Notes
 You must use one of the following subcommands. Using this command as-is will only produce this help message.
 
+For more information on input and keybindings, read the [Reedline chapter of the Nushell book](https://www.nushell.sh/book/line_editor.html).
+
 ## Subcommands:
 
 | name                                                           | type    | usage                                                          |


### PR DESCRIPTION
I am just starting to play around with nushell, and I wanted to map option+backspace to cut-small-word or something, to match my muscle memory from bash/macos GUI apps (this muscle memory is what currently keeps me using bash even on macos).

I initially tried typing key<tab> and this gave me the "keybindings" family of commands, but the help messages for these commands are quite sparse. Web searches also brought me preferentially to the unhelpful keybindings command help page.

Hopefully this will signal people in the right direction.

<details><summary>context</summary>
Next step on my journey will be working out the mapping between `char: h, code: 0x000068, modifier: CONTROL | ALT, flags: 0b000110, kind: Press, state: NONE` (as generated by vscode on macos) and the format used by `config nu`. Would you be interested in a  `keybindings generate` command (similar to `keybindings listen` but with a different output format) if I write one?

Once I have worked out the mapping, I expect I will stumble across https://github.com/nushell/reedline/issues/570 and need to fix that. It is going to be an adventure ;-) 
</details>

I'm genuinely not sure what's going on at the bottom of the file. I guess it's missing a trailing newline or something? This is just what GitHub's editor does when I follow the link from the online docs page.