### PR TITLE
Fix example history command pipeline

### DIFF
--- a/commands/docs/history.md
+++ b/commands/docs/history.md
@@ -45,7 +45,7 @@ Show last 5 commands you have ran
 
 Search all the commands from history that contains 'cargo'
 ```shell
-> history | wrap cmd | where cmd =~ cargo
+> history | wrap record | where record.command =~ cargo | get record.command
 
 ```
 


### PR DESCRIPTION
```
❯ history | wrap cmd | where cmd =~ cargo
Error: nu::shell::type_mismatch

  × Type mismatch during operation.
   ╭─[entry #23:1:1]
 1 │ history | wrap cmd | where cmd =~ cargo
   · ───┬───                        ─┬ ──┬──
   ·    │                            │   ╰── string
   ·    │                            ╰── type mismatch for operator
   ·    ╰── record<start_timestamp: string, command: string, cwd: string, duration: duration, exit_status: int>
   ╰────
```