### PR TITLE
add a link to the contributor book at the end of the plugins chapter

### DIFF
--- a/book/plugins.md
+++ b/book/plugins.md
@@ -49,3 +49,7 @@ The simplest way to debug a plugin is to print to stderr; plugins' standard erro
 ## Help
 
 Nu's plugin documentation is a work in progress. If you're unsure about something, the #plugins channel on [the Nu Discord](https://discord.gg/NtAbbGn) is a great place to ask questions!
+
+## More details
+
+The [plugin chapter in the contributor book](/contributor-book/plugins.html) offers more details on the intricacies of how plugins work from a software developer point of view.


### PR DESCRIPTION

The contributor book has a great chapter on how plugins work...

However, when reading the plugins chapter in the nushell book there is no reference to it.

You have to search for it to find it...

I added a link to the end of the plugins chapter so people can read more stuff about plugins...

I found the chapter in the contributor book incredibly insightful.
 