### PR TITLE
Fix external completers typo

### DIFF
--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -148,7 +148,7 @@ let external_completer = {|spans|
         $spans
     }
 
-    match {
+    match $spans.0 {
         # carapace completions are incorrect for nu
         nu => $fish_completer
         # fish completes commits and branch names in a nicer way


### PR DESCRIPTION
This PR fixes a typo introduced in https://github.com/nushell/nushell.github.io/pull/1049 ✨ 