### PR TITLE
Update working_with_lists.md - format date

### DIFF
--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -202,6 +202,6 @@ be converted to a separate row with a single column:
 let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
 
 # Show world clock for selected time zones
-$zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | date format '%Y.%m.%d %H:%M')}
+$zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}
 ```
 


### PR DESCRIPTION
Replaces removed `date format` with `format date`.

---

I ran into the following error when following the [working with lists guide](https://www.nushell.sh/book/working_with_lists.html)

```Nushell
~/tmp> $zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | date format '%Y.%m.%d %H:%M')}                               09/10/2023 01:47:31 PM
Error: nu::shell::removed_command

  × Removed command: date format
   ╭─[entry #97:1:1]
 1 │ $zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | date format '%Y.%m.%d %H:%M')}
   ·                                                                                  ─────┬─────
   ·                                                                                       ╰── 'date format' has been removed from Nushell. Please use 'format date' instead.
   ╰────
```