### PR TITLE
Update variables_and_subexpressions.md - remove obsolete section

### DIFF
--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -94,20 +94,6 @@ It is common for some scripts to declare variables that start with `$`. This is 
 # identical to `let var = 42`
 ```
 
-### Variable Values
-
-A common issue that users run into is trying to declare a variable using a pipeline as the value like so:
-
-```nu
-let val = 42 | math sqrt
-```
-
-This is an error, because the pipe command is used to separate pipeline elements, so Nushell will see this as a pipeline with two elements, one of which is not allowed in pipelines because it doesn't return a value (`let val = 42`). The correct way to declare using a pipeline is to wrap the pipeline in parentheses
-
-```nu
-let val = (42 | math sqrt)
-```
-
 ### Variable Paths
 
 A variable path works by reaching inside of the contents of a variable, navigating columns inside of it, to reach a final value. Let's say instead of `4`, we had assigned a table value:

--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -99,13 +99,13 @@ It is common for some scripts to declare variables that start with `$`. This is 
 A common issue that users run into is trying to declare a variable using a pipeline as the value like so:
 
 ```nu
-let val = 42 | math sin
+let val = 42 | math sqrt
 ```
 
 This is an error, because the pipe command is used to separate pipeline elements, so Nushell will see this as a pipeline with two elements, one of which is not allowed in pipelines because it doesn't return a value (`let val = 42`). The correct way to declare using a pipeline is to wrap the pipeline in parentheses
 
 ```nu
-let val = (42 | math sin)
+let val = (42 | math sqrt)
 ```
 
 ### Variable Paths


### PR DESCRIPTION
Replaces unknown `sin` with `sqrt` for the “Variable values” example.

---

I encountered an error in the [Variable values guide](https://www.nushell.sh/book/variables_and_subexpressions.html#variable-values).

```
~> let val = (42 | math sin)                                                                                                                         09/10/2023 01:58:00 PM
Error: nu::parser::extra_positional

  × Extra positional argument.
   ╭─[entry #108:1:1]
 1 │ let val = (42 | math sin)
   ·                      ─┬─
   ·                       ╰── extra positional argument
   ╰────
  help: Usage: math
```

I chose `math sqrt`, but feel free to edit to any math subcommand.