### PR TITLE
Support for standard input in script with shebang

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -86,3 +86,13 @@ On Linux and macOS you can optionally use a [shebang](<https://en.wikipedia.org/
 > ./myscript
 Hello World!
 ```
+For script to have access to standard input, `nu` should be invoked with `--stdin` flag:
+```
+#!/usr/bin/env -S nu --stdin
+echo $"stdin: ($in)"
+```
+
+```
+> echo "Hello World!" | ./myscript
+stdin: Hello World!
+```


### PR DESCRIPTION
I found out that `stdin` is not available when running a script with shebang, and after some investigation I found a solution. 