### PR TITLE
Change direnv example to upload $env.PATH as a list

### DIFF
--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -18,8 +18,13 @@ $env.config = {
   hooks: {
     pre_prompt: [{ ||
       let direnv = (direnv export json | from json)
-      let direnv = if ($direnv | length) == 1 { $direnv } else { {} }
-      $direnv | load-env
+      let no_changes = $direnv | is-empty
+      let changes = not $no_changes
+
+      if $changes {
+        let direnv = $direnv | upsert PATH {|direnv_result| ($direnv_result.PATH | split row ":") }
+        $direnv | load-env
+      }
     }]
   }
 }

--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -21,7 +21,7 @@ $env.config = {
       let no_changes = $direnv | is-empty
       let changes = not $no_changes
 
-      if $changes {
+      if not ($direnv | is-empty) {
         let direnv = $direnv | upsert PATH {|direnv_result| ($direnv_result.PATH | split row ":") }
         $direnv | load-env
       }

--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -22,7 +22,7 @@ $env.config = {
       let changes = not $no_changes
 
       if not ($direnv | is-empty) {
-        let direnv = $direnv | upsert PATH {|direnv_result| ($direnv_result.PATH | split row ":") }
+        let direnv = $direnv | upsert PATH {|it| $it.PATH | split row ":" }
         $direnv | load-env
       }
     }]

--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -18,8 +18,6 @@ $env.config = {
   hooks: {
     pre_prompt: [{ ||
       let direnv = (direnv export json | from json)
-      let no_changes = $direnv | is-empty
-      let changes = not $no_changes
 
       if not ($direnv | is-empty) {
         let direnv = $direnv | upsert PATH {|it| $it.PATH | split row ":" }


### PR DESCRIPTION
First of all thanks for the direnv example!
It got me unblocked, but I missed that I couldn't see the path in the list format when I typed `$env.PATH`.

I'm new to nushell, so if there's a better way to do this than the `no_changes` `changes` thing, let me know and I'll change it. I couldn't find like a `$my_thing | is-not-empty`.