### PR TITLE
add the "style guide" page to the sidebar

### DIFF
--- a/.vuepress/configs/sidebar/en.ts
+++ b/.vuepress/configs/sidebar/en.ts
@@ -48,6 +48,7 @@ export const sidebarEn: SidebarConfig = {
         '/book/overlays.md',
         '/book/command_signature.md',
         '/book/testing.md',
+        '/book/style_guide.md',
       ],
     },
     {


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell.github.io/pull/904

this PR adds the "style guide" page to the book index in the sidebar to the left under the "Programming in Nu" section, hopefully making it visible to everyone :pray: 

i hope this is the way to do it :yum: 