### PR TITLE
make_docs: Parallelize command generation

### DIFF
--- a/make_docs.nu
+++ b/make_docs.nu
@@ -362,7 +362,7 @@ def main [] {
 
     let number_generated_commands = (
         $unique_commands
-        | each { |command_name|
+        | par-each { |command_name|
             generate-command $commands_group $command_name
         }
         | length


### PR DESCRIPTION
On my machine, that reduces runtime from 34s to 13s