### PR TITLE
fixed alias normalization

### DIFF
--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -96,7 +96,7 @@ let expanded_alias = (scope aliases | where name == $spans.0 | get -i 0 | get -i
 # overwrite
 let spans = (if $expanded_alias != null  {
     # put the first word of the expanded alias first in the span
-    $spans | skip 1 | prepend ($expanded_alias | split words)
+    $spans | skip 1 | prepend ($expanded_alias | split row " ")
 } else { $spans })
 ```
 


### PR DESCRIPTION
changed `split words` to `split row " "` because `split words` gets rid of too much. For example, `"-foo__bar baz" | split words` outputs the list `[foo, bar, daz]` while `"-foo__bar baz" | split row " "` outputs `[-foo__bar, baz]`, which is what we want

This was an issue as I was trying to setup completion for zoxide and this code was splitting `__zoxide_z` into `[zoxide, z]`