### PR TITLE
Fix a minor typo in `working_with_lists`

### DIFF
--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -107,7 +107,7 @@ $"total = ($scores | reduce { |it, acc| $acc + $it })" # total = 15
 
 $"total = ($scores | math sum)" # easier approach, same result
 
-$"product = ($scores | reduce --fold 1 { |it, acc| $acc * $it })" # total = 96
+$"product = ($scores | reduce --fold 1 { |it, acc| $acc * $it })" # product = 96
 
 $scores | enumerate | reduce --fold 0 { |it, acc| $acc + $it.index * $it.item } # 0*3 + 1*8 + 2*4 = 16
 ```


### PR DESCRIPTION
One comment said `total = 96`, where `product = 96` is printed.