### PR TITLE
book/overlays: fix tip div formatting

### DIFF
--- a/book/overlays.md
+++ b/book/overlays.md
@@ -29,11 +29,13 @@ To create a new overlay, you first need a module:
 
 We'll use this module throughout the chapter, so whenever you see `overlay use spam`, assume `spam` is referring to this module.
 
-:::tip The module can be created by any of the three methods described in [Modules](modules.md):
+::: tip
+The module can be created by any of the three methods described in [Modules](modules.md):
 
 - "inline" modules (used in this example)
 - file
-- directory :::
+- directory
+:::
 
 To create the overlay, call [`overlay use`](/commands/docs/overlay_use.md):
 


### PR DESCRIPTION
The `:::` div closer was located as a last part of the list, which broke formatting.

![image](https://github.com/nushell/nushell.github.io/assets/97791001/bcd9961d-05f9-41f0-93a6-a5c70dc0ccb9)