### PR TITLE
add a few fixes for the release note of 0.86.0

### DIFF
--- a/blog/2023-10-17-nushell_0_86.md
+++ b/blog/2023-10-17-nushell_0_86.md
@@ -176,11 +176,6 @@ compiled artifact.
 
 ![Animation showing shorthand directory expansion](../assets/images/0_86_completions.gif)
 
-> :bulb: **Note**  
-> please have a look at
-> [this comment on GitHub](https://github.com/nushell/nushell/issues/10543#issuecomment-1740451687)
-> for a preview of this feature.
-
 ::: warning Breaking change
 See a full overview of the [breaking changes](#breaking-changes)
 :::

--- a/blog/2023-10-17-nushell_0_86.md
+++ b/blog/2023-10-17-nushell_0_86.md
@@ -474,13 +474,13 @@ In 0.86, we now differentiate between a switch `--x` and a flag with a boolean a
 ## Before
 
 ```nushell
-G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str camel-case
+> [UserID ABCdefGHI foo123bar] | str camel-case
 ╭───┬───────────╮
 │ 0 │ userID    │
 │ 1 │ abcdefGHI │
 │ 2 │ foo123Bar │
 ╰───┴───────────╯
-G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str snake-case
+> [UserID ABCdefGHI foo123bar] | str snake-case
 ╭───┬─────────────╮
 │ 0 │ user_id     │
 │ 1 │ ab_cdef_ghi │
@@ -491,13 +491,13 @@ G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str snake-case
 ## After
 
 ```nushell
-G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str camel-case
+> [UserID ABCdefGHI foo123bar] | str camel-case
 ╭───┬───────────╮
 │ 0 │ userId    │
 │ 1 │ abCdefGhi │
 │ 2 │ foo123bar │
 ╰───┴───────────╯
-G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str snake-case
+> [UserID ABCdefGHI foo123bar] | str snake-case
 ╭───┬─────────────╮
 │ 0 │ user_id     │
 │ 1 │ ab_cdef_ghi │

--- a/blog/2023-10-17-nushell_0_86.md
+++ b/blog/2023-10-17-nushell_0_86.md
@@ -473,7 +473,7 @@ In 0.86, we now differentiate between a switch `--x` and a flag with a boolean a
 
 ## Before
 
-```
+```nushell
 G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str camel-case
 ╭───┬───────────╮
 │ 0 │ userID    │
@@ -490,7 +490,7 @@ G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str snake-case
 
 ## After
 
-```
+```nushell
 G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str camel-case
 ╭───┬───────────╮
 │ 0 │ userId    │


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell.github.io/pull/1071

this PR
- removes a useless note that points to a link that has the same GIF as locally: see [*Improving the completions in the REPL*](https://www.nushell.sh/blog/2023-10-17-nushell_0_86.html#improving-the-completions-in-the-repl-toc)
- makes all code blocks Nushell code blocks to have syntax highlighting: see [*Before*](https://www.nushell.sh/blog/2023-10-17-nushell_0_86.html#before) and [*After*](https://www.nushell.sh/blog/2023-10-17-nushell_0_86.html#after)
- removes paths to personal directories in the prompts of code blocks:  see [*Before*](https://www.nushell.sh/blog/2023-10-17-nushell_0_86.html#before) and [*After*](https://www.nushell.sh/blog/2023-10-17-nushell_0_86.html#after)