### PR TITLE
update the Direnv section in the cookbook

### DIFF
--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -17,24 +17,19 @@ To make direnv work with nushell the way it does with other shells, we can use t
 $env.config = {
   hooks: {
     pre_prompt: [{ ||
-        let direnv = (direnv export json | from json | default {})
-        if ($direnv | is-empty) {
-            return
-        }
-        $direnv
-        | items {|key, value|
-           {
-              key: $key
-              value: (if $key in $env.ENV_CONVERSIONS {
-                do ($env.ENV_CONVERSIONS | get $key | get from_string) $value
-              } else {
-                  $value
-              })
-            }
-        } | transpose -ird | load-env
+      if (which direnv | is-empty) {
+        return
+      }
+
+      direnv export json | from json | default {} | load-env
     }]
   }
 }
 ```
+
+::: tip Note
+you can follow the [`nu_scripts` of Nushell](https://github.com/nushell/nu_scripts/blob/main/hooks/direnv/config.nu)
+for the always up-to-date version of the hook above
+:::
 
 With that configuration in place, direnv should now work with nushell.


### PR DESCRIPTION
related to
- https://github.com/nushell/nu_scripts/pull/628
- https://github.com/direnv/direnv/pull/1175

## description
i propose to update the Direnv hook, as in https://github.com/nushell/nu_scripts/pull/628 and https://github.com/direnv/direnv/pull/1175 :yum: 

i've seen a few people complaining about this hook in the cookbook, so here is both a working and a much simpler hook to run Direnv in Nushell :innocent: 