### PR TITLE
add translation for bash "command 2>&1 | less"

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -9,56 +9,57 @@ $env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 
 Note: this table assumes Nu 0.60.0 or later.
 
-| Bash                                 | Nu                                               | Task                                                              |
-| ------------------------------------ | ------------------------------------------------ | ----------------------------------------------------------------- |
-| `ls`                                 | `ls`                                             | Lists the files in the current directory                          |
-| `ls <dir>`                           | `ls <dir>`                                       | Lists the files in the given directory                            |
-| `ls pattern*`                        | `ls pattern*`                                    | Lists files that match a given pattern                            |
-| `ls -la`                             | `ls --long --all` or `ls -la`                    | List files with all available information, including hidden files |
-| `ls -d */`                           | `ls \| where type == dir`                        | List directories                                                  |
-| `find . -name *.rs`                  | `ls **/*.rs`                                     | Find recursively all files that match a given pattern             |
-| `find . -name Makefile \| xargs vim` | `ls **/Makefile \| get name \| vim $in`          | Pass values as command parameters                                 |
-| `cd <directory>`                     | `cd <directory>`                                 | Change to the given directory                                     |
-| `cd`                                 | `cd`                                             | Change to the home directory                                      |
-| `cd -`                               | `cd -`                                           | Change to the previous directory                                  |
-| `mkdir <path>`                       | `mkdir <path>`                                   | Creates the given path                                            |
-| `mkdir -p <path>`                    | `mkdir <path>`                                   | Creates the given path, creating parents as necessary             |
-| `touch test.txt`                     | `touch test.txt`                                 | Create a file                                                     |
-| `> <path>`                           | `\| save --raw <path>`                           | Save string into a file                                           |
-| `>> <path>`                          | `\| save --raw --append <path>`                  | Append string to a file                                           |
-| `> /dev/null`                        | `\| ignore`                                      | Discard command output                                            |
-| `> /dev/null 2>&1`                   | `out+err> /dev/null`                             | Discard command output, including stderr                                            |
-| `cat <path>`                         | `open --raw <path>`                              | Display the contents of the given file                            |
-|                                      | `open <path>`                                    | Read a file as structured data                                    |
-| `mv <source> <dest>`                 | `mv <source> <dest>`                             | Move file to new location                                         |
-| `cp <source> <dest>`                 | `cp <source> <dest>`                             | Copy file to new location                                         |
-| `cp -r <source> <dest>`              | `cp -r <source> <dest>`                          | Copy directory to a new location, recursively                     |
-| `rm <path>`                          | `rm <path>`                                      | Remove the given file                                             |
-|                                      | `rm -t <path>`                                   | Move the given file to the system trash                           |
-| `rm -rf <path>`                      | `rm -r <path>`                                   | Recursively removes the given path                                |
-| `date -d <date>`                     | `"<date>" \| into datetime -f <format>`          | Parse a date ([format documentation](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html)) |
-| `sed`                                | `str replace`                                    | Find and replace a pattern in a string                            |
-| `grep <pattern>`                     | `where $it =~ <substring>` or `find <substring>` | Filter strings that contain the substring                         |
-| `man <command>`                      | `help <command>`                                 | Get the help for a given command                                  |
-|                                      | `help commands`                                  | List all available commands                                       |
-|                                      | `help --find <string>`                           | Search for match in all available commands                        |
-| `command1 && command2`               | `command1; command2`                             | Run a command, and if it's successful run a second                |
-| `stat $(which git)`                  | `stat (which git).path`                          | Use command output as argument for other command                  |
-| `echo /tmp/$RANDOM`                  | `$"/tmp/(random integer)"`                       | Use command output in a string                                    |
-| `cargo b --jobs=$(nproc)`            | `cargo b $"--jobs=(sys \| get cpu \| length)"`   | Use command output in an option                                   |
-| `echo $PATH`                         | `$env.PATH` (Non-Windows) or `$env.Path` (Windows) | See the current path                                            |
-| `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Update PATH permanently                                           |
-| `export PATH = $PATH:/usr/other/bin` | `$env.PATH = ($env.PATH \| append /usr/other/bin)` | Update PATH temporarily                                      |
-| `export`                             | `$env`                                           | List the current environment variables                            |
-| `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Update environment variables permanently                          |
-| `FOO=BAR ./bin`                      | `FOO=BAR ./bin`                                  | Update environment temporarily                                    |
-| `export FOO=BAR`                     | `$env.FOO = BAR`                              | Set environment variable for current session                      |
-| `echo $FOO`                          | `$env.FOO`                                       | Use environment variables                                         |
-| `unset FOO`                          | `hide-env FOO`                                   | Unset environment variable for current session                    |
-| `alias s="git status -sb"`           | `alias s = git status -sb`                       | Define an alias temporarily                                       |
-| `type FOO`                           | `which FOO`                                      | Display information about a command (builtin, alias, or executable) |
-| `<update ~/.bashrc>`                 | `vim $nu.config-path`                            | Add and edit alias permanently (for new shells)                   |
-| `bash -c <commands>`                 | `nu -c <commands>`                               | Run a pipeline of commands                                        |
-| `bash <script file>`                 | `nu <script file>`                               | Run a script file                                                 |
-| `\`                                  | `( <command> )`                                  | A command can span multiple lines when wrapped with `(` and `)`   |
-| `pwd`                                | `$env.PWD`                                       | Display the current directory                                     |
+| Bash                                 | Nu                                                            | Task                                                              |
+| ------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `ls`                                 | `ls`                                                          | Lists the files in the current directory                          |
+| `ls <dir>`                           | `ls <dir>`                                                    | Lists the files in the given directory                            |
+| `ls pattern*`                        | `ls pattern*`                                                 | Lists files that match a given pattern                            |
+| `ls -la`                             | `ls --long --all` or `ls -la`                                 | List files with all available information, including hidden files |
+| `ls -d */`                           | `ls \| where type == dir`                                     | List directories                                                  |
+| `find . -name *.rs`                  | `ls **/*.rs`                                                  | Find recursively all files that match a given pattern             |
+| `find . -name Makefile \| xargs vim` | `ls **/Makefile \| get name \| vim $in`                       | Pass values as command parameters                                 |
+| `cd <directory>`                     | `cd <directory>`                                              | Change to the given directory                                     |
+| `cd`                                 | `cd`                                                          | Change to the home directory                                      |
+| `cd -`                               | `cd -`                                                        | Change to the previous directory                                  |
+| `mkdir <path>`                       | `mkdir <path>`                                                | Creates the given path                                            |
+| `mkdir -p <path>`                    | `mkdir <path>`                                                | Creates the given path, creating parents as necessary             |
+| `touch test.txt`                     | `touch test.txt`                                              | Create a file                                                     |
+| `> <path>`                           | `\| save --raw <path>`                                        | Save string into a file                                           |
+| `>> <path>`                          | `\| save --raw --append <path>`                               | Append string to a file                                           |
+| `> /dev/null`                        | `\| ignore`                                                   | Discard command output                                            |
+| `> /dev/null 2>&1`                   | `out+err> /dev/null`                                          | Discard command output, including stderr                          |
+| `command arg1 arg2 2>&1 \| less`     | `run-external --redirect-combine command [arg1 arg2] \| less` | Pipe stdout+stderr of a command into less, output updated live    |
+| `cat <path>`                         | `open --raw <path>`                                           | Display the contents of the given file                            |
+|                                      | `open <path>`                                                 | Read a file as structured data                                    |
+| `mv <source> <dest>`                 | `mv <source> <dest>`                                          | Move file to new location                                         |
+| `cp <source> <dest>`                 | `cp <source> <dest>`                                          | Copy file to new location                                         |
+| `cp -r <source> <dest>`              | `cp -r <source> <dest>`                                       | Copy directory to a new location, recursively                     |
+| `rm <path>`                          | `rm <path>`                                                   | Remove the given file                                             |
+|                                      | `rm -t <path>`                                                | Move the given file to the system trash                           |
+| `rm -rf <path>`                      | `rm -r <path>`                                                | Recursively removes the given path                                |
+| `date -d <date>`                     | `"<date>" \| into datetime -f <format>`                       | Parse a date ([format documentation](https://docs.rs/chrono/0.4.15/chrono/format/strftime/index.html)) |
+| `sed`                                | `str replace`                                                 | Find and replace a pattern in a string                            |
+| `grep <pattern>`                     | `where $it =~ <substring>` or `find <substring>`              | Filter strings that contain the substring                         |
+| `man <command>`                      | `help <command>`                                              | Get the help for a given command                                  |
+|                                      | `help commands`                                               | List all available commands                                       |
+|                                      | `help --find <string>`                                        | Search for match in all available commands                        |
+| `command1 && command2`               | `command1; command2`                                          | Run a command, and if it's successful run a second                |
+| `stat $(which git)`                  | `stat (which git).path`                                       | Use command output as argument for other command                  |
+| `echo /tmp/$RANDOM`                  | `$"/tmp/(random integer)"`                                    | Use command output in a string                                    |
+| `cargo b --jobs=$(nproc)`            | `cargo b $"--jobs=(sys \| get cpu \| length)"`                | Use command output in an option                                   |
+| `echo $PATH`                         | `$env.PATH` (Non-Windows) or `$env.Path` (Windows)            | See the current path                                              |
+| `<update ~/.bashrc>`                 | `vim $nu.config-path`                                         | Update PATH permanently                                           |
+| `export PATH = $PATH:/usr/other/bin` | `$env.PATH = ($env.PATH \| append /usr/other/bin)`            | Update PATH temporarily                                           |
+| `export`                             | `$env`                                                        | List the current environment variables                            |
+| `<update ~/.bashrc>`                 | `vim $nu.config-path`                                         | Update environment variables permanently                          |
+| `FOO=BAR ./bin`                      | `FOO=BAR ./bin`                                               | Update environment temporarily                                    |
+| `export FOO=BAR`                     | `$env.FOO = BAR`                                              | Set environment variable for current session                      |
+| `echo $FOO`                          | `$env.FOO`                                                    | Use environment variables                                         |
+| `unset FOO`                          | `hide-env FOO`                                                | Unset environment variable for current session                    |
+| `alias s="git status -sb"`           | `alias s = git status -sb`                                    | Define an alias temporarily                                       |
+| `type FOO`                           | `which FOO`                                                   | Display information about a command (builtin, alias, or executable) |
+| `<update ~/.bashrc>`                 | `vim $nu.config-path`                                         | Add and edit alias permanently (for new shells)                   |
+| `bash -c <commands>`                 | `nu -c <commands>`                                            | Run a pipeline of commands                                        |
+| `bash <script file>`                 | `nu <script file>`                                            | Run a script file                                                 |
+| `\`                                  | `( <command> )`                                               | A command can span multiple lines when wrapped with `(` and `)`   |
+| `pwd`                                | `$env.PWD`                                                    | Display the current directory                                     |


### PR DESCRIPTION
closes https://github.com/nushell/nushell/issues/10805

This is a very common thing to want to do and isnt documented anywhere that I could find.
I think an addition to this table would be the best way to communicate how to achieve this.

The pipe could go to anything but I chose less as thats the most common destination and it illustrates the point better than using something generic like `command 2>&1 | other_command`

I had to adjust the table width, so you will want to review with "hide whitespace" enabled.