### PR TITLE
Add a note on theming Reedline’s menus

### DIFF
--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -559,4 +559,4 @@ $env.config = {
 
 Reedline (Nu’s line editor) style is not using the `color_config` key.
 Instead, each menu has its own style to be configured separately.
-See the [section dedicated Reedline’s menus configuration](line_editor.md#menus) to learn more on this.
+See the [section dedicated to Reedline’s menus configuration](line_editor.md#menus) to learn more on this.

--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -554,3 +554,9 @@ $env.config = {
 }
 
 ```
+
+## Line editor menus (completion, history, help…)
+
+Reedline (Nu’s line editor) style is not using the `color_config` key.
+Instead, each menu has its own style to be configured separately.
+See the [section dedicated Reedline’s menus configuration](line_editor.md#menus) to learn more on this.


### PR DESCRIPTION
This adds a note on how Reedline’s menus are themed in the chapter dedicated on coloring and theming.
I found myself looking for this information at the wrong place, and thought it was sensible to at least mention it.