### PR TITLE
Change Ambiguous Example in `select` documentation

### DIFF
--- a/commands/docs/select.md
+++ b/commands/docs/select.md
@@ -38,20 +38,20 @@ usage: |
 
 Select a column in a table
 ```nu
-> [{a: a b: b}] | select a
+> [{a: 1 b: 2}] | select a
 ╭───┬───╮
 │ # │ a │
 ├───┼───┤
-│ 0 │ a │
+│ 0 │ 1 │
 ╰───┴───╯
 
 ```
 
 Select a field in a record
 ```nu
-> {a: a b: b} | select a
+> {a: 1 b: 2} | select a
 ╭───┬───╮
-│ a │ a │
+│ a │ 1 │
 ╰───┴───╯
 ```
 


### PR DESCRIPTION
Using 'a' and 'b' for both the keys and the values leaves the reader guessing as to how the command works. Changed the values to be numeric.

---

As a sidenote, I think some of these toy examples might be easier to understand if they were a little more realistic. Personally I find it very easy to gloss over things like "x", "y", "z" or "1", "2", "3", and when they are rather short, it is hard to see what is happening. E.g. some others I have seen use tables with one row. I think two-three minimum helps with working out dimensionality and what we are doing.

For object-orientation, examples are often real-world items that are easy to visualise - such as vehicles, animals, etc. I think the examples starting form `ls` etc. are also good springboards. It helps people think in terms of real data, and that connects how you might realistically use a command. Selecting processes or stats from my machine would also work nicely.