### PR TITLE
Clarify Dumping files into directory

### DIFF
--- a/book/modules.md
+++ b/book/modules.md
@@ -464,8 +464,8 @@ Now you've set up a directory where you can put your completion files and you sh
 
 > **Note**
 > This will use the file name (in our example `git` from `git.nu`) as the modules name. This means some completions might not work if the definition has the base command in it's name.
-> For example a completion like this `export extern 'git push' [] {}` in our `git.nu` will result in a completion like this `git git push`. If you have this style of completion you must instead
-> import like this `use completions git *` which will import the exported definitions of the submoudule `git`. 
+> For example a completion like this `export extern 'git push' []` in our `git.nu` will result in a completion like this `git git push`. If you have this style of completion you must instead
+> import like this `use completions git *` which will import the exported definitions of the submoudule `git`. Or simply rename `git push` to just `push`.
 
 ### Setting environment + aliases (conda style)
 

--- a/book/modules.md
+++ b/book/modules.md
@@ -463,8 +463,9 @@ $env.NU_LIB_DIRS = [
 Now you've set up a directory where you can put your completion files and you should have some Git completions the next time you start Nushell
 
 > **Note**
-> This will use the file name (in our example `git` from `git.nu`) as the modules name. This means completions like the ones found in the [nu scripts](https://github.com/nushell/nu_scripts) repo won't work
-> as you will end up with completions like `git-completions git ...`. You should instead do `use completions git-completions *` which will import the exported definitions of the submodule `git-completions` 
+> This will use the file name (in our example `git` from `git.nu`) as the modules name. This means some completions might not work if the definition has the base command in it's name.
+> For example a complition like this `export extern 'git push' [] {}` in our `git.nu` will result in a completion like this `git git push`. If you have this style of completion you must instead
+> import like this `use completions git *` which will import the exported definitions of the submoudule `git`. 
 
 ### Setting environment + aliases (conda style)
 

--- a/book/modules.md
+++ b/book/modules.md
@@ -464,7 +464,7 @@ Now you've set up a directory where you can put your completion files and you sh
 
 > **Note**
 > This will use the file name (in our example `git` from `git.nu`) as the modules name. This means some completions might not work if the definition has the base command in it's name.
-> For example a complition like this `export extern 'git push' [] {}` in our `git.nu` will result in a completion like this `git git push`. If you have this style of completion you must instead
+> For example a completion like this `export extern 'git push' [] {}` in our `git.nu` will result in a completion like this `git git push`. If you have this style of completion you must instead
 > import like this `use completions git *` which will import the exported definitions of the submoudule `git`. 
 
 ### Setting environment + aliases (conda style)

--- a/book/modules.md
+++ b/book/modules.md
@@ -423,15 +423,14 @@ Since directories can be imported as submodules and submodules can naturally for
 
 A common pattern in traditional shells is dumping and auto-sourcing files from a directory (for example, loading custom completions). In Nushell, similar effect can be achieved via module directories.
 
-1. Create a directory (e.g., `mkdir ($nu.default-config-dir | path join completions)`) and create empty `mod.nu` inside
-2. Add the directory containing the new directory to your NU_LIB_DIRS inside env.nu. For the example in 1. that would be $nu.default-config-dir
-3. Put `use completions *` into your `config.nu`
+Here we'll create a simple completion module with a submodule dedicated to some Git completions:
 
-Now you've set up a directory where you can put your completion files. For example:
-
+1. Create the completion directory
+`mkdir ($nu.default-config-dir | path join completions)`
+2. Create an empty mod.nu for it
+`touch ($nu.default-config-dir | path join completions mod.nu)`
+3. Put the following snippet in git.nu under the completion directory
 ```nu
-# git.nu
-
 export extern main [
     --version(-v)
     -C: string
@@ -452,8 +451,20 @@ def complete-git-branch [] {
     # ... code to list git branches
 }
 ```
+4. Add the parent of the completion directory to your NU_LIB_DIRS inside env.nu
+```nu
+$env.NU_LIB_DIRS = [
+    ...
+    $nu.default-config-dir
+]
+```
+5. import the completions to Nushell in your config.nu
+`use completions *`
+Now you've set up a directory where you can put your completion files and you should have some Git completions the next time you start Nushell
 
-If you put this file into the `completions` directory and reload config/Nushell, you should see the `git`, `git add` and `git checkout` commands highlighted with flag completions working.
+> **Note**
+> This will use the file name (in our example `git` from `git.nu`) as the modules name. This means completions like the ones found in the [nu scripts](https://github.com/nushell/nu_scripts) repo won't work
+> as you will end up with completions like `git-completions git ...`. You should instead do `use completions git-completions *` which will import the exported definitions of the submodule `git-completions` 
 
 ### Setting environment + aliases (conda style)
 

--- a/book/modules.md
+++ b/book/modules.md
@@ -424,7 +424,7 @@ Since directories can be imported as submodules and submodules can naturally for
 A common pattern in traditional shells is dumping and auto-sourcing files from a directory (for example, loading custom completions). In Nushell, similar effect can be achieved via module directories.
 
 1. Create a directory (e.g., `mkdir ($nu.default-config-dir | path join completions)`) and create empty `mod.nu` inside
-2. Add the directory to your NU_LIB_DIRS inside `env.nu`
+2. Add the directory containing the new directory to your NU_LIB_DIRS inside env.nu. For the example in 1. that would be $nu.default-config-dir
 3. Put `use completions *` into your `config.nu`
 
 Now you've set up a directory where you can put your completion files. For example:

--- a/book/modules.md
+++ b/book/modules.md
@@ -427,9 +427,9 @@ Here we'll create a simple completion module with a submodule dedicated to some 
 
 1. Create the completion directory
 `mkdir ($nu.default-config-dir | path join completions)`
-2. Create an empty mod.nu for it
+2. Create an empty `mod.nu` for it
 `touch ($nu.default-config-dir | path join completions mod.nu)`
-3. Put the following snippet in git.nu under the completion directory
+3. Put the following snippet in `git.nu` under the completion directory
 ```nu
 export extern main [
     --version(-v)
@@ -451,14 +451,14 @@ def complete-git-branch [] {
     # ... code to list git branches
 }
 ```
-4. Add the parent of the completion directory to your NU_LIB_DIRS inside env.nu
+4. Add the parent of the completion directory to your NU_LIB_DIRS inside `env.nu`
 ```nu
 $env.NU_LIB_DIRS = [
     ...
     $nu.default-config-dir
 ]
 ```
-5. import the completions to Nushell in your config.nu
+5. import the completions to Nushell in your `config.nu`
 `use completions *`
 Now you've set up a directory where you can put your completion files and you should have some Git completions the next time you start Nushell
 


### PR DESCRIPTION
The created completions directory in the example cannot itself be added to NU_LIB_DIRS but it's parent directory instead. In our example we create the directory in $nu.default-config-dir which should be added to NU_LIB_DIRS