### PR TITLE
Add a snippet to suggest using the ? operator for environmental variables

### DIFF
--- a/book/environment.md
+++ b/book/environment.md
@@ -95,6 +95,21 @@ Error: nu::shell::column_not_found
 
 > $env.FOO? | describe
 nothing
+
+> $env.FOO? | default "BAR"
+BAR
+```
+
+Alternatively, you can check for the presence of an environmental variable with `in`:
+
+```
+> $env.FOO
+BAR
+
+> if "FOO" in $env {
+>     echo $env.FOO
+> }
+BAR
 ```
 
 ## Scoping

--- a/book/environment.md
+++ b/book/environment.md
@@ -80,6 +80,23 @@ Individual environment variables are fields of a record that is stored in the `$
 BAR
 ```
 
+Sometimes, you may want to access an environmental variable which might be unset. Consider using the [question mark operator](variables_and_subexpressions.md#variable-paths) to avoid an error:
+```nu
+> $env.FOO | describe
+Error: nu::shell::column_not_found
+
+  × Cannot find column
+   ╭─[entry #1:1:1]
+ 1 │ $env.FOO
+   · ──┬─ ─┬─
+   ·   │   ╰── cannot find column 'FOO'
+   ·   ╰── value originates here
+   ╰────
+
+> $env.FOO? | describe
+nothing
+```
+
 ## Scoping
 
 When you set an environment variable, it will be available only in the current scope (the block you're in and any block inside of it).


### PR DESCRIPTION
I didn't initially realize the `?` operator existed (there's only two sections in the book about this, both of which are easy to miss!), and originally accomplished this using `$env | get --ignore-errors FOO` as suggested by `help default`. This seems like a common use case for the `?` operator, so I added a little snippet to guide users towards using `?`