### PR TITLE
Unifies all cookbook codeblocks to use the same style.

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -11,7 +11,7 @@ where you will find interesting scripts written for Nushell.
 And if you are looking for cool oneliners like this one
 
 ```nu
-> (http get https://api.chucknorris.io/jokes/random).value
+(http get https://api.chucknorris.io/jokes/random).value
 ```
 
 head to join Nushell's discord channel and check the

--- a/cookbook/files.md
+++ b/cookbook/files.md
@@ -12,7 +12,7 @@ Use `help inc` to get more information.
 Read the file's initial contents
 
 ```nu
-> open Cargo.toml | get package.version
+open Cargo.toml | get package.version
 ```
 
 Output
@@ -24,7 +24,7 @@ Make the edit to the version number and save it.
 _Note: running this command should work but it will reorder the toml file alphabetically by section._
 
 ```nu
-> open Cargo.toml | upsert package.version { |p| $p | get package.version | inc --patch } | save Cargo.toml
+open Cargo.toml | upsert package.version { |p| $p | get package.version | inc --patch } | save Cargo.toml
 ```
 
 Output
@@ -33,7 +33,7 @@ _none_
 View the changes we made to the file.
 
 ```nu
-> open Cargo.toml | get package.version
+open Cargo.toml | get package.version
 ```
 
 Output
@@ -58,7 +58,7 @@ Fugazi:In On The Kill Taker:1993
 You can parse it into a table.
 
 ```nu
-> open bands.txt | lines | split column ":" Band Album Year | skip 1 | sort-by Year
+open bands.txt | lines | split column ":" Band Album Year | skip 1 | sort-by Year
 ```
 
 Output
@@ -84,7 +84,7 @@ open bands.txt | lines | parse "{Band}:{Album}:{Year}" | skip 1 | sort-by Year
 Or, you can utilize the `headers` command to use the first row as a header row. The only difference would be the headers would match the case of the text file. So, in this case, the headers would be lowercase.
 
 ```nu
-> open bands.txt | lines | split column ":" | headers | sort-by year
+open bands.txt | lines | split column ":" | headers | sort-by year
 ```
 
 ---
@@ -94,7 +94,7 @@ Or, you can utilize the `headers` command to use the first row as a header row. 
 Suppose you would like to check the number of lines the string "Value" appears per file in the nushell project, then sort those files by largest line count.
 
 ```nu
-> rg -c Value | lines | split column ":" file line_count | into int line_count | sort-by line_count | reverse
+rg -c Value | lines | split column ":" file line_count | into int line_count | sort-by line_count | reverse
 ```
 
 Output

--- a/cookbook/git.md
+++ b/cookbook/git.md
@@ -11,7 +11,7 @@ Nu can help with common `Git` tasks like removing all local branches which have 
 **Warning**: This command will hard delete the merged branches from your machine. You may want to check the branches selected for deletion by omitting the last git command.
 
 ```nu
-> git branch --merged | lines | where ($it != "* master" and $it != "* main") | each {|br| git branch -D ($br | str trim) } | str trim
+git branch --merged | lines | where ($it != "* master" and $it != "* main") | each {|br| git branch -D ($br | str trim) } | str trim
 ```
 
 Output
@@ -25,7 +25,7 @@ Output
 Parse formatted commit messages (more details in the parsing git log section)
 
 ```nu
-> git log --pretty=%h»¦«%aN»¦«%s»¦«%aD | lines | split column "»¦«" sha1 committer desc merged_at | first 10
+git log --pretty=%h»¦«%aN»¦«%s»¦«%aD | lines | split column "»¦«" sha1 committer desc merged_at | first 10
 ```
 
 Output
@@ -55,7 +55,7 @@ Output
 _Note: the `histogram` command is not yet ported to the latest version_
 
 ```nu
-> git log --pretty=%h»¦«%aN»¦«%s»¦«%aD | lines | split column "»¦«" sha1 committer desc merged_at | histogram committer merger | sort-by merger | reverse
+git log --pretty=%h»¦«%aN»¦«%s»¦«%aD | lines | split column "»¦«" sha1 committer desc merged_at | histogram committer merger | sort-by merger | reverse
 ```
 
 ```

--- a/cookbook/help.md
+++ b/cookbook/help.md
@@ -9,7 +9,7 @@ The `help` command is a good way to become familiar with all that Nu has to offe
 ### How to see all supported commands:
 
 ```nu
-> help commands
+help commands
 ```
 
 ---
@@ -19,7 +19,7 @@ The `help` command is a good way to become familiar with all that Nu has to offe
 To find more specific information on a command, use `help <COMMAND>`. This works for regular commands (i.e. `http`) and subcommands (i.e. `http get`):
 
 ```nu
-> help http get
+help http get
 ```
 
 Output:

--- a/cookbook/http.md
+++ b/cookbook/http.md
@@ -7,7 +7,7 @@ title: HTTP
 ### Fetching JSON from a url
 
 ```nu
-> http get https://jsonplaceholder.typicode.com/posts | first 5
+http get https://jsonplaceholder.typicode.com/posts | first 5
 ```
 
 Output
@@ -63,7 +63,7 @@ An example JSON file, `urls.json`, with the following contents:
 ```
 
 ```nu
-> open urls.json | get urls | each { |u| http get $u }
+open urls.json | get urls | each { |u| http get $u }
 ```
 
 Output
@@ -94,7 +94,7 @@ Output
 If you specify the `--raw` flag, you'll see 3 separate json objects, one in each row.
 
 ```nu
-> open urls.json | get urls | each { |u| http get $u -r }
+open urls.json | get urls | each { |u| http get $u -r }
 ```
 
 Output
@@ -132,7 +132,7 @@ Output
 To combine these responses together into a valid JSON array, you can turn the table into json.
 
 ```nu
-> open urls.json | get urls | each { |u| http get $u } | to json
+open urls.json | get urls | each { |u| http get $u } | to json
 ```
 
 Output
@@ -175,7 +175,7 @@ Making a `post` request to an endpoint with a JSON payload. To make long request
 ```
 
 ```nu
-> open payload.json | get my_payload | to json | post https://jsonplaceholder.typicode.com/posts $in
+open payload.json | get my_payload | to json | post https://jsonplaceholder.typicode.com/posts $in
 ```
 
 Output
@@ -193,8 +193,10 @@ Output
 We can put this all together into a pipeline where we read data, manipulate it, and then send it back to the API. Lets `fetch` a post, `increment` the id, and `post` it back to the endpoint. In this particular example, the test endpoint gives back an arbitrary response which we can't actually mutate.
 
 ```nu
-> open urls.json | get urls | first | http get $in | upsert id {|item| $item.id | inc} | to json | post https://jsonplaceholder.typicode.com/posts $in
+open urls.json | get urls | first | http get $in | upsert id {|item| $item.id | inc} | to json | post https://jsonplaceholder.typicode.com/posts $in
 ```
+
+Output
 
 ```
 ━━━━━

--- a/cookbook/parsing.md
+++ b/cookbook/parsing.md
@@ -9,10 +9,10 @@ Nu offers the ability to do some basic parsing.
 How to parse an arbitrary pattern from a string of text into a multi-column table.
 
 ```nu
-> cargo search shells --limit 10 | lines | parse "{crate_name} = {version} #{description}" | str trim
+cargo search shells --limit 10 | lines | parse "{crate_name} = {version} #{description}" | str trim
 ```
 
-Output
+Output:
 
 ```
 ───┬──────────────┬─────────────────┬────────────────────────────────────────────────────────────────────────────────

--- a/cookbook/parsing_git_log.md
+++ b/cookbook/parsing_git_log.md
@@ -9,13 +9,13 @@ title: Parsing Git Log
 This `git log` command is interesting but you can't do a lot with it like this.
 
 ```nu
-> git log
+git log
 ```
 
 Let's make it more parsable
 
 ```nu
-> git log --pretty="%h|%s|%aN|%aE|%aD" -n 25
+git log --pretty="%h|%s|%aN|%aE|%aD" -n 25
 ```
 
 This will work but I've been burnt by this in the past when a pipe `|` gets injected in the commits.
@@ -23,7 +23,7 @@ This will work but I've been burnt by this in the past when a pipe `|` gets inje
 So, let's try again with something that most likely won't show up in commits, `»¦«`. Also, since we're not using a pipe now we don't have to use quotes around the pretty format string. Notice that the output is just a bunch of strings.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5
 ```
 
 ```
@@ -39,7 +39,7 @@ Ahh, much better. Now that we have the raw data, let's try to parse it with nu.
 First we need to get it in lines or rows. Notice that the output is now in a table format.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines
 ```
 
 ```
@@ -62,7 +62,7 @@ That's more like nushell, but it would be nice to have some columns.
 We used the delimiter `»¦«` specifically so we can create columns so let's use it like this.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«"
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«"
 ```
 
 ```
@@ -90,7 +90,7 @@ Yay, for columns! But wait, it would really be nice if those columns had somethi
 Let's try adding the columns names to `split column` like this.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«" commit subject name email date
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«" commit subject name email date
 ```
 
 Ahhh, that looks much better.
@@ -118,7 +118,7 @@ Ahhh, that looks much better.
 Hmmm, that date string is a string. If it were a date vs a string it could be used for sorting by date. The way we do that is we have to convert the datetime to a real datetime and update the column. Try this.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime}
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime}
 ```
 
 Now this looks more nu-ish
@@ -146,7 +146,7 @@ Now this looks more nu-ish
 If we want to revert back to a date string we can do something like this with the `nth` command and the `get` command.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | select 3 | get date | date format | get 0
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | select 3 | get date | date format | get 0
 ```
 
 ```
@@ -157,7 +157,7 @@ Cool! Now that we have a real datetime we can do some interesting things with it
 Let's try `sort-by` first
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | sort-by date
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | sort-by date
 ```
 
 ```
@@ -229,7 +229,7 @@ Let's try `sort-by` first
 That's neat but what if I want it sorted in the opposite order? Try the `reverse` command and notice the newest commits are at the top.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | sort-by date | reverse
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | sort-by date | reverse
 ```
 
 ```
@@ -301,7 +301,7 @@ That's neat but what if I want it sorted in the opposite order? Try the `reverse
 Now let's try `group-by` and see what happens. This is a tiny bit tricky because dates are tricky. When you use `group-by` on dates you have to remember to use the `group-by date` subcommand so it's `group-by date date_column_name`.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime | date format '%Y-%m-%d'} | group-by date
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime | date format '%Y-%m-%d'} | group-by date
 ```
 
 ```
@@ -317,7 +317,7 @@ Now let's try `group-by` and see what happens. This is a tiny bit tricky because
 This would look better if we transpose the data and name the columns
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime | date format '%Y-%m-%d'} | group-by date | transpose date count
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime | date format '%Y-%m-%d'} | group-by date | transpose date count
 ```
 
 ```
@@ -335,7 +335,7 @@ This would look better if we transpose the data and name the columns
 How about `where` now? Show only the records that are less than a year old.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 365day))
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 365day))
 ```
 
 ```
@@ -408,7 +408,7 @@ How about `where` now? Show only the records that are less than a year old.
 Or even show me all the commits in the last 7 days.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 7day))
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 7day))
 ```
 
 ```
@@ -480,7 +480,7 @@ Or even show me all the commits in the last 7 days.
 Now, with the 365 day slice of data, let's `group-by` name where the commits are less than a year old. This table has a lot of columns so it's unreadable. However, if we `group-by` name and `transpose` the table things will look much cleaner. `Pivot` takes rows and turns them into columns or turns columns into rows.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 365day)) | group-by name | transpose
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 365day)) | group-by name | transpose
 ```
 
 ```
@@ -517,14 +517,14 @@ error: Unknown column
 Here's one tip for dealing with this error. We have a `do` command that has an `--ignore_errors` parameter. This is how you'd use it in the above example, if it were giving errors.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | do -i { split column "»¦«" commit subject name email date } | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 365day)) | group-by name | transpose
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | do -i { split column "»¦«" commit subject name email date } | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 365day)) | group-by name | transpose
 ```
 
 Now, back to parsing.
 What if we throw in the `sort-by` and `reverse` commands for good measure? Also, while we're in there, let's get rid of the `[table 21 rows]` thing too. We do that by using the `length` command on each row of column1.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 365day)) | group-by name | transpose | upsert column1 {|c| $c.column1 | length} | sort-by column1 | reverse
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | where ($it.date > ((date now) - 365day)) | group-by name | transpose | upsert column1 {|c| $c.column1 | length} | sort-by column1 | reverse
 ```
 
 ```
@@ -550,7 +550,7 @@ What if we throw in the `sort-by` and `reverse` commands for good measure? Also,
 This is still a lot of data so let's just look at the top 10 and use the `rename` command to name the columns. We could've also provided the column names with the `transpose` command.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | group-by name | transpose | upsert column1 {|c| $c.column1 | length} | sort-by column1 | rename name commits | reverse | first 10
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | group-by name | transpose | upsert column1 {|c| $c.column1 | length} | sort-by column1 | rename name commits | reverse | first 10
 ```
 
 ```
@@ -575,7 +575,7 @@ And there you have it. The top 10 committers and we learned a little bit of pars
 Here's one last little known command. Perhaps you don't want your table numbered starting with 0. Here's a way to change that with the `table` command.
 
 ```nu
-> git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | group-by name | transpose | upsert column1 {|c| $c.column1 | length} | sort-by column1 | rename name commits | reverse | first 10 | table -n 1
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | group-by name | transpose | upsert column1 {|c| $c.column1 | length} | sort-by column1 | rename name commits | reverse | first 10 | table -n 1
 ```
 
 ```

--- a/cookbook/pattern_matching.md
+++ b/cookbook/pattern_matching.md
@@ -9,14 +9,19 @@ title: Pattern Matching
 Like many other languages, nu offers a [`match`](https://www.nushell.sh/commands/docs/match.html#frontmatter-title-for-core) keyword. Usually this is used as a slightly more ergonomic version of `if-else` statements if you have many branches
 
 ```nu
-> [black red yellow green purple blue indigo] | each {|c|
- match $c {
-  "black" => "classy"
-  "red" | "green" | "blue" => "fundamental"
-  "yellow" | "purple" => "vibrant"
-  _ => "innovative"
- }
+[black red yellow green purple blue indigo] | each {|c|
+  match $c {
+    "black" => "classy"
+    "red" | "green" | "blue" => "fundamental"
+    "yellow" | "purple" => "vibrant"
+    _ => "innovative"
+  }
 }
+```
+
+Output:
+
+```
 ───┬────────────
  0 │ classy
  1 │ funamental
@@ -31,29 +36,33 @@ Like many other languages, nu offers a [`match`](https://www.nushell.sh/commands
 The equivalent in `if-else` statements would be:
 
 ```nu
-> [black red yellow green purple blue] | each {|c|
- if ($c == "black") {
-  "classy"
-  } else if ( $c in ["red", "green", "blue"]) {
-   "fundamental"
-  } else if ( $c in ['yellow', "purple"]){
-   "vibrant"
-  }  else {
-   "innovative"
+[black red yellow green purple blue] | each {|c|
+  if ($c == "black") {
+   "classy"
+  } else if ($c in ["red", "green", "blue"]) {
+    "fundamental"
+  } else if ($c in ['yellow', "purple"]) {
+    "vibrant"
+  } else {
+    "innovative"
   }
- }
 }
 ```
 
 As you can see you can also use command expressions in match statements (in this case used with `|`). Also notice the `_` case at the end, this is called the default arm and is used in case none of the other patterns match. Note also that in the case that cases overlap the first matching pattern will be used (just like with `if-else` statements):
 
 ```nu
- [yellow green] | each {|c|
+[yellow green] | each {|c|
   match $c {
-   "green" => "fundamental"
-   "yellow" | "green" => "vibrant"
+    "green" => "fundamental"
+    "yellow" | "green" => "vibrant"
   }
- }
+}
+```
+
+Output:
+
+```
 ───┬────────────
  0 │ vibrant
  1 │ funamental
@@ -66,9 +75,21 @@ You can use the [`describe`](https://www.nushell.sh/commands/docs/describe.html)
 
 ```nu
 {one: 1 two: 2} | describe
-record<one: int, two: int>
+```
 
+Output:
+
+```
+record<one: int, two: int>
+```
+
+```nu
 [{a: 1 b: 2} {a: 2 b:3 }] | describe
+```
+
+Output:
+
+```
 table<a: int, b: int>
 ```
 

--- a/cookbook/polars_v_pandas_v_nushell.md
+++ b/cookbook/polars_v_pandas_v_nushell.md
@@ -9,11 +9,16 @@ A dataframe example based on https://studioterabyte.nl/en/blog/polars-vs-pandas
 ## 1. Opening the file and show the shape of the DataFrame
 
 ```nu
-> let df = (dfr open NYCTaxi.csv)
+let df = (dfr open NYCTaxi.csv)
 ```
 
 ```nu
-> $df | shape
+$df | shape
+```
+
+Output:
+
+```
 ╭───┬─────────┬─────────╮
 │ # │  rows   │ columns │
 ├───┼─────────┼─────────┤
@@ -26,7 +31,12 @@ A dataframe example based on https://studioterabyte.nl/en/blog/polars-vs-pandas
 ## 2. Opening the file and show the first 5 rows
 
 ```nu
-> $df | first 5
+$df | first 5
+```
+
+Output:
+
+```
 ╭───┬───────────┬───────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬──────────────┬──────────────╮
 │ # │    id     │ vendor_id │ pickup_dateti │ dropoff_datet │ passenger_cou │ pickup_longit │ pickup_latitu │ dropoff_longi │ dropoff_latit │ store_and_fw │ trip_duratio │
 │   │           │           │ me            │ ime           │ nt            │ ude           │ de            │ tude          │ ude           │ d_flag       │ n            │
@@ -50,8 +60,13 @@ A dataframe example based on https://studioterabyte.nl/en/blog/polars-vs-pandas
 ## 3. Opening the file and get the length of all strings in the "id" column
 
 ```nu
-> let ids = ($df | first 5 | get id | str-lengths)
-> $df | first 5 | append $ids | rename id_x vendor_id_length
+let ids = ($df | first 5 | get id | str-lengths)
+$df | first 5 | append $ids | rename id_x vendor_id_length
+```
+
+Output:
+
+```
 ╭───┬───────────┬───────────┬──────────────┬──────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────╮
 │ # │    id     │ vendor_id │ pickup_datet │ dropoff_date │ passenger_c │ pickup_long │ pickup_lati │ dropoff_lon │ dropoff_lat │ store_and_f │ trip_durati │ vendor_id_l │
 │   │           │           │ ime          │ time         │ ount        │ itude       │ tude        │ gitude      │ itude       │ wd_flag     │ on          │ ength       │
@@ -75,7 +90,12 @@ A dataframe example based on https://studioterabyte.nl/en/blog/polars-vs-pandas
 Here's an alternate approach using `with-column`
 
 ```nu
-> $df | first 5 | with-column ($df | first 5 | get id | str-lengths) --name vendor_id_length
+$df | first 5 | with-column ($df | first 5 | get id | str-lengths) --name vendor_id_length
+```
+
+Output:
+
+```
 ╭───┬───────────┬───────────┬──────────────┬──────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────╮
 │ # │    id     │ vendor_id │ pickup_datet │ dropoff_date │ passenger_c │ pickup_long │ pickup_lati │ dropoff_lon │ dropoff_lat │ store_and_f │ trip_durati │ vendor_id_l │
 │   │           │           │ ime          │ time         │ ount        │ itude       │ tude        │ gitude      │ itude       │ wd_flag     │ on          │ ength       │
@@ -99,7 +119,12 @@ Here's an alternate approach using `with-column`
 ## 4. Opening the file and apply a function to the "trip_duration" to divide the number by 60 to go from the second value to a minute value
 
 ```nu
-> $df | first 5 | with-column ((col trip_duration) / 60.0)
+$df | first 5 | with-column ((col trip_duration) / 60.0)
+```
+
+Output:
+
+```
 ╭───┬───────────┬───────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬──────────────┬──────────────╮
 │ # │    id     │ vendor_id │ pickup_dateti │ dropoff_datet │ passenger_cou │ pickup_longit │ pickup_latitu │ dropoff_longi │ dropoff_latit │ store_and_fw │ trip_duratio │
 │   │           │           │ me            │ ime           │ nt            │ ude           │ de            │ tude          │ ude           │ d_flag       │ n            │
@@ -123,7 +148,12 @@ Here's an alternate approach using `with-column`
 ## 5. Opening the file and filtering out all rows with a trip duration shorther than 500 seconds
 
 ```nu
-> $df | filter-with ((col trip_duration) >= 500) | first 5
+$df | filter-with ((col trip_duration) >= 500) | first 5
+```
+
+Output:
+
+```
 ╭───┬───────────┬───────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬──────────────┬──────────────╮
 │ # │    id     │ vendor_id │ pickup_dateti │ dropoff_datet │ passenger_cou │ pickup_longit │ pickup_latitu │ dropoff_longi │ dropoff_latit │ store_and_fw │ trip_duratio │
 │   │           │           │ me            │ ime           │ nt            │ ude           │ de            │ tude          │ ude           │ d_flag       │ n            │
@@ -147,7 +177,12 @@ Here's an alternate approach using `with-column`
 ## 6. Opening the file, filtering out all the rows with a "Y" store_and_fwd_flag value, group by ID and calculate the mean duration time
 
 ```nu
-> $df | filter-with ((col store_and_fwd_flag) == "N") | group-by id | agg (col trip_duration | mean) | sort-by id | first 5
+$df | filter-with ((col store_and_fwd_flag) == "N") | group-by id | agg (col trip_duration | mean) | sort-by id | first 5
+```
+
+Output:
+
+```
 ╭───┬───────────┬───────────────╮
 │ # │    id     │ trip_duration │
 ├───┼───────────┼───────────────┤

--- a/cookbook/setup.md
+++ b/cookbook/setup.md
@@ -24,7 +24,7 @@ For more detailed instructions, see the documentation about [environment variabl
 ### How to list your environment variables
 
 ```nu
-> $env
+$env
 ```
 
 Output
@@ -46,7 +46,7 @@ Output
 or for a more detailed view, use our new `env` command.
 
 ```nu
-> env
+env
 ```
 
 Output
@@ -98,13 +98,13 @@ You should now be able to run `config nu` or `config env` and edit those files e
 ### How to get a single environment variable's value
 
 ```nu
-> $env.APPDATA
+$env.APPDATA
 ```
 
 or
 
 ```nu
-> env | where name == APPDATA
+env | where name == APPDATA
 ```
 
 ```

--- a/cookbook/system.md
+++ b/cookbook/system.md
@@ -9,7 +9,7 @@ Nu offers many commands that help interface with the filesystem and control your
 ### View all files in the current directory
 
 ```nu
-> ls | where type == file
+ls | where type == file
 ```
 
 Output
@@ -41,7 +41,7 @@ Output
 ### View all directories in the current directory
 
 ```nu
-> ls | where type == dir
+ls | where type == dir
 ```
 
 Output
@@ -70,7 +70,7 @@ Output
 ### Find processes sorted by greatest cpu utilization.
 
 ```nu
-> ps | where cpu > 0 | sort-by cpu | reverse
+ps | where cpu > 0 | sort-by cpu | reverse
 ```
 
 Output
@@ -92,7 +92,7 @@ Output
 Sometimes a process doesn't shut down correctly. Using `ps` it's fairly easy to find the pid of this process:
 
 ```nu
-> ps | where name == Notepad2.exe
+ps | where name == Notepad2.exe
 ```
 
 Output
@@ -108,7 +108,7 @@ Output
 This process can be sent the kill signal in a one-liner:
 
 ```nu
-> ps | where name == Notepad2.exe | get pid.0 | kill $in
+ps | where name == Notepad2.exe | get pid.0 | kill $in
 ```
 
 Output

--- a/cookbook/tables.md
+++ b/cookbook/tables.md
@@ -8,10 +8,15 @@ title: Advanced table workflows
 
 Examples shown in [`Working with tables`](../book/working_with_tables.md) work fine when our tables have equal amount of rows but what if we want to merge tables of different sizes?
 
+```nu
+let first = [[a b]; [1 2] [3 4]]
+let second = [[c d]; [5 6]]
+$first | merge $second
 ```
-> let first = [[a b]; [1 2] [3 4]]
-> let second = [[c d]; [5 6]]
-> $first | merge $second
+
+Output:
+
+```
 ───┬───┬───┬───┬───
  # │ a │ b │ c │ d
 ───┼───┼───┼───┼───
@@ -23,13 +28,18 @@ Examples shown in [`Working with tables`](../book/working_with_tables.md) work f
 
 Second row in columns `c` and `d` is empty because our `second` table only contained a single row so nushell has nothing to fill the remaining rows with. But what if we wanted the smaller table to 'wrap around' and keep filling the rows? For that we can use the [`group`](/commands/docs/group.md) command to split the larger table into subtables, merge each of them with the smaller table and then combine the merged tables together using [`flatten`](/commands/docs/flatten.md) command like this:
 
+```nu
+let first = [[a b]; [1 2] [3 4]]
+let second = [[c d]; [3 4]]
+$first
+| group ($second | length)
+| each { merge $second }
+| flatten
 ```
-> let first = [[a b]; [1 2] [3 4]]
-> let second = [[c d]; [3 4]]
-> $first | group ($second | length)
-  | each {|it|
-    merge $second
-  } | flatten
+
+Output:
+
+```
 ───┬───┬───┬───┬───
  # │ a │ b │ c │ d
 ───┼───┼───┼───┼───
@@ -41,23 +51,25 @@ Second row in columns `c` and `d` is empty because our `second` table only conta
 
 Can we do that with more than two tables? Sure we can! Let's add a third table:
 
-```
-> let third = [[e f]; [7 8]]
+```nu
+let third = [[e f]; [7 8]]
 ```
 
 We could join all three tables like this:
 
+```nu
+$first
+| group ($second|length)
+| each { merge $second }
+| flatten
+| group ($third | length)
+| each { merge $third }
+| flatten
 ```
-> $first | group ($second|length)
-   | each {|it|
-     merge $second
-   }
-   | flatten
-   | group ($third | length)
-   | each {|it|
-     merge $third
-   }
-   | flatten
+
+Output:
+
+```
 ───┬───┬───┬───┬───┬───┬───
  # │ a │ b │ c │ d │ e │ f
 ───┼───┼───┼───┼───┼───┼───
@@ -69,15 +81,19 @@ We could join all three tables like this:
 
 Or just like last time we could use the [`reduce`](../book/docs/reduce.md) command to merge tables together recursively:
 
-```
-> [$first_table $second_table $third_table]|reduce {|it, acc|
+```nu
+[$first_table $second_table $third_table]
+| reduce { |it, acc|
     $acc
     | group ($it | length)
-    | each {|x|
-        merge $it
-    }
+    | each { merge $it }
     | flatten
-}
+  }
+```
+
+Output:
+
+```
 ───┬───┬───┬───┬───┬───┬───
  # │ a │ b │ c │ d │ e │ f
 ───┼───┼───┼───┼───┼───┼───


### PR DESCRIPTION
The unified style favours the removal of any prompt indicator such as `>`.

When appropriate I split `nu` blocks and output blocks as well.

And fixed an example in pattern_matching.md