### PR TITLE
Replace usage of removed `date format` with `format date` in examples

### DIFF
--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -372,7 +372,7 @@ The Nushell prompt is configurable through these environment variables and confi
 Example: For a simple prompt one could do this. Note that `PROMPT_COMMAND` requires a `block` whereas the others require a `string`.
 
 ```nu
-> $env.PROMPT_COMMAND = { build-string (date now | date format '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
+> $env.PROMPT_COMMAND = { build-string (date now | format date '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
 ```
 
 If you don't like the default `PROMPT_INDICATOR` you could change it like this.

--- a/book/coming_from_cmd.md
+++ b/book/coming_from_cmd.md
@@ -48,7 +48,7 @@ This table was last updated for Nu 0.67.0.
 | `SET <var>=<string>`                 | `$env.<var> = <string>`                                                             | Set environment variables                                             |
 | `SETLOCAL`                           | (default behavior)                                                                  | Localize environment changes to a script                              |
 | `START <path>`                       | `explorer <path>`                                                                   | Open a file as if double-clicked in File Explorer                     |
-| `TIME /T`                            | `date now \| date format "%H:%M:%S"`                                                | Get the current time                                                  |
+| `TIME /T`                            | `date now \| format date "%H:%M:%S"`                                                | Get the current time                                                  |
 | `TIME`                               |                                                                                     | Set the current time                                                  |
 | `TITLE`                              |                                                                                     | Set the cmd.exe window name                                           |
 | `TYPE`                               | `open --raw`                                                                        | Display the contents of a text file                                   |

--- a/book/line_editor.md
+++ b/book/line_editor.md
@@ -148,7 +148,7 @@ def create_left_prompt [] {
 
 def create_right_prompt [] {
     let time_segment = ([
-        (date now | date format '%m/%d/%Y %r')
+        (date now | format date '%m/%d/%Y %r')
     ] | str join)
 
     $time_segment

--- a/cookbook/parsing_git_log.md
+++ b/cookbook/parsing_git_log.md
@@ -146,7 +146,7 @@ Now this looks more nu-ish
 If we want to revert back to a date string we can do something like this with the `nth` command and the `get` command.
 
 ```nu
-git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | select 3 | get date | date format | get 0
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 5 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime} | select 3 | get date | format date | get 0
 ```
 
 ```
@@ -301,7 +301,7 @@ git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split col
 Now let's try `group-by` and see what happens. This is a tiny bit tricky because dates are tricky. When you use `group-by` on dates you have to remember to use the `group-by date` subcommand so it's `group-by date date_column_name`.
 
 ```nu
-git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime | date format '%Y-%m-%d'} | group-by date
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime | format date '%Y-%m-%d'} | group-by date
 ```
 
 ```
@@ -317,7 +317,7 @@ git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split col
 This would look better if we transpose the data and name the columns
 
 ```nu
-git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime | date format '%Y-%m-%d'} | group-by date | transpose date count
+git log --pretty=%h»¦«%s»¦«%aN»¦«%aE»¦«%aD -n 25 | lines | split column "»¦«" commit subject name email date | upsert date {|d| $d.date | into datetime | format date '%Y-%m-%d'} | group-by date | transpose date count
 ```
 
 ```

--- a/de/book/coloring_and_theming.md
+++ b/de/book/coloring_and_theming.md
@@ -375,7 +375,7 @@ Der Nushell Prompt ist konfigurierbar mit diesen Umgebungsvariablen:
 Beispiel: Für einen einfachen Prompt wäre folgendes mögllich. Hinweis `PROMPT_COMMAND` benötigt einen `block` wogegen die anderen einen `string` erwarten.
 
 ```nu
-> $env.PROMPT_COMMAND = { build-string (date now | date format '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
+> $env.PROMPT_COMMAND = { build-string (date now | format date '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
 ```
 
 Soll der standard `PROMPT_INDICATOR` geändert werden, sieht das so aus.

--- a/de/book/working_with_lists.md
+++ b/de/book/working_with_lists.md
@@ -184,5 +184,5 @@ Jedes Listen-Element wird in eine eigene Zeile mit einer einzigen Spalte √ºberf√
 let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
 
 # Show world clock for selected time zones
-$zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | date format '%Y.%m.%d %H:%M')}
+$zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}
 ```

--- a/zh-CN/book/coloring_and_theming.md
+++ b/zh-CN/book/coloring_and_theming.md
@@ -371,7 +371,7 @@ Nushell 的提示符可以通过这些环境变量进行配置：
 例如：对于一个简单的提示，我们可以这样做。注意`PROMPT_COMMAND`需要一个`block`而其他的需要一个`string`。
 
 ```nu
-> $env.PROMPT_COMMAND = { build-string (date now | date format '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
+> $env.PROMPT_COMMAND = { build-string (date now | format date '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
 ```
 
 如果你不喜欢默认的`PROMPT_INDICATOR`，你可以这样改变它：

--- a/zh-CN/book/line_editor.md
+++ b/zh-CN/book/line_editor.md
@@ -135,7 +135,7 @@ def create_left_prompt [] {
 
 def create_right_prompt [] {
     let time_segment = ([
-        (date now | date format '%m/%d/%Y %r')
+        (date now | format date '%m/%d/%Y %r')
     ] | str join)
 
     $time_segment

--- a/zh-CN/book/working_with_lists.md
+++ b/zh-CN/book/working_with_lists.md
@@ -171,7 +171,7 @@ $zones | wrap 'Zone' | upsert Time {|it|
     (
         date now
             | date to-timezone $it.Zone
-            | date format '%Y.%m.%d %H:%M'
+            | format date '%Y.%m.%d %H:%M'
     )
 }
 ```


### PR DESCRIPTION
I've noticed one of the examples doesn't work because of removed command so I replace usage of it in all the examples with the new one. It's still part of automatically generated documentation but that should be changed in the main nushell repo which should be fixed as well to avoid confusion.