### PR TITLE
Improve workaround for carapace ERR output

### DIFF
--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -117,7 +117,7 @@ The solution to this involves manually checking the value to filter it out:
 let carapace_completer = {|spans: list<string>|
     carapace $spans.0 nushell $spans
     | from json
-    | if ($in | default [] | where value =~ '^-.*ERR$' | is-empty) { $in } else { null }
+    | if ($in | default [] | where value == $"($spans | last)ERR" | is-empty) { $in } else { null }
 }
 ```
 


### PR DESCRIPTION
In case of an unknown flag somewhere in the span, carapace outputs the last element of the span followed by the string "ERR". If the flag itself is not the last element, the regex won't match the error message. Instead, check the exact expected value.

Test with
```nu
> chmod -x foo<TAB>
```