### PR TITLE
Update command signature doc to modern syntax

### DIFF
--- a/book/command_signature.md
+++ b/book/command_signature.md
@@ -1,16 +1,12 @@
 # Command signature
 
-nu commands can be given explicit signatures; take [`histogram`](/commands/docs/histogram.md) as an example, the signature is like this:
+nu commands can be given explicit signatures; take [`str stats`](/commands/docs/str_stats.md) as an example, the signature is like this:
 
 ```nu
-def histogram [
-  column-name?: string,
-  frequency-column-name?: string,
-  --percentage-type (-t): string = "normalize"
-]: list<any> -> table { }
+def "str stats" []: string -> record { }
 ```
 
-The type names between the `:` and the opening curly brace `{` describe the command's input/output pipeline types. The input type for a given pipeline, in this case `list<any>`, is given before the `->`; and the output type `table` is given after `->`. There can be multiple input/output types. If there are multiple input/output types, they can be placed within brackets and separated with commas, as in [`str join`](/commands/docs/str_join.md):
+The type names between the `:` and the opening curly brace `{` describe the command's input/output pipeline types. The input type for a given pipeline, in this case `string`, is given before the `->`; and the output type `record` is given after `->`. There can be multiple input/output types. If there are multiple input/output types, they can be placed within brackets and separated with commas, as in [`str join`](/commands/docs/str_join.md):
 
 ```nu
 def "str join" [separator?: string]: [list -> string, string -> string] { }

--- a/book/command_signature.md
+++ b/book/command_signature.md
@@ -1,24 +1,22 @@
 # Command signature
 
-nu commands contain a signature section, take [`str distance`](/commands/docs/str_distance.md) as example, the signature is like this:
+nu commands can be given explicit signatures; take [`str distance`](/commands/docs/str_distance.md) as an example, the signature is like this:
 
 ```nu
-Signatures(Cell paths are supported):
-  <string> | str distance <string> -> <int>
+def "str distance" [comapare-string: string, ...rest: cell-path]: [string -> int, table -> table, record -> record]
 ```
 
-The first type name before `|` describes the type of input pipeline. The command name is followed by the required argument type(s) for the command. The output type is `int` and given after `->`.
+The type names in the brackets after the `:` describe the command's input/output pipeline types. The input type for a given pipeline, in this case `string`, is given before the `->`; and the output type `int` is given after `->`. There can be multiple input/output types.
 
-`(Cell paths are supported)` indicates that you can provide cell paths for `str distance` to apply an operation at the given cell path(s) in a nested structure or table, and replace the column or field with the result, like:  `ls | str distance 'nushell' 'name'`
+The `cell-path` type indicates that you can provide cell paths for `str distance` to apply an operation at the given cell path(s) in a nested structure or table, and replace the column or field with the result, like: `ls | str distance 'nushell' 'name'`
 
-Here is another one example, [`str join`](/commands/docs/str_join.md):
+Here is another example, [`str join`](/commands/docs/str_join.md):
 
 ```nu
-Signatures:
-  list<string> | str join <string?> -> <string>
+def "str join" [separator?: string]: [list<string> -> string, string -> string]
 ```
 
-It says that [`str join`](/commands/docs/str_join.md) command expect input pipeline is a list of string, and take optional `string` type argument, finally the output type is `string`.
+It says that the [`str join`](/commands/docs/str_join.md) command takes an optional `string` type argument, and an input pipeline of either a list of `string`s with output type of `string`, or a single `string`, again with output type of `string`.
 
 Some commands don't accept or require data through the input pipeline, thus the input type will be `<nothing>`.
 The same is true for the output type if the command returns `null` (e.g. [`rm`](/commands/docs/rm.md)).

--- a/book/command_signature.md
+++ b/book/command_signature.md
@@ -1,22 +1,26 @@
 # Command signature
 
-nu commands can be given explicit signatures; take [`str distance`](/commands/docs/str_distance.md) as an example, the signature is like this:
+nu commands can be given explicit signatures; take [`histogram`](/commands/docs/histogram.md) as an example, the signature is like this:
 
 ```nu
-def "str distance" [compare-string: string, ...rest: cell-path]: string -> int { }
+def histogram [
+  column-name?: string,
+  frequency-column-name?: string,
+  --percentage-type (-t): string = "normalize"
+]: list<any> -> table { }
 ```
 
-The type names after after the `:` describe the command's input/output pipeline types. The input type for a given pipeline, in this case `string`, is given before the `->`; and the output type `int` is given after `->`. There can be multiple input/output types. If there are multiple input/output types, they can be placed within brackets and separated with commas: `str distance`'s signature actually has the `[string -> int, table -> table, record -> record]` pipeline types.
-
-The `cell-path` type indicates that you can provide cell paths for `str distance` to apply an operation at the given cell path(s) in a nested structure or table, and replace the column or field with the result, like: `ls | str distance 'nushell' 'name'`
-
-Here is another example, [`str join`](/commands/docs/str_join.md):
+The type names between the `:` and the opening curly brace `{` describe the command's input/output pipeline types. The input type for a given pipeline, in this case `list<any>`, is given before the `->`; and the output type `table` is given after `->`. There can be multiple input/output types. If there are multiple input/output types, they can be placed within brackets and separated with commas, as in [`str join`](/commands/docs/str_join.md):
 
 ```nu
-def "str join" [separator?: string]: [list<string> -> string, string -> string] { }
+def "str join" [separator?: string]: [list -> string, string -> string] { }
 ```
 
-It says that the [`str join`](/commands/docs/str_join.md) command takes an optional `string` type argument, and an input pipeline of either a list of `string`s with output type of `string`, or a single `string`, again with output type of `string`.
+It says that the [`str join`](/commands/docs/str_join.md) command takes an optional `string` type argument, and an input pipeline of either a `list` (implying `list<any>`) with output type of `string`, or a single `string`, again with output type of `string`.
 
 Some commands don't accept or require data through the input pipeline, thus the input type will be `<nothing>`.
-The same is true for the output type if the command returns `null` (e.g. [`rm`](/commands/docs/rm.md)).
+The same is true for the output type if the command returns `null` (e.g. [`rm`](/commands/docs/rm.md) or [`hide`](/commands/docs/hide.md)):
+
+```nu
+def hide [module: string, members?]: nothing -> nothing { }
+```

--- a/book/command_signature.md
+++ b/book/command_signature.md
@@ -3,17 +3,17 @@
 nu commands can be given explicit signatures; take [`str distance`](/commands/docs/str_distance.md) as an example, the signature is like this:
 
 ```nu
-def "str distance" [comapare-string: string, ...rest: cell-path]: [string -> int, table -> table, record -> record]
+def "str distance" [compare-string: string, ...rest: cell-path]: string -> int { }
 ```
 
-The type names in the brackets after the `:` describe the command's input/output pipeline types. The input type for a given pipeline, in this case `string`, is given before the `->`; and the output type `int` is given after `->`. There can be multiple input/output types.
+The type names after after the `:` describe the command's input/output pipeline types. The input type for a given pipeline, in this case `string`, is given before the `->`; and the output type `int` is given after `->`. There can be multiple input/output types. If there are multiple input/output types, they can be placed within brackets and separated with commas: `str distance`'s signature actually has the `[string -> int, table -> table, record -> record]` pipeline types.
 
 The `cell-path` type indicates that you can provide cell paths for `str distance` to apply an operation at the given cell path(s) in a nested structure or table, and replace the column or field with the result, like: `ls | str distance 'nushell' 'name'`
 
 Here is another example, [`str join`](/commands/docs/str_join.md):
 
 ```nu
-def "str join" [separator?: string]: [list<string> -> string, string -> string]
+def "str join" [separator?: string]: [list<string> -> string, string -> string] { }
 ```
 
 It says that the [`str join`](/commands/docs/str_join.md) command takes an optional `string` type argument, and an input pipeline of either a list of `string`s with output type of `string`, or a single `string`, again with output type of `string`.


### PR DESCRIPTION
While implementing a custom alias, I found myself unable to provide an explicit command signature as described in the documentation. A bit of crawling the main repo's commit history led to my discovery that the syntax as described in the documentation was indeed outdated.
After a bit of experimentation I was able to discover the correct annotation syntax.
Ideally, in a slightly longer timescale than I am willing to deal with right now, this change shouldn't be needed; I believe the information on this page would serve better integrated with the rest of the documentation. It seems as though it would fit better there after the syntax change.