### PR TITLE
external completer: fixed cookbook example to exchange the first span entry only

### DIFF
--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -96,7 +96,7 @@ let expanded_alias = (scope aliases | where name == $spans.0 | get -i 0 | get -i
 # overwrite
 let spans = (if $expanded_alias != null  {
     # put the first word of the expanded alias first in the span
-    $spans | skip 1 | prepend ($expanded_alias | split row " ")
+    $spans | skip 1 | prepend ($expanded_alias | split row " " | take 1)
 } else { $spans })
 ```
 
@@ -143,7 +143,7 @@ let external_completer = {|spans|
     let spans = if $expanded_alias != null {
         $spans
         | skip 1
-        | prepend ($expanded_alias | split row ' ')
+        | prepend ($expanded_alias | split row ' ' | take 1)
     } else {
         $spans
     }


### PR DESCRIPTION
Hi,

@rsteube and i integrated the cookbook example for alias expansion in carapace rsteube/carapace-bin#2102. We (mostly not me) found, that nushell expands the alias partially and returns for eg `alias gco = git checkout` a span with `[ "gc", "checkout" ]`. Thus, the cookbook example replaces `gc` with `git` and `checkout`.

To replace `gc` only, we added `take 1` to ensure the alias gets replaced with `git`.

Kind regards
Alexander