### PR TITLE
Adding warning to nu_plugin_formats commands

### DIFF
--- a/commands/docs/from_eml.md
+++ b/commands/docs/from_eml.md
@@ -14,6 +14,10 @@ usage: |
 
 <div class='command-title'>{{ $frontmatter.formats }}</div>
 
+
+::: warning
+Command `from eml` resides in [plugin](/book/plugins.html) [`nu_plugin_formats`](https://crates.io/crates/nu_plugin_formats). To use this command, you must install/compile and register nu_plugin_formats
+:::
 ## Signature
 
 ```> from eml {flags} ```

--- a/commands/docs/from_ics.md
+++ b/commands/docs/from_ics.md
@@ -14,6 +14,10 @@ usage: |
 
 <div class='command-title'>{{ $frontmatter.formats }}</div>
 
+
+::: warning
+Command `from ics` resides in [plugin](/book/plugins.html) [`nu_plugin_formats`](https://crates.io/crates/nu_plugin_formats). To use this command, you must install/compile and register nu_plugin_formats
+:::
 ## Signature
 
 ```> from ics {flags} ```

--- a/commands/docs/from_ini.md
+++ b/commands/docs/from_ini.md
@@ -14,6 +14,10 @@ usage: |
 
 <div class='command-title'>{{ $frontmatter.formats }}</div>
 
+
+::: warning
+Command `from ini` resides in [plugin](/book/plugins.html) [`nu_plugin_formats`](https://crates.io/crates/nu_plugin_formats). To use this command, you must install/compile and register nu_plugin_formats
+:::
 ## Signature
 
 ```> from ini {flags} ```

--- a/commands/docs/from_vcf.md
+++ b/commands/docs/from_vcf.md
@@ -14,6 +14,10 @@ usage: |
 
 <div class='command-title'>{{ $frontmatter.formats }}</div>
 
+
+::: warning
+Command `from vcf` resides in [plugin](/book/plugins.html) [`nu_plugin_formats`](https://crates.io/crates/nu_plugin_formats). To use this command, you must install/compile and register nu_plugin_formats
+:::
 ## Signature
 
 ```> from vcf {flags} ```

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -243,8 +243,12 @@ $"($example.description)
         $'(char nl)**Tips:** Command `($command.name)` was not included in the official binaries by default, you have to build it with `--features=extra` flag(char nl)'
     } else { '' }
 
+    let plugins = if $command.name in ['from ini', 'from ics', 'from eml', 'from vcf'] {
+        $"(char nl)::: warning(char nl)Command `($command.name)` resides in [plugin]\(/book/plugins.html) [`nu_plugin_formats`]\(https://crates.io/crates/nu_plugin_formats). To use this command, you must install/compile and register nu_plugin_formats(char nl):::(char nl)"
+    } else { '' }
+
     let doc = (
-        ($top + $signatures + $flags + $parameters + $in_out + $examples + $extra_usage + $sub_commands + $tips)
+        ($top + $plugins + $signatures + $flags + $parameters + $in_out + $examples + $extra_usage + $sub_commands + $tips)
         | lines
         | each {|it| ($it | str trim -r) }
         | str join (char newline)


### PR DESCRIPTION
Resolves #1091

In `make_docs.nu` command page generation section, added a check for the commands from the plugin `nu_plugin_formats` (`from ini` and others) to add a warning box to those pages informing the users they have to install and register the plugin to use those commands. Also added the changes to the generated docs as well.

![nushell-from-ini-doc](https://github.com/nushell/nushell.github.io/assets/83514642/40c94fdf-25f7-4d2d-b4b1-f3bccff874da)

There might be a small merge conflict with #1183, but it should be easy to resolve.

---

I tried to figure out a way to not hardcode the command names in `make_docs.nu` and I figured out how the `make_docs.nu` could determine if a command was from a plugin, however I couldn't figure out how to determine which plugins the respective commands came from which I figured was important to add. Maybe it could parse the nu script at `$nu.plugin-path`, but that seemed kind of janky. If anyone knows how to determine them in that script or has any other ideas, just let me know.