### PR TITLE
Updating cookbook intro page due to discord channel rename and other editing.

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -4,9 +4,12 @@ In this section we have put together a bunch of useful tips to get you
 started with Nushell. These are simple commands that will help you ease your
 way into the Nushell philosophy.
 
-However, if you are in the need of more detailed Nushell scripts, have a look
-at the [Nushell's scripts](https://github.com/nushell/nu_scripts) repository
-where you will find interesting scripts written for Nushell.
+If you are in the need of more detailed Nushell scripts, have a look
+at the [Nushell scripts](https://github.com/nushell/nu_scripts) repository or
+the
+[#cool-scripts](https://discord.com/channels/601130461678272522/615253963645911060)
+channel on Nushell's Discord where you will find many other interesting scripts
+written for Nushell.
 
 And if you are looking for cool oneliners like this one
 
@@ -14,6 +17,6 @@ And if you are looking for cool oneliners like this one
 (http get https://api.chucknorris.io/jokes/random).value
 ```
 
-head to join Nushell's discord channel and check the
-[cool-oneliners](https://discord.com/channels/601130461678272522/615253963645911060)
-channel.
+check out the
+[cool-oneliners](https://github.com/nushell/nu_scripts/tree/main/sourced/cool-oneliners)
+section of the Nushell scripts repository.


### PR DESCRIPTION
The docs currently reference a "#cool-oneliners" channel in the Nushell Discord for Nushell oneliners, however, it links to the "#cool-scripts" channel which I presume was previously the "#cool-onliners" channel. Since I presume the name change was to broaden the channel content up to "multiple line" scripts, and it seems like it's not just oneliners anymore, I moved the mention of the channel to the previous paragraph where it's talking about more general scripts.

I replaced the oneliner channel with the oneliner section of the nu_scripts repo instead. (It looks like there are some things in that section that aren't really oneliners, but that's an issue for the nu_shells repo).

Since the given oneliner is supposed to be an example of what's in the nu_scripts oneliner section, I'll also create a pull request there to add that oneliner.