### PR TITLE
Adding range related info.

### DIFF
--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -155,7 +155,19 @@ true
 
 ## Ranges
 
-A range is a way of expressing a sequence of values from start to finish. They take the form \<start\>..\<end\>. For example, the range `1..3` means the numbers 1, 2, and 3.
+A range is a way of expressing a sequence of integer or float values from start to finish. They take the form \<start\>..\<end\>. For example, the range `1..3` means the numbers 1, 2, and 3.
+
+::: tip
+
+You can also easily create lists of characters with a form similar to ranges with the command [`seq char`](/commands/docs/seq_char.html) as well as with dates using the [`seq date`](/commands/docs/seq_date.html) command.
+
+:::
+
+### Specifying the step
+
+You can specify the step of a range with the form \<start\>..\<second\>..\<end\>, where the step between values in the range is the distance between the \<start\> and \<second\> values, which numerically is \<second\> - \<start\>. For example, the range `2..5..11` means the numbers 2, 5, 8, and 11 because the step is \<second\> - \<first\> = 5 - 2 = 3. The third value is 5 + 3 = 8 and the fourth value is 8 + 3 = 11.
+
+[`seq`](/commands/docs/seq.md) can also create sequences of numbers, and provides an alternate way of specifying the step with three parameters. It's called with `seq $start $step $end` where the step amount is the second parameter rather than being the second parameter minus the first parameter. So `2..5..9` would be equivalent to `seq 2 3 9`.
 
 ### Inclusive and non-inclusive ranges
 
@@ -170,6 +182,12 @@ Ranges can also be open-ended. You can remove the start or the end of the range 
 Let's say you wanted to start counting at 3, but you didn't have a specific end in mind. You could use the range `3..` to represent this. When you use a range that's open-ended on the right side, remember that this will continue counting for as long as possible, which could be a very long time! You'll often want to use open-ended ranges with commands like [`take`](/commands/docs/take.md), so you can take the number of elements you want from the range.
 
 You can also make the start of the range open. In this case, Nushell will start counting with `0`. For example, the range `..2` is the numbers 0, 1, and 2.
+
+::: warning
+
+Watch out for displaying open-ended ranges like just entering `3..` into the command line. It will keep printing out numbers very quickly until you stop it with something like Ctr + c.
+
+:::
 
 ## Binary data
 


### PR DESCRIPTION
Resolves #1191 and resolves #404

Added a section about the middle "step" range parameter, changed it to "sequence of integer or float values", added a tip about creating similar sequences for chars and dates, and added a warning about displaying open ended ranges.

Hopefully the range step section makes sense or at least isn't too confusing. I tried to be careful with how I presented it but it was a bit tricky.

---

After seeing that the range design is still in flux here nushell/nushell#11086, I considered holding off on adding this and waiting until it's more nailed down, however I figured increasing awareness of it might help us get more feedback about the current design. We can always change it when the time comes.