### PR TITLE
explicit print as nu no longer automatically prints output of every line

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -17,7 +17,7 @@ Let's look at an example script file:
 ```nu
 # myscript.nu
 def greet [name] {
-  ["hello" $name]
+  print ["hello" $name]
 }
 
 greet "world"
@@ -31,7 +31,7 @@ In the above, first `greet` is defined by the Nushell interpreter. This allows u
 greet "world"
 
 def greet [name] {
-  ["hello" $name]
+  print ["hello" $name]
 }
 ```
 


### PR DESCRIPTION
# Change

This PR updates the script examples to explicity `print` output.

# Reason

As per this comment https://github.com/nushell/nushell.github.io/issues/1163#issuecomment-1841613415, Nu no longer automatically print output of every line.

closes #1163