### PR TITLE
fix(exec.md): remove `{flags}` since there is no flag for exec

### DIFF
--- a/commands/docs/exec.md
+++ b/commands/docs/exec.md
@@ -17,7 +17,7 @@ feature: default
 
 ## Signature
 
-```> exec {flags} (command)```
+```> exec (command)```
 
 ## Parameters
 


### PR DESCRIPTION
- there is no flag for `exec`
- it's confusing since it could mean flags to the command, which is not the case