### PR TITLE
Add a section describing how to change table outputs

### DIFF
--- a/book/hooks.md
+++ b/book/hooks.md
@@ -257,6 +257,17 @@ a browser that automatically reloads when the file changes.
 Instead of the [`save`](/commands/docs/save.md) command, you would normally customize this
 to send the HTML output to a desired window.
 
+### Changing how output is displayed
+
+You can change to default behavior of how output is displayed by using the `display_output` hook.
+Here is an example that changes the default display behavior to show a table 1 layer deep if the terminal is wide enough, or collapse otherwise:
+
+```nu
+$env.config = ($env.config | upsert hooks {
+    display_output: {if (term size).columns >= 100 { table -ed 1 } else { table }}
+})
+```
+
 ### `command_not_found` hook in _Arch Linux_
 
 The following hook uses the `pkgfile` command, to find which packages commands belong to in _Arch Linux_.

--- a/book/working_with_tables.md
+++ b/book/working_with_tables.md
@@ -19,6 +19,11 @@ To start off, let's get a table that we can use:
 ───┴───────────────┴──────┴─────────┴────────────
 ```
 
+::: tip Changing how tables are displayed
+Nu will try to expands all table's structure by default. You can change this behavior by changing the `display_output` hook.
+See [hooks](/book/hooks.md#changing-how-output-is-displayed) for more information.
+:::
+
 ## Sorting the data
 
 We can sort a table by calling the [`sort-by`](/commands/docs/sort-by.md) command and telling it which columns we want to use in the sort. Let's say we wanted to sort our table by the size of the file:


### PR DESCRIPTION
I've been trying out Nu for a while. Some problem I have is that Nu will try to expand the table structure unless I pipe 
it with `table` command. I've looked into [Working with table](https://www.nushell.sh/book/working_with_tables.html) and [Configuration](https://www.nushell.sh/book/configuration.html) on how to change this default behavior without success. I found a solution by accidently finding this nushell/nushell#7292 issues. So I think that we should have some documentation explaining how to configure it more explicitly.