### PR TITLE
Add note about string interpolation at parse time

### DIFF
--- a/book/how_nushell_code_gets_run.md
+++ b/book/how_nushell_code_gets_run.md
@@ -149,7 +149,7 @@ let my_path = 'foo'
 source $"($my_path)/common.nu"
 ```
 
-Let's break down what would need to happen for this to work (assuming `$my_path` is set somewhere):
+Let's break down what would need to happen for this to work:
 
 1. Parse `let my_path = 'foo'` and `source $"($my_path)/config.nu"`
 2. To evaluate `source $"($my_path)/common.nu"`:

--- a/book/how_nushell_code_gets_run.md
+++ b/book/how_nushell_code_gets_run.md
@@ -4,9 +4,10 @@ As you probably noticed, Nushell behaves quite differently from other shells and
 
 First, let's give a few example which you might intuitively try but which do not work in Nushell.
 
-1. Sourcing a dynamic path
+1. Sourcing a dynamic path (note that a constant would work, see [parse-time evaluation](#parse-time-evaluation))
 
 ```nu
+let my_path = 'foo'
 source $"($my_path)/common.nu"
 ```
 
@@ -144,17 +145,18 @@ _Note: The following examples use [`source`](/commands/docs/source.md), but simi
 ### 1. Sourcing a dynamic path
 
 ```nu
+let my_path = 'foo'
 source $"($my_path)/common.nu"
 ```
 
 Let's break down what would need to happen for this to work (assuming `$my_path` is set somewhere):
 
-1. Parse `source $"($my_path)/common.nu"`
+1. Parse `let my_path = 'foo'` and `source $"($my_path)/config.nu"`
 2. To evaluate `source $"($my_path)/common.nu"`:
-   2.1. Parse `$"($my_path)/common.nu"`
-   2.2. Evaluate `$"($my_path)/common.nu"` to get the file name
-   2.3. Parse the contents of the file
-   2.4. Evaluate the contents of the file
+   1. Parse `$"($my_path)/common.nu"`
+   2. Evaluate `$"($my_path)/common.nu"` to get the file name
+   3. Parse the contents of the file
+   4. Evaluate the contents of the file
 
 You can see the process is similar to the `eval` functionality we talked about earlier. Nesting parse-evaluation cycles into the evaluation is not allowed in Nushell.
 
@@ -193,11 +195,11 @@ source "output.nu"
 Here, the sourced path is static (= known at parse-time) so everything should be fine, right? Well... no. Let's break down the sequence again:
 
 1. Parse the whole source code
-   1.1. Parse `"def abc [] { 1 + 2 }" | save output.nu`
-   1.2. Parse `source "output.nu"` - 1.2.1. Open `output.nu` and parse its contents
+   1. Parse `"def abc [] { 1 + 2 }" | save output.nu`
+   2. Parse `source "output.nu"` - 1.2.1. Open `output.nu` and parse its contents
 2. Evaluate the whole source code
-   2.1. Evaluate `"def abc [] { 1 + 2 }" | save output.nu` to generate `output.nu`
-   2.2. ...wait what???
+   1. Evaluate `"def abc [] { 1 + 2 }" | save output.nu` to generate `output.nu`
+   2. ...wait what???
 
 We're asking Nushell to read `output.nu` before it even exists. All the source code needs to be available to Nushell at parse-time, but `output.nu` is only generated during evaluation. Again, it helps here to _think of Nushell as a compiled language_.
 
@@ -282,25 +284,29 @@ While it is impossible to add parsing into the evaluation, we can add _a little 
 One pattern that this unlocks is being able to [`source`](/commands/docs/source.md)/[`use`](/commands/docs/use.md)/etc. a path from a "variable". We've seen that
 
 ```nu
-let some_path = 'foo/common.nu'
-source $some_path
+let some_path = $nu.default-config-dir
+source $"($some_path)/common.nu"
 ```
 
 does not work, but we can do the following:
 
 ```nu
-const some_path = 'foo/common.nu'
-source $some_path
+const some_path = $nu.default-config-dir
+source $"($some_path)/config.nu"
 ```
 
 We can break down what is happening again:
 
 1. Parse the whole source code
-   1.1. Parse `const some_path = 'foo/common.nu'` - 1.1.1. Evaluate* `'foo/common.nu'` and store it as a `some_path` constant
-   1.2. Parse `source $some_path` - 1.2.1. Evaluate* `$some_path`, see that it is a constant, fetch it - 1.2.2. Parse the `foo/common.nu` file
+   1. Parse `const some_path = $nu.default-config-dir`
+      1. Evaluate\* `$nu.default-config-dir` to `/home/user/.config/nushell` and store it as a `some_path` constant
+   2. Parse `source $"($some_path)/config.nu"`
+      1. Evaluate\* `$some_path`, see that it is a constant, fetch it
+      2. Evaluate\* `$"($some_path)/config.nu"` to `/home/user/.config/nushell/config.nu`
+      3. Parse the `/home/user/.config/nushell/config.nu` file
 2. Evaluate the whole source code
-   2.1. Evaluate `const some_path = 'foo/common.nu'` (i.e., add the `foo/common.nu` string to the runtime stack as `some_path` variable)
-   2.2. Evaluate `source $some_path` (i.e., evaluate the contents of `foo/common.nu`)
+   1. Evaluate `const some_path = $nu.default-config-dir` (i.e., add the `/home/user/.config/nushell` string to the runtime stack as `some_path` variable)
+   2. Evaluate `source $"($some_path)/config.nu"` (i.e., evaluate the contents of `/home/user/.config/nushell/config.nu`)
 
 This still does not violate our rule of not having an eval function, because an eval function adds additional parsing to the evaluation step. With parse-time evaluation we're doing the opposite.
 

--- a/book/thinking_in_nu.md
+++ b/book/thinking_in_nu.md
@@ -48,7 +48,16 @@ Another common issue is trying to dynamically create the filename to source from
 > source $"($my_path)/common.nu"
 ```
 
-This would require the evaluator to run and evaluate the string, but unfortunately Nushell needs this information at compile-time.
+This doesn't work if `my_path` is a regular runtime variable declared with `let`. This would require the
+evaluator to run and evaluate the string, but unfortunately Nushell needs this information at compile-time.
+
+However, if `my_path` is a [constant](/book/variables_and_subexpressions#constant-variables), then this
+would work, since the string can be evaluated at compile-time:
+
+```nu
+> const my_path = ([$nu.home-path nushell] | path join)
+> source $"($my_path)/common.nu" # sources /home/user/nushell/common.nu
+```
 
 **Thinking in Nushell:** Nushell is designed to use a single compile step for all the source you send it, and this is separate from evaluation. This will allow for strong IDE support, accurate error messages, an easier language for third-party tools to work with, and in the future even fancier output like being able to compile Nushell directly to a binary file.
 

--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -75,7 +75,7 @@ To use mutable variables for such behaviour, you are encouraged to use the loops
 
 A constant variable is an immutable variable that can be fully evaluated at parse-time. These are useful with commands that need to know the value of an argument at parse time, like [`source`](/commands/docs/source.md), [`use`](/commands/docs/use.md) and [`register`](/commands/docs/register.md). See [how nushell code gets run](how_nushell_code_gets_run.md) for a deeper explanation. They are declared using the `const` keyword
 
-```
+```nu
 const plugin = 'path/to/plugin'
 register $plugin
 ```

--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -164,7 +164,7 @@ You can also use reduce:
 
 Though in the cases of strings, especially if you don't have to operate on the strings, it's usually easier and more correct (notice the extra + at the end in the example above) to use `str join`.
 
-Finally you could also use string interpolation, but that is complex enough that it is covered in it's own subsection below.
+Finally you could also use string interpolation, but that is complex enough that it is covered in its own subsection below.
 
 ## String interpolation
 
@@ -189,6 +189,15 @@ As of version 0.61, interpolated strings support escaping parentheses, so that t
 ```nu
 > $"2 + 2 is (2 + 2) \(you guessed it!)"
 2 + 2 is 4 (you guessed it!)
+```
+
+Interpolated strings can be evaluated at parse time, but if they include values whose formatting depends
+on your configuration and your `config.nu` hasn't been loaded yet, they will use the default configuration.
+So if you have something like this in your `config.nu`, `x` will be `"2.0 KB"` even if your config says to use
+`MB` for all file sizes (datetimes will similarly use the default config).
+
+```nu
+> const x = $"(2kb)"
 ```
 
 ## Splitting strings


### PR DESCRIPTION
Since string interpolation at parse time has been merged (https://github.com/nushell/nushell/pull/11562) but it has unexpected behavior for formatting file sizes and datetimes if used before config.nu is loaded (the default config is used instead of your runtime config), this PR adds a note about that to the "Working with strings" page.

The docs do say [here](https://www.nushell.sh/book/how_nushell_code_gets_run.html) that sourcing a *dynamic* path like `source $"($my_path)/common.nu"` isn't possible, but this may be interpreted as meaning that stuff like `const x = "foo"; source $"($x)"` doesn't work too. There are a few different ways (not mutually exclusive) to avoid confusion:
- Adding `let my_path = ...` to show that `my_path` isn't a constant
- Amending "Sourcing a dynamic path" to something like "Sourcing a dynamic path (constants are fine, see \<some section\>)"
- Adding examples (like fdncred's screenshots [here](https://github.com/nushell/nushell/pull/11562#issuecomment-1904254075)) of using string interpolation at parse time for sourcing
- Something else?