### PR TITLE
Update custom_completions.md to use new spread operator in carapace example

### DIFF
--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -161,7 +161,7 @@ This example will enable carapace external completions:
 
 ```nu
 let carapace_completer = {|spans|
-    carapace $spans.0 nushell $spans | from json
+    carapace $spans.0 nushell ...$spans | from json
 }
 ```
 


### PR DESCRIPTION
Noticed I was getting an error after updating nushell warning me that auto spreading lists would be deprecated, updated my configuration and thought this change could be reflected in the docs.
<img width="1119" alt="image" src="https://github.com/nushell/nushell.github.io/assets/12947728/49fd85c2-dc92-4cbe-8bf0-4439c6a60d95">

