### PR TITLE
Fix typo in `into cell-path` in the 0.90.1 release notes

### DIFF
--- a/blog/2024-02-06-nushell_0_90_0.md
+++ b/blog/2024-02-06-nushell_0_90_0.md
@@ -175,7 +175,7 @@ As usual, new release rhyms with changes to commands!
 
 ### New commands [[toc](#table-of-content)]
 
-Apart from commands already mentioned above, [`into cellpath`](https://github.com/nushell/nushell/pull/11322) can now be used to create cell paths dynamically.
+Apart from commands already mentioned above, [`into cell-path`](https://github.com/nushell/nushell/pull/11322) can now be used to create cell paths dynamically.
 
 # Breaking changes [[toc](#table-of-content)]
 


### PR DESCRIPTION
The release notes for `0.90.1` mention a new `into cellpath` command, but it is actually called `into cell-path`.