### PR TITLE
docs: start rework data types and operator

### DIFF
--- a/book/operators.md
+++ b/book/operators.md
@@ -123,171 +123,43 @@ Operators are usually case-sensitive when operating on strings. There are a few 
 
 ## Spread operator
 
-Nushell has a spread operator (`...`) for unpacking lists and records. You may be familiar with it
-if you've used JavaScript before. Some languages use `*` for their spread/splat operator. It can
-expand lists or records in places where multiple values or key-value pairs are expected.
+The spread operator (`...`) allows to expand lists and records.
 
-There are three places you can use the spread operator:
+lists in a list literal or records in a record literal, as well as expand a list into multiple arguments in a command call.
 
-- [In list literals](#in-list-literals)
-- [In record literals](#in-record-literals)
-- [In command calls](#in-command-calls)
+### Creating lists and records
 
-### In list literals
+When creating a list literal, the spread operator can expand the values of another list. For example, to insert a list into another list:
 
-Suppose you have multiple lists you want to concatenate together, but you also want to intersperse
-some individual values. This can be done with `append` and `prepend`, but the spread
-operator can let you do it more easily.
-
-```nushell
-> let dogs = [Spot, Teddy, Tommy]
-> let cats = ["Mr. Humphrey Montgomery", Kitten]
-> [
-    ...$dogs
-    Polly
-    ...($cats | each { |it| $"($it) \(cat\)" })
-    ...[Porky Bessie]
-    ...Nemo
-  ]
-╭───┬───────────────────────────────╮
-│ 0 │ Spot                          │
-│ 1 │ Teddy                         │
-│ 2 │ Tommy                         │
-│ 3 │ Polly                         │
-│ 4 │ Mr. Humphrey Montgomery (cat) │
-│ 5 │ Kitten (cat)                  │
-│ 6 │ Porky                         │
-│ 7 │ Bessie                        │
-│ 8 │ ...Nemo                       │
-╰───┴───────────────────────────────╯
+```nu
+> [sam, ...[fred, george], susan]
+╭───┬────────╮
+│ 0 │ sam    │
+│ 1 │ fred   │
+│ 2 │ george │
+│ 3 │ susan  │
+╰───┴────────╯
 ```
 
-The below code is an equivalent version using `append`:
-```nushell
-> $dogs |
-    append Polly |
-    append ($cats | each { |it| $"($it) \(cat\)" }) |
-    append [Porky Bessie] |
-    append ...Nemo
+This is shorter than to chain multiple `append` or `prepend` commans for each list part. Also, since only one new list is created, it might be slightly more performant.
+
+When creating a record literal, the spread operator can expand the values of another record. For example, to insert a record into another record:
+
+```nu
+> { ...{ name: sam, rank: 10 }, age: 21 }
+╭──────┬─────╮
+│ name │ sam │
+│ rank │ 10  │
+│ age  │ 21  │
+╰──────┴─────╯
 ```
 
-Note that each call to `append` results in the creation of a new list, meaning that in this second
-example, 3 unnecessary intermediate lists are created. This is not the case with the spread operator,
-so there may be (very minor) performance benefits to using `...` if you're joining lots of large
-lists together, over and over.
+### Multiple command arguments
 
-You may have noticed that the last item of the resulting list above is `"...Nemo"`. This is because
-inside list literals, it can only be used to spread lists, not strings. As such, inside list literals, it can
-only be used before variables (`...$foo`), subexpressions (`...(foo)`), and list literals (`...[foo]`).
-
-The `...` also won't be recognized as the spread operator if there's any whitespace between it and
-the next expression:
+When calling a command with a rest parameter or an external command, the spread operator can expand the values of a list of arguments.
 
 ```nushell
-> [ ... [] ]
-╭───┬────────────────╮
-│ 0 │ ...            │
-│ 1 │ [list 0 items] │
-╰───┴────────────────╯
-```
-
-This is mainly so that `...` won't be confused for the spread operator in commands such as `mv ... $dir`.
-
-### In record literals
-
-Let's say you have a record with some configuration information and you want to add more fields to
-this record:
-
-```nushell
-> let config = { path: /tmp, limit: 5 }
-```
-
-You can make a new record with all the fields of `$config` and some new additions using the spread
-operator. You can use the spread multiple records inside a single record literal.
-
-```nushell
-> {
-    ...$config,
-    users: [alice bob],
-    ...{ url: example.com },
-    ...(sys | get mem)
-  }
-╭────────────┬───────────────╮
-│ path       │ /tmp          │
-│ limit      │ 5             │
-│            │ ╭───┬───────╮ │
-│ users      │ │ 0 │ alice │ │
-│            │ │ 1 │ bob   │ │
-│            │ ╰───┴───────╯ │
-│ url        │ example.com   │
-│ total      │ 8.3 GB        │
-│ free       │ 2.6 GB        │
-│ used       │ 5.7 GB        │
-│ available  │ 2.6 GB        │
-│ swap total │ 2.1 GB        │
-│ swap free  │ 18.0 MB       │
-│ swap used  │ 2.1 GB        │
-╰────────────┴───────────────╯
-```
-
-Similarly to lists, inside record literals, the spread operator can only be used before variables (`...$foo`),
-subexpressions (`...(foo)`), and record literals (`...{foo:bar}`). Here too, there needs to be no
-whitespace between the `...` and the next expression for it to be recognized as the spread operator.
-
-### In command calls
-
-You can also spread arguments to a command, provided that it either has a rest parameter or is an
-external command.
-
-Here is an example custom command that has a rest parameter:
-
-```nushell
-> def foo [ --flag req opt? ...args ] { [$flag, $req, $opt, $args] | to nuon }
-```
-
-It has one flag (`--flag`), one required positional parameter (`req`), one optional positional parameter
-(`opt?`), and rest parameter (`args`).
-
-If you have a list of arguments to pass to `args`, you can spread it the same way you'd spread a list
-[inside a list literal](#in-list-literals). The same rules apply: the spread operator is only
-recognized before variables, subexpressions, and list literals, and no whitespace is allowed in between.
-
-```nushell
-> foo "bar" "baz" ...[1 2 3] # With ..., the numbers are treated as separate arguments
-[false, bar, baz, [1, 2, 3]]
-> foo "bar" "baz" [1 2 3] # Without ..., [1 2 3] is treated as a single argument
-[false, bar, baz, [[1, 2, 3]]]
-```
-
-A more useful way to use the spread operator is if you have another command with a rest parameter
-and you want it to forward its arguments to `foo`:
-
-```nushell
-> def bar [ ...args ] { foo --flag "bar" "baz" ...$args }
-> bar 1 2 3
-[true, bar, baz, [1, 2, 3]]
-```
-
-You can spread multiple lists in a single call, and also intersperse individual arguments:
-
-```nushell
-> foo "bar" "baz" 1 ...[2 3] 4 5 ...(6..9 | take 2) last
-[false, bar, baz, [1, 2, 3, 4, 5, 6, 7, last]]
-```
-
-Flags/named arguments can go after a spread argument, just like they can go after regular rest arguments:
-
-```nushell
-> foo "bar" "baz" 1 ...[2 3] --flag 4
-[true, bar, baz, [1, 2, 3, 4]]
-```
-
-If a spread argument comes before an optional positional parameter, that optional parameter is treated
-as being omitted:
-
-```nushell
-> foo "bar" ...[1 2] "not opt" # The null means no argument was given for opt
-[false, bar, null, [1, 2, "not opt"]]
+> print ...[1 2 3]
 ```
 
 ## Cell path access

--- a/book/operators.md
+++ b/book/operators.md
@@ -289,3 +289,53 @@ as being omitted:
 > foo "bar" ...[1 2] "not opt" # The null means no argument was given for opt
 [false, bar, null, [1, 2, "not opt"]]
 ```
+
+## Cell path access
+
+To access a value in a list or record in the output of a command, we can pipe it into `get` and specify the index or key. However, if we have a literal or variable this would often require a separate subexpression. Instead, we can use cell path access like this:
+
+```nu
+> [sam, fred, george].1
+fred
+> {name: sam, rank: 10}.name
+sam
+```
+
+:::tip
+
+If the key isn't a bare string, it needs quotes:
+
+```nu
+> {"first name": sam, rank: 10}."first name"
+sam
+> {"1": sam, 2: fred}."1"
+sam
+```
+
+:::
+
+To access nested values, we can chain cell path access members:
+
+```nu
+> [{name: sam, rank: 10}, {name: bob, rank: 7}].1.name
+bob
+```
+
+Since this is much shorter than chaining multiple `get`s, `get` also accepts a cell path:
+
+```nu
+> [{name: sam, rank: 10}, {name: bob, rank: 7}] | get 1.name
+bob
+```
+
+One advantage over `get` is that cell path members can be optional using `?`. If the value doesn't exist it returns `null` instead of an error:
+
+```nu
+> [sam, fred, george].3?
+> {name: sam, rank: 10}.age?
+> [{name: sam, rank: 10}, {rank: 7}] | get name?
+╭───┬─────╮
+│ 0 │ sam │
+│ 1 │     │
+╰───┴─────╯
+```

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -277,10 +277,10 @@ To make a copy of a record with new fields, you can use the [spread operator](/b
 
 ## Lists
 
-Lists are ordered sequences of data values. List syntax is very similar to arrays in JSON. However, commas are _not_ required to separate values if Nushell can easily distinguish them!
+A list is an ordered sequence of values. Unlike most languages, comma separators are optional.
 
 ```nu
-> [sam fred george]
+> [sam, fred, george]
 ╭───┬────────╮
 │ 0 │ sam    │
 │ 1 │ fred   │
@@ -288,30 +288,31 @@ Lists are ordered sequences of data values. List syntax is very similar to array
 ╰───┴────────╯
 ```
 
-:::tip
-Lists are equivalent to the individual columns of tables. You can think of a list as essentially being a "one-column table" (with no column name). Thus, any command which operates on a column _also_ operates on a list. For instance, [`where`](/commands/docs/where.md) can be used with lists:
+You can think of a list as a table column without the column name. Any command which operates on a table column also works with a list.
+
+To access a value, you can use the [`get`](/commands/docs/get.md) command or cell path access:
 
 ```nu
-> [bell book candle] | where ($it =~ 'b')
-╭───┬──────╮
-│ 0 │ bell │
-│ 1 │ book │
-╰───┴──────╯
+> [sam, fred, george] | get 1
+fred
+> [sam, fred, george].1
+fred
 ```
 
-:::
-
-Accessing lists' data is done by placing a `.` before a bare integer:
+To filter a list, you can use the [`where`](/commands/docs/where.md) command:
 
 ```nu
-> [a b c].1
-b
+> [sam, fred, george] | where ($it =~ 'e')
+╭───┬────────╮
+│ 0 │ fred   │
+│ 1 │ george │
+╰───┴────────╯
 ```
 
 To get a sub-list from a list, you can use the [`range`](/commands/docs/range.md) command:
 
 ```nu
-> [a b c d e f] | range 1..3
+> [a, b, c, d, e, f] | range 1..3
 ╭───┬───╮
 │ 0 │ b │
 │ 1 │ c │
@@ -323,8 +324,8 @@ To append one or more lists together, optionally with values interspersed in bet
 [spread operator](/book/operators#spread-operator) (`...`):
 
 ```nu
-> let x = [1 2]
-> [...$x 3 ...(4..7 | take 2)]
+> let x = [1, 2]
+> [...$x, 3, ...(4..7 | take 2)]
 ╭───┬───╮
 │ 0 │ 1 │
 │ 1 │ 2 │

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -209,35 +209,45 @@ Structured data builds from the simple data. For example, instead of a single in
 
 ## Records
 
-Records hold key-value pairs, which associate string keys with various data values. Record syntax is very similar to objects in JSON. However, commas are _not_ required to separate values if Nushell can easily distinguish them!
+A record is a collection of key-value pairs. Unlike most languages, comma separators are optional.
 
 ```nu
-> {name: sam rank: 10}
+> {name: sam, rank: 10}
 ╭──────┬─────╮
 │ name │ sam │
 │ rank │ 10  │
 ╰──────┴─────╯
 ```
 
-As these can sometimes have many fields, a record is printed up-down rather than left-right.
+You can think of a record as a table row. Any command which operates on a table row also works with a record.
 
 :::tip
-A record is identical to a single row of a table (see below). You can think of a record as essentially being a "one-row table", with each of its keys as a column (although a true one-row table is something distinct from a record).
 
-This means that any command that operates on a table's rows _also_ operates on records. For instance, [`insert`](/commands/docs/insert.md), which adds data to each of a table's rows, can be used with records:
-
-```nu
-> {x:3 y:1} | insert z 0
-╭───┬───╮
-│ x │ 3 │
-│ y │ 1 │
-│ z │ 0 │
-╰───┴───╯
-```
+Unlike a table row, a record is printed vertically rather than horizontally.
 
 :::
 
-You can iterate over records by first transposing it into a table:
+To access a value, you can use the [`get`](/commands/docs/get.md) command or cell path access:
+
+```nu
+> {name: sam, rank: 10} | get name
+sam
+> {name: sam, rank: 10}.name
+sam
+```
+
+To add data to a record, you can use the [`insert`](/commands/docs/insert.md) command:
+
+```nu
+> {name: sam, rank: 10} | insert age 21
+╭──────┬─────╮
+│ name │ sam │
+│ rank │ 10  │
+│ age  │ 21  │
+╰──────┴─────╯
+```
+
+To transform a record into a table, you can use the [`transpose`](/commands/docs/insert.md) command:
 
 ```nu
 > {name: sam, rank: 10} | transpose key value
@@ -247,32 +257,6 @@ You can iterate over records by first transposing it into a table:
 │ 0 │ name │  sam  │
 │ 1 │ rank │   10  │
 ╰───┴──────┴───────╯
-```
-
-Accessing records' data is done by placing a `.` before a string, which is usually a bare string:
-
-```nu
-> {x:12 y:4}.x
-12
-```
-
-However, if a record has a key name that can't be expressed as a bare string, or resembles an integer (see lists, below), you'll need to use more explicit string syntax, like so:
-
-```nu
-> {"1":true " ":false}." "
-false
-```
-
-To make a copy of a record with new fields, you can use the [spread operator](/book/operators#spread-operator) (`...`):
-
-```nu
-> let data = { name: alice, age: 50 }
-> { ...$data, hobby: cricket }
-╭───────┬─────────╮
-│ name  │ alice   │
-│ age   │ 50      │
-│ hobby │ cricket │
-╰───────┴─────────╯
 ```
 
 ## Lists

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -418,39 +418,6 @@ To filter rows or columns in a table, you can use the [`select`](/commands/docs/
 ╰───┴──────┴──────╯
 ```
 
-### Cell Paths
-
-You can combine list and record data access syntax to navigate tables. When used on tables, these access chains are called "cell paths".
-
-You can access individual rows by number to obtain records:
-
-@[code](@snippets/types_of_data/cell-paths.sh)
-
-Moreover, you can also access entire columns of a table by name, to obtain lists:
-
-```nu
-> [{x:12 y:5} {x:4 y:7} {x:2 y:2}].x
-╭───┬────╮
-│ 0 │ 12 │
-│ 1 │  4 │
-│ 2 │  2 │
-╰───┴────╯
-```
-
-#### Optional cell paths
-
-By default, cell path access will fail if it can't access the requested row or column. To suppress these errors, you can add `?` to a cell path member to mark it as _optional_:
-
-```nu
-> [{foo: 123}, {}].foo?
-╭───┬─────╮
-│ 0 │ 123 │
-│ 1 │     │
-╰───┴─────╯
-```
-
-When using optional cell path members, missing data is replaced with `null`.
-
 ## Closures
 
 Closures are anonymous functions that can be passed a value through parameters and _close over_ (i.e. use) a variable outside their scope.

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -203,10 +203,6 @@ You can write binary as a literal using any of the `0x[...]`, `0b[...]`, or `0o[
 
 Incomplete bytes will be left-padded with zeros.
 
-## Structured data
-
-Structured data builds from the simple data. For example, instead of a single integer, structured data gives us a way to represent multiple integers in the same value. Here's a list of the currently supported structured data types: records, lists and tables.
-
 ## Records
 
 A record is a collection of key-value pairs. Unlike most languages, comma separators are optional.


### PR DESCRIPTION
Start to rework sections on records, lists and tables in data types, and sections cell path access and spread operator in operators.

The main theme is to clarify the wording and examples used in order to aid comprehension. By being more concise and saying only what's needed, we can remove complexity that's impeding comprehension.

The commits are self-contained and have a description with more detail on the reasoning for each change, such that they can be reviewed individually.

Because fundamental changes to prose like moving and rewording can make reading the line-by-line diff difficult, I'd recommend to glance at the diff only for seeing which sections changed, and then read the rendered new version as well as the rendered old version to feel which one reads better.