### PR TITLE
Fix regex section

### DIFF
--- a/book/regular_expressions.md
+++ b/book/regular_expressions.md
@@ -1,3 +1,9 @@
 # Regular expressions
 
-Regular expressions in Nushell's commands are handled by the `rust-lang/regex` crate. If you want to know more, check the crate documentation: "[regex](https://github.com/rust-lang/regex)".
+Regular expressions in Nushell's commands are mostly handled by the [`fancy-regex` crate](https://crates.io/crates/fancy-regex), which builds upon the [`rust-lang/regex` crate](https://github.com/rust-lang/regex). If you want to know more, check the documentation of both crates, in particular their "Syntax" sections.
+
+There are a couple of exceptions, where only [`rust-lang/regex`](https://github.com/rust-lang/regex) is used. These are currently:
+
+* `split column`
+* `split list`
+* `split row`


### PR DESCRIPTION
Currently, the docs say

> Regular expressions in Nushell's commands are handled by the rust-lang/regex crate.

-- which is not correct as of https://github.com/nushell/nushell/commit/cdeb8de75d69b76c9120a53aa8e1814d388d3f0e .

In particular, `help parse` suggests that one can use "fancy-regex look behind pattern", which got me terribly confused (until visiting the source code ...).

Regarding the commands that use (only) `regex`: In my opinion, the proper fix would be to upgrade them to `fancy-regex` as well, but unfortunately i don't know much Rust, so updating the docs is the best, i can offer. :/