### PR TITLE
Remove pyenv setup instructions

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -164,24 +164,3 @@ $env.PATH = ($env.PATH | split row (char esep) | prepend '/opt/homebrew/bin')
 $env.PATH = ($env.PATH | split row (char esep) | prepend '/home/linuxbrew/.linuxbrew/bin')
 ```
 
-### Pyenv
-[Pyenv](https://github.com/pyenv/pyenv) is a popular Python version manager. To add it to your Nushell PATH:
-
-#### MacOS or Linux
-```nu
-# MacOS or Linux
-$env.PATH = ($env.PATH | split row (char esep) | prepend $"(pyenv root)/shims")
-```
-
-#### Windows
-Windows users need to install [pyenv-win](https://github.com/pyenv-win/pyenv-win)
-and execute the `Get-Command pyenv` command in PowerShell to get the path of `pyenv.ps1` after the installation.
-
-The result usually looks like: `C:\Users\<your-username>\.pyenv\pyenv-win\bin\pyenv.ps1`
-
-Then add the path of pyenv to your Nushell PATH:
-```nu
-# Windows
-$env.Path = ($env.Path | split row (char esep) | prepend $"~/.pyenv/pyenv-win/bin/pyenv.ps1")
-```
-


### PR DESCRIPTION
Hi,

I was a little confused why setup instructions for `pyenv`, a python version manager was included here.

So I removed it and created a PR for `pyenv` to include it in there setup here:
https://github.com/pyenv/pyenv/pull/2916