### PR TITLE
Mention cell paths in Working w/ Tables

### DIFF
--- a/book/working_with_tables.md
+++ b/book/working_with_tables.md
@@ -161,9 +161,9 @@ These look very similar! Let's see if we can spell out the difference between th
 - [`select`](/commands/docs/select.md) - creates a new table which includes only the columns specified
 - [`get`](/commands/docs/get.md) - returns the values inside the column specified as a list
 
-The one way to tell these apart looking at the table is that the column names are missing, which lets us know that this is going to be a list of values we can work with.
-
-The [`get`](/commands/docs/get.md) command can go one step further and take a path to data deeper in the table. This simplifies working with more complex data, like the structures you might find in a .json file.
+:::tip
+The arguments provided to `select` and `get` are [cell paths](/book/types_of_data.html#cell-paths), a fundamental part of Nu's query language. In addition to simple queries like `get name`, you can also do things like `get name?` (will replace missing values with `null` instead of returning an error) or `get some.deeply.nested.column` for nested data.
+:::
 
 ## Changing data in a table
 


### PR DESCRIPTION
![image](https://github.com/nushell/nushell.github.io/assets/26268125/be3f2e86-68d1-4560-8fe4-d4c4a8637a3d)

## Context

@devyn had [a good suggestion on Discord](https://discord.com/channels/601130461678272522/729071784321876040/1213932488313933936):

> I think it would be useful to mention / link to the section on cell paths within the 'working with tables' guide
> 
> https://www.nushell.sh/book/types_of_data.html#cell-paths
> https://www.nushell.sh/book/working_with_tables.html
>
> it seems like a lot of people miss the 'optional cell paths' feature - I certainly didn't find out about it until somewhat recently