### PR TITLE
Fix a bug in zoxide completer

### DIFF
--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -38,7 +38,7 @@ A couple of things to note on this command:
 
 ```nu
 let zoxide_completer = {|spans|
-    $spans | skip 1 | zoxide query -l $in | lines | where {|x| $x != $env.PWD}
+    $spans | skip 1 | zoxide query -l ...$in | lines | where {|x| $x != $env.PWD}
 }
 ```
 


### PR DESCRIPTION
should using ...$in in extern command. other wise will cause an error and no result will be returned.