### PR TITLE
Add "Contrib" link to the navbar

### DIFF
--- a/.vuepress/configs/navbar/en.ts
+++ b/.vuepress/configs/navbar/en.ts
@@ -2,8 +2,8 @@ import type { NavbarConfig } from '@vuepress/theme-default';
 
 export const navbarEn: NavbarConfig = [
   { text: 'Book', link: '/book/' },
-  // { text: "Contributor Book", link: "/contributor-book/" },
   { text: 'Commands', link: '/commands/' },
+  { text: 'Contrib', link: '/contributor-book/' },
   { text: 'Cookbook', link: '/cookbook/' },
   { text: 'Blog', link: '/blog/' },
   { text: 'Ref', link: '/lang-guide/' },


### PR DESCRIPTION
This links the contributor book on the navbar, which seems to have been previously linked but removed, probably because it was long and took up a lot of space. As an alternative, this just calls it "Contrib" instead and puts it between "Commands" and "Cookbook" (the alphabetical order was appealing to me)