### PR TITLE
Add info on XDG_CONFIG_HOME

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -20,6 +20,24 @@ When you launch Nushell without these files set up, Nushell will prompt you to d
 
 You can browse the default files for default values of environment variables and a list of all configurable settings.
 
+The `XDG_CONFIG_HOME` environment variable can be used to control which directory Nushell reads config files from.
+For example, on Windows, you may want to make Nushell look for config files in `~/.config/nushell` rather than
+the default directory for Windows, which is `C:\Users\username\AppData\Roaming\nushell`. You can do that by setting
+`$env.XDG_CONFIG_HOME` **before** starting Nushell.
+
+```nu
+> $env.XDG_CONFIG_HOME = "C:\Users\username\.config"
+> nu
+> $nu.default-config-dir
+C:\Users\username\.config\nushell
+```
+
+::: warning
+`XDG_CONFIG_HOME` is not a Nushell-specific environment variable and should not be set to the directory that contains Nushell config files.
+It should be the directory *above* the `nushell` directory. If you set it to `/Users/username/dotfiles/nushell`, Nushell will look for
+config files in `/Users/username/dotfiles/nushell/nushell` instead. In this case, you would want to set it to `/Users/username/dotfiles`.
+:::
+
 ### Configuring `$env.config`
 
 Nushell's main settings are kept in the `config` environment variable as a record. This record can be created using:


### PR DESCRIPTION
Adds information on using `XDG_CONFIG_HOME` to control where Nushell looks for config files. Also added a warning about setting `XDG_CONFIG_HOME` to the directory above the Nushell-specific config directory, rather than the `nushell` directory itself.