### PR TITLE
Document dynamic command arguments

### DIFF
--- a/lang-guide/lang-guide.md
+++ b/lang-guide/lang-guide.md
@@ -377,7 +377,7 @@ There are a couple things to be aware of in the above example.
 
 ### Executing String Interpolated strings
 
-Sometimes you need to build a path to execute external commands.
+Sometimes you need to build a path to execute external commands or build command arguments.
 
 Example:
 
@@ -385,8 +385,9 @@ Example:
 let path1 = "/part1"
 let path2 = "/part2"
 let fn = "filename"
+let arguments = ["arg1", "-a", "arg2"]
 
-^$"($path1)($path2)($fn)"
+^$"($path1)($path2)($fn)" ...$arguments
 ```
 
 The caret `^` before the string interpolation symbol `$` allows that external command to be executed.


### PR DESCRIPTION
I had been wondering how to add arguments to commands directly without a new instance of the shell, as its not documented anywhere as far as i can tell.

Now that i have figured it out a way to do it, i thought id add it to the doc.

I'm not sure if it should be mentioned that `"-a arg2"` does not work, as they become one argument with space instead of the normal two arguments split by space as one would normally expect. That also means that one does not need to double wrap like `'"long arg"'`.

I guess it could also be mentioned that you can also have static arguments instead of, or in addition, like `^$"command" --static-arg ...$arguments`.