### PR TITLE
fix(files.md): override Cargo.toml in example

### DIFF
--- a/cookbook/files.md
+++ b/cookbook/files.md
@@ -24,8 +24,10 @@ Make the edit to the version number and save it.
 _Note: running this command should work but it will reorder the toml file alphabetically by section._
 
 ```nu
-open Cargo.toml | upsert package.version { |p| $p | get package.version | inc --patch } | save Cargo.toml
+open Cargo.toml | upsert package.version { |p| $p | get package.version | inc --patch } | save -f Cargo.toml
 ```
+
+Note: `inc` is available through the plugin `nu_plugin_inc`.
 
 Output
 _none_


### PR DESCRIPTION
- override existing `Cargo.toml` file with `-f` flag for `save` in example
- Point out `inc` is available through the `nu_plugin_inc`