### PR TITLE
The `not` operator was missing in the list of the order of operations.

### DIFF
--- a/book/operators.md
+++ b/book/operators.md
@@ -50,6 +50,7 @@ Operations are evaluated in the following order (from highest precedence to lowe
 - Bitwise and (`bit-and`)
 - Bitwise xor (`bit-xor`)
 - Bitwise or (`bit-or`)
+- Logical not (`not`)
 - Logical and (`and`)
 - Logical xor (`xor`)
 - Logical or (`or`)

--- a/book/operators.md
+++ b/book/operators.md
@@ -50,9 +50,9 @@ Operations are evaluated in the following order (from highest precedence to lowe
 - Bitwise and (`bit-and`)
 - Bitwise xor (`bit-xor`)
 - Bitwise or (`bit-or`)
-- Logical and (`&&`, `and`)
+- Logical and (`and`)
 - Logical xor (`xor`)
-- Logical or (`||`, `or`)
+- Logical or (`or`)
 - Assignment operations
 
 ```


### PR DESCRIPTION
I tried to find its position experimentally (with the help of GPT-4), and it suggested the next test. So I placed the `not` before `and`.

```nu
> not true and false
false
> not (true and false)
true
```

I would be glad if anybody could check my conclusions. 