### PR TITLE
fix(lang-guide): IEE-754 -> IEEE-754

### DIFF
--- a/lang-guide/lang-guide.md
+++ b/lang-guide/lang-guide.md
@@ -249,7 +249,7 @@ What it is: Real numeric values using floating point internal arithmetic.
 
 Annotation: `float`
 
-Internally IEE-754 floats with 64 bit precision.
+Internally IEEE-754 floats with 64 bit precision.
 
 Literals with a fractional decimal component are evaluated as `Float`: `0.1`, `3.14159`, `-10.4`
 


### PR DESCRIPTION
Spelling issues in lang-guide/lang-guide.md +252.
IEE-754 should be IEEE-754