### PR TITLE
Documentation for the plugin.msgpackz overhaul

### DIFF
--- a/book/cheat_sheet.md
+++ b/book/cheat_sheet.md
@@ -456,8 +456,8 @@
 > This expression results in error.**
 
 ```nu
-    > const plugin = 'path/­to/­plugin'
-    > register $plugin
+    > const file = 'path/­to/­file.nu'
+    > source $file
 ```
 
 > **a constant variable is immutable value which is fully evaluated at parse-time**

--- a/book/plugins.md
+++ b/book/plugins.md
@@ -32,36 +32,31 @@ If you chose to download the git repository instead, run this when inside the cl
 > cargo install --path .
 ```
 
-This will create a binary file that can be used to register the plugin.
+This will create a binary file that can be used to add the plugin.
 
 Keep in mind that when installing using crates.io, the binary can be saved in different locations depending on how your system is set up. A typical location is in the users's home directory under .cargo/bin.
 
-## Registering a plugin
+## Adding a plugin
 
-To enable an installed plugin, call the [`register`](/commands/docs/register.md) command to tell Nu where to find it. As you do, you'll need to also tell Nushell what encoding the plugin uses.
+To add a plugin to the plugin cache file, call the [`plugin add`](/commands/docs/plugin_add.md) command to tell Nu where to find it.
 
 Please note that the plugin name needs to start with `nu_plugin_`, Nu uses the name prefix to detect plugins.
 
 Linux+macOS:
 
 ```nu
-> register ./my_plugins/nu_plugin_cool
+> plugin add ./my_plugins/nu_plugin_cool
 ```
 
 Windows:
 
 ```nu
-> register .\my_plugins\nu_plugin_cool.exe
+> plugin add .\my_plugins\nu_plugin_cool.exe
 ```
 
-When [`register`](/commands/docs/register.md) is called:
+When [`plugin add`](/commands/docs/plugin_add.md) is called, Nu runs the plugin binary and communicates via the [plugin protocol](plugin_protocol_reference.md) to get the signatures of all of the commands the plugin supports. It then saves information about the plugin, including the command signatures, to the plugin cache file at `$nu.plugin-path` in a custom brotli-compressed MessagePack format. This caching step saves `nu` from having to run all plugins during startup, which could be very slow.
 
-1. Nu launches the plugin, and waits for the plugin to tell Nu which communication encoding it should use
-2. Nu sends it a "Signature" message over stdin
-3. The plugin responds via stdout with a message containing its signature (name, description, arguments, flags, and more)
-4. Nu saves the plugin signature in the file at `$nu.plugin-path`, so registration is persisted across multiple launches
-
-Once registered, the plugin is available as part of your set of commands:
+Once added, the next time `nu` is started, the plugin's commands are available as part of your set of commands:
 
 ```nu
 > help commands | where command_type == "plugin"
@@ -69,7 +64,7 @@ Once registered, the plugin is available as part of your set of commands:
 
 ### Updating a plugin
 
-When updating a plugin, it is important to run `register` again just as above to load the new signatures from the plugin and allow Nu to rewrite them to the plugin file (`$nu.plugin-path`).
+When updating a plugin, it is important to run `plugin add` again just as above to load the new signatures from the plugin and allow Nu to rewrite them to the plugin file (`$nu.plugin-path`).
 
 ## Managing plugins
 

--- a/book/plugins.md
+++ b/book/plugins.md
@@ -139,7 +139,13 @@ For more information on exactly under what circumstances a plugin is considered 
 
 ## Removing a plugin
 
-To remove a plugin, edit the `$nu.plugin-path` file and remove all of the `register` commands referencing the plugin you want to remove, including the signature argument.
+To remove a plugin, call `plugin rm` with the name of the plugin you want to remove. For example, if you previously added the plugin `~/.cargo/bin/nu_plugin_gstat`, its name would be `gstat`. To remove it:
+
+```nushell
+plugin rm gstat
+```
+
+You can check the name of a plugin by running `plugin list`.
 
 ## Examples
 

--- a/book/variables_and_subexpressions.md
+++ b/book/variables_and_subexpressions.md
@@ -76,8 +76,8 @@ To use mutable variables for such behaviour, you are encouraged to use the loops
 A constant variable is an immutable variable that can be fully evaluated at parse-time. These are useful with commands that need to know the value of an argument at parse time, like [`source`](/commands/docs/source.md), [`use`](/commands/docs/use.md) and [`register`](/commands/docs/register.md). See [how nushell code gets run](how_nushell_code_gets_run.md) for a deeper explanation. They are declared using the `const` keyword
 
 ```nu
-const plugin = 'path/to/plugin'
-register $plugin
+const file = 'path/to/file.nu'
+source $file
 ```
 
 ### Variable Names

--- a/contributor-book/plugins.md
+++ b/contributor-book/plugins.md
@@ -16,7 +16,7 @@ For more detailed information about how exactly this communication works, especi
 
 ## Discovery
 
-Nu keeps a registry of plugins at the file system location defined by configuration variable `$nu.plugin-path`. To register a plugin, execute `register <path_to_plugin_executable>` in a Nu shell.
+Nu keeps a registry of plugins known as the ‘plugin cache file’ at the file system location defined by configuration variable `$nu.plugin-path`. To add a plugin, execute `plugin add <path_to_plugin_executable>` in a Nu shell.
 
 ## Launch environment
 
@@ -243,11 +243,12 @@ Once we have finished our plugin, to use it all we need to do is install it.
 
 ```sh
 > cargo install --path .
+> plugin add ~/.cargo/bin/nu_plugin_len # add .exe on Windows
 ```
 
-Once `nu` starts up, it will discover the plugin and register it as a command.
+Once `nu` starts up, it will discover the plugin and add its commands to the scope.
 
-If you're already running `nu` during the installation process of your plugin, ensure you restart `nu` so that it can load and register your plugin or register it manually with `register ./target/release/nu_plugin_len`.
+If you're already running `nu` during the installation process of your plugin, ensure you restart `nu` so that it can load your plugin.
 
 ```
 > nu


### PR DESCRIPTION
Docs for https://github.com/nushell/nushell/pull/12579

Will also document `plugin use` when https://github.com/nushell/nushell/pull/12607 is merged, to fully replace the `register` instructions from before (right now it just suggests restarting `nu`).
