### PR TITLE
Update docs for commands from `nu-std/std/dirs.nu`

### DIFF
--- a/commands/docs/dexit.md
+++ b/commands/docs/dexit.md
@@ -1,0 +1,18 @@
+---
+title: dexit
+categories: |
+  shells
+version: 0.92.0
+shells: |
+  Enters a new shell at the given path.
+usage: |
+  Enters a new shell at the given path.
+---
+
+# `dexit` for [shells](/commands/categories/shells.md)
+
+<div class='command-title'>Leaves the currently active working directory if there are multiple shell paths open.</div>
+
+## Signature
+
+```> dexit```

--- a/commands/docs/enter.md
+++ b/commands/docs/enter.md
@@ -2,16 +2,16 @@
 title: enter
 categories: |
   shells
-version: 0.79.0
+version: 0.92.0
 shells: |
   Enters a new shell at the given path.
 usage: |
   Enters a new shell at the given path.
 ---
 
-# <code>{{ $frontmatter.title }}</code> for shells
+# `enter` for [shells](/commands/categories/shells.md)
 
-<div class='command-title'>{{ $frontmatter.shells }}</div>
+<div class='command-title'>Enters a new shell at the given path.</div>
 
 ## Signature
 

--- a/commands/docs/g.md
+++ b/commands/docs/g.md
@@ -2,16 +2,16 @@
 title: g
 categories: |
   shells
-version: 0.79.0
+version: 0.92.0
 shells: |
   Switch to a given shell, or list all shells if no given shell number.
 usage: |
   Switch to a given shell, or list all shells if no given shell number.
 ---
 
-# <code>{{ $frontmatter.title }}</code> for shells
+# `g` for [shells](/commands/categories/shells.md)
 
-<div class='command-title'>{{ $frontmatter.shells }}</div>
+<div class='command-title'>Switch to a given shell, or list all shells if no given shell number.</div>
 
 ## Signature
 

--- a/commands/docs/n.md
+++ b/commands/docs/n.md
@@ -2,16 +2,16 @@
 title: n
 categories: |
   shells
-version: 0.79.0
+version: 0.92.0
 shells: |
   Switch to the next shell.
 usage: |
   Switch to the next shell.
 ---
 
-# <code>{{ $frontmatter.title }}</code> for shells
+# `n` for [shells](/commands/categories/shells.md)
 
-<div class='command-title'>{{ $frontmatter.shells }}</div>
+<div class='command-title'>Switch to the next shell.</div>
 
 ## Signature
 

--- a/commands/docs/p.md
+++ b/commands/docs/p.md
@@ -2,16 +2,16 @@
 title: p
 categories: |
   shells
-version: 0.79.0
+version: 0.92.0
 shells: |
   Switch to the previous shell.
 usage: |
   Switch to the previous shell.
 ---
 
-# <code>{{ $frontmatter.title }}</code> for shells
+# `p` for [shells](/commands/categories/shells.md)
 
-<div class='command-title'>{{ $frontmatter.shells }}</div>
+<div class='command-title'>Switch to the previous shell.</div>
 
 ## Signature
 

--- a/commands/docs/shells.md
+++ b/commands/docs/shells.md
@@ -2,16 +2,16 @@
 title: shells
 categories: |
   shells
-version: 0.79.0
+version: 0.92.0
 shells: |
   Lists all open shells.
 usage: |
   Lists all open shells.
 ---
 
-# <code>{{ $frontmatter.title }}</code> for shells
+# `shells` for [shells](/commands/categories/shells.md)
 
-<div class='command-title'>{{ $frontmatter.shells }}</div>
+<div class='command-title'>Lists all open shells.</div>
 
 ## Signature
 


### PR DESCRIPTION
Create an entry for `dexit`, which was missing, and add backlinks to the category page to the rest of the commands as well. (Closes https://github.com/nushell/nushell/issues/12642.)