### PR TITLE
add section about the `nuon` crate for `0.93.0`

### DIFF
--- a/blog/2024-04-30-nushell_0_93_0.md
+++ b/blog/2024-04-30-nushell_0_93_0.md
@@ -101,7 +101,7 @@ in the rest of this section, we will build a very simple Rust binary application
 new `nuon` crate works :)
 
 first, let's define some dependencies
-```toml
+```nushell
 cargo add clap --features derive
 cargo add nuon
 ```

--- a/blog/2024-04-30-nushell_0_93_0.md
+++ b/blog/2024-04-30-nushell_0_93_0.md
@@ -80,6 +80,91 @@ Thanks to all the contributors below for helping us making the documentation of 
 | ------------------------------------ | ----------- | ------------------------------------------------------- |
 | [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
 
+## A new crate: `nuon`
+NUON is the NUshell Object Notation, a superset of JSON that allows to store any kind of data.
+
+Until now, the NUON format has been confined to the source base of Nushell only...
+With this release, a new crate is born: `nuon` :partying_face:
+
+`nuon` provides three main objects to play with:
+- the `from_nuon` function that converts a string into a Nushell value, similar to [`from nuon`]
+- the `to_nuon` function that converts a Nushell value back to a string, similar to [`to nuon`]
+- the `ToStyle` enumeration that tells `to_nuon` how the raw string output should look like
+    - raw: the output will be on a single line, similar to `to nuon --raw`
+    - space-based indentation: output will be indented, with a given amount of spaces, similar to
+      `to nuon --indent`
+    - tab-based indentation: output will be indented, with a given amount of tabulations, similar to
+      `to nuon --tabs`
+
+### an example
+in the rest of this section, we will build a very simple Rust binary application to show how this
+new `nuon` crate works :)
+
+first, let's define some dependencies
+```toml
+cargo add clap --features derive
+cargo add nuon
+```
+
+then, we'll use Clap to have a simple and better CLI interface
+```rust
+use clap::{Parser, ValueEnum};
+
+#[derive(ValueEnum, Clone)]
+enum Style {
+    Raw,
+    Spaces,
+    Tabs,
+}
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    /// the input raw NUON value to play with
+    value: String,
+
+    #[arg(short, long)]
+    /// the style to dump the value back to raw NUON
+    style: Option<Style>,
+}
+```
+and, in the `main`, we can parse the CLI arguments
+```rust
+let cli = Cli::parse();
+let style = match cli.style {
+    Some(Style::Raw) | None => nuon::ToStyle::Raw,
+    Some(Style::Spaces) => nuon::ToStyle::Spaces(4),
+    Some(Style::Tabs) => nuon::ToStyle::Tabs(1),
+};
+let input = cli.value;
+```
+
+```rust
+fn main() {
+    // CLI parsing defined above
+
+    // convert the raw NUON input to a Nushell value
+    let value = match nuon::from_nuon(&input, None) {
+        Ok(v) => v,
+        Err(e) => {
+            // ... unless the input is not valid NUON and thus cannot be parsed
+            eprintln!("{}", e);
+            return;
+        }
+    };
+
+    // convert the Nushell value back to NUON, using the style provided as argument
+    let output = nuon::to_nuon(&value, style, None).unwrap()
+
+    // give some output to see what's happening
+    println!("* input:\n{}", input);
+    println!("");
+    println!("* Nushell value:\n{:?}", value);
+    println!("");
+    println!("* NUON output:\n{}", );
+}
+```
+
 ## Our set of commands is evolving [[toc](#table-of-content)]
 As usual, new release rhyms with changes to commands!
 


### PR DESCRIPTION
the full Rust example is
```rust
use clap::{Parser, ValueEnum};

#[derive(ValueEnum, Clone)]
enum Style {
    Raw,
    Spaces,
    Tabs,
}

#[derive(Parser)]
#[command(version, about, long_about = None)]
struct Cli {
    /// the input raw NUON value to play with
    value: String,

    #[arg(short, long)]
    /// the style to dump the value back to raw NUON
    style: Option<Style>,
}

fn main() {
    let cli = Cli::parse();
    let style = match cli.style {
        Some(Style::Raw) | None => nuon::ToStyle::Raw,
        Some(Style::Spaces) => nuon::ToStyle::Spaces(4),
        Some(Style::Tabs) => nuon::ToStyle::Tabs(1),
    };
    let input = cli.value;

    let value = match nuon::from_nuon(&input, None) {
        Ok(v) => v,
        Err(e) => {
            eprintln!("{}", e);
            return;
        }
    };

    println!("* input:\n{}", input);
    println!("");
    println!("* Nushell value:\n{:?}", value);
    println!("");
    println!("* NUON output:\n{}", nuon::to_nuon(&value, style, None).unwrap());
}
```