### PR TITLE
Make clear that `plugin use` is not needed in the config file

### DIFF
--- a/blog/2024-04-30-nushell_0_93_0.md
+++ b/blog/2024-04-30-nushell_0_93_0.md
@@ -24,59 +24,60 @@ The optional dataframe functionality is available by `cargo install nu --feature
 As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
 
 # Table of content
-- [*Themes of this release / New features*](#themes-of-this-release-new-features-toc)
-    - [*Redesigned plugin management commands*](#redesigned-plugin-management-commands-toc)
-    - [*New plugin cache format*](#new-plugin-cache-format-toc)
-    - [*Improved terminal interaction for plugins*](#improved-terminal-interaction-for-plugins-toc)
-    - [Introduction of the Polars Plugin](#introduction-of-the-polars-plugin-toc)
-    - [Dataframes deprecation](#dataframes-deprecation-toc)
-    - [*Lazy record deprecation*](#lazy-record-deprecation-toc)
-    - [*Stricter rules around setting environment variables*](#stricter-rules-around-setting-environment-variables-toc)
-    - [*Improved parsing of input/output types*](#improved-parsing-of-input-output-types-toc)
-    - [*New CLI flag: `--no-newline`*](#new-cli-flag-no-newline-toc)
-    - [*Hall of fame*](#hall-of-fame-toc)
-        - [*Bug fixes*](#bug-fixes-toc)
-        - [*Enhancing the documentation*](#enhancing-the-documentation-toc)
-    - [*Our set of commands is evolving*](#our-set-of-commands-is-evolving-toc)
-        - [*New commands*](#new-commands-toc)
-            - [*`plugin add`*](#plugin-add-toc)
-            - [*`plugin rm`*](#plugin-rm-toc)
-            - [*`plugin use`*](#plugin-use-toc)
-            - [*`from msgpack`*](#from-msgpack-toc)
-            - [*`to msgpack`*](#to-msgpack-toc)
-            - [*`from msgpackz`*](#from-msgpackz-toc)
-            - [*`to msgpackz`*](#to-msgpackz-toc)
-            - [*`metadata set`*](#metadata-set-toc)
-        - [*Changes to existing commands*](#changes-to-existing-commands-toc)
-            - [*`with-env`*](#with-env-toc)
-            - [*`load-env`*](#load-env-toc)
-            - [*`last`*](#last-toc)
-            - [*`drop`*](#drop-toc)
-            - [*`skip`*](#skip-toc)
-            - [*`group-by`*](#group-by-toc)
-            - [*`timeit`*](#timeit-toc)
-            - [*`kill`*](#kill-toc)
-            - [*`each`*](#each-toc)
-            - [*`ls`*](#ls-toc)
-            - [*`du`*](#du-toc)
-            - [*`try`*](#try-toc)
-            - [*`version`*](#version-toc)
-            - [*`into-filesize`*](#into-filesize-toc)
-            - [*`view source`*](#view-source-toc)
-            - [*`grid`*](#grid-toc)
-            - [*`explain`*](#explain-toc)
-        - [*Deprecated commands*](#deprecated-commands-toc)
-            - [*`register`*](#register-toc)
-            - [*`lazy make`*](#lazy-make-toc)
-            - [*`describe --collect-lazyrecords`*](#describe-collect-lazyrecords-toc)
-        - [*Removed commands and flags*](#removed-commands-and-flags-toc)
-            - [*`run external` flags*](#run-external-flags-toc)
-            - [*`commandline` flags*](#commandline-flags-toc)
-    - [*For plugin developers*](#for-plugin-developers-toc)
-        - [*New protocol features*](#new-protocol-features-toc)
-        - [*New engine calls*](#new-engine-calls-toc)
-- [*Breaking changes*](#breaking-changes-toc)
-- [*Full changelog*](#full-changelog-toc)
+
+- [_Themes of this release / New features_](#themes-of-this-release-new-features-toc)
+  - [_Redesigned plugin management commands_](#redesigned-plugin-management-commands-toc)
+  - [_New plugin cache format_](#new-plugin-cache-format-toc)
+  - [_Improved terminal interaction for plugins_](#improved-terminal-interaction-for-plugins-toc)
+  - [Introduction of the Polars Plugin](#introduction-of-the-polars-plugin-toc)
+  - [Dataframes deprecation](#dataframes-deprecation-toc)
+  - [_Lazy record deprecation_](#lazy-record-deprecation-toc)
+  - [_Stricter rules around setting environment variables_](#stricter-rules-around-setting-environment-variables-toc)
+  - [_Improved parsing of input/output types_](#improved-parsing-of-input-output-types-toc)
+  - [_New CLI flag: `--no-newline`_](#new-cli-flag-no-newline-toc)
+  - [_Hall of fame_](#hall-of-fame-toc)
+    - [_Bug fixes_](#bug-fixes-toc)
+    - [_Enhancing the documentation_](#enhancing-the-documentation-toc)
+  - [_Our set of commands is evolving_](#our-set-of-commands-is-evolving-toc)
+    - [_New commands_](#new-commands-toc)
+      - [_`plugin add`_](#plugin-add-toc)
+      - [_`plugin rm`_](#plugin-rm-toc)
+      - [_`plugin use`_](#plugin-use-toc)
+      - [_`from msgpack`_](#from-msgpack-toc)
+      - [_`to msgpack`_](#to-msgpack-toc)
+      - [_`from msgpackz`_](#from-msgpackz-toc)
+      - [_`to msgpackz`_](#to-msgpackz-toc)
+      - [_`metadata set`_](#metadata-set-toc)
+    - [_Changes to existing commands_](#changes-to-existing-commands-toc)
+      - [_`with-env`_](#with-env-toc)
+      - [_`load-env`_](#load-env-toc)
+      - [_`last`_](#last-toc)
+      - [_`drop`_](#drop-toc)
+      - [_`skip`_](#skip-toc)
+      - [_`group-by`_](#group-by-toc)
+      - [_`timeit`_](#timeit-toc)
+      - [_`kill`_](#kill-toc)
+      - [_`each`_](#each-toc)
+      - [_`ls`_](#ls-toc)
+      - [_`du`_](#du-toc)
+      - [_`try`_](#try-toc)
+      - [_`version`_](#version-toc)
+      - [_`into-filesize`_](#into-filesize-toc)
+      - [_`view source`_](#view-source-toc)
+      - [_`grid`_](#grid-toc)
+      - [_`explain`_](#explain-toc)
+    - [_Deprecated commands_](#deprecated-commands-toc)
+      - [_`register`_](#register-toc)
+      - [_`lazy make`_](#lazy-make-toc)
+      - [_`describe --collect-lazyrecords`_](#describe-collect-lazyrecords-toc)
+    - [_Removed commands and flags_](#removed-commands-and-flags-toc)
+      - [_`run external` flags_](#run-external-flags-toc)
+      - [_`commandline` flags_](#commandline-flags-toc)
+  - [_For plugin developers_](#for-plugin-developers-toc)
+    - [_New protocol features_](#new-protocol-features-toc)
+    - [_New engine calls_](#new-engine-calls-toc)
+- [_Breaking changes_](#breaking-changes-toc)
+- [_Full changelog_](#full-changelog-toc)
 
 # Themes of this release / New features [[toc](#table-of-content)]
 
@@ -98,6 +99,8 @@ We now have two commands to replace `register` that break this functionality int
 
 1. [`plugin add`](#plugin-add-toc), a normal command, which runs the plugin to get command signatures and adds them to your `$nu.plugin-file`, replacing any existing plugin definition with the same name
 2. [`plugin use`](#plugin-use-toc), a parser command, which loads the plugin command signatures from your `$nu.plugin-file` and makes them available in scope.
+
+All plugins are still loaded automatically from the plugin registry file at startup, so it is not necessary to add `plugin use` to your config file.
 
 The previous example would now be equivalent to this, at the REPL:
 
@@ -193,6 +196,7 @@ After installing the plugin, simply replace `dfr` with `polars` to adapt your sc
 ### Installation
 
 Installing the Polars plugin follows the same process as other plugins:
+
 ```nushell
 # Install the polars plugin
 > cargo install nu_plugin_polars
@@ -203,6 +207,7 @@ Installing the Polars plugin follows the same process as other plugins:
 # Load it into scope:
 > plugin use polars
 ```
+
 ## Dataframes deprecation [[toc](#table-of-content)]
 
 ::: warning Deprecation warning
@@ -234,6 +239,7 @@ See a full overview of the [breaking changes](#breaking-changes-toc)
 :::
 
 The setting of environment variables via the following ways:
+
 - `$env.VAR_NAME = ...` assignment
 - scopes with the `with-env` command
 - the short hand syntax `FOO=bar command-to-run`
@@ -241,10 +247,11 @@ The setting of environment variables via the following ways:
 
 will now consistently prohibit you from changing a set of special environment variables controlled by Nushell.
 Currently this is the following set (already valid for `$env.` assignment):
+
 - `$env.PWD`
 - `$env.FILE_PWD`
 - `$env.CURRENT_FILE`
-This set may be expanded by future breaking changes to ensure consistent semantics of those special variables
+  This set may be expanded by future breaking changes to ensure consistent semantics of those special variables
 
 Furthermore the `FOO=bar BAZ=bla command` shorthand syntax to set an environment variable for the scope of one command is now stricter.
 It will disallow you from repeating the same environment variable name twice and instead return an error ([#12523](https://github.com/nushell/nushell/pull/12523)).
@@ -322,19 +329,19 @@ Thanks to all the contributors below for helping us solve issues and bugs :pray:
 ### Enhancing the documentation [[toc](#table-of-content)]
 
 Thanks to all the contributors below for helping us making the documentation of Nushell commands better :pray:
-| author                                             | description                                                                  | url                                                     |
+| author | description | url |
 | -------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------- |
-| [@deepanchal](https://github.com/deepanchal)       | fix simple typo in commandline_.rs                                           | [#12387](https://github.com/nushell/nushell/pull/12387) |
-| [@SylvanBrocard](https://github.com/SylvanBrocard) | Update list of supported formats in dfr open error message.                  | [#12408](https://github.com/nushell/nushell/pull/12408) |
-| [@IanManske](https://github.com/IanManske)         | Mention `print` in the `echo` help text                                      | [#12436](https://github.com/nushell/nushell/pull/12436) |
-| [@oornaque](https://github.com/oornaque)           | Fix typo in help stor import                                                 | [#12442](https://github.com/nushell/nushell/pull/12442) |
-| [@KAAtheWiseGit](https://github.com/KAAtheWiseGit) | Fix example wording in `seq date`                                            | [#12665](https://github.com/nushell/nushell/pull/12665) |
-| [@IanManske](https://github.com/IanManske)         | Fix an `into bits` example                                                   | [#12668](https://github.com/nushell/nushell/pull/12668) |
-| [@fdncred](https://github.com/fdncred)             | improve `nu --lsp` command tooltips                                          | [#12589](https://github.com/nushell/nushell/pull/12589) |
-| [@NotTheDr01ds](https://github.com/NotTheDr01ds)   | Fixes #12482 by pointing help links for ndjson to a non-spam source (take 2) | [#12509](https://github.com/nushell/nushell/pull/12509) |
-| [@woosaaahh](https://github.com/woosaaahh)         | Change `cal --week-start` examples + error message                           | [#12597](https://github.com/nushell/nushell/pull/12597) |
-| [@maxim-uvarov](https://github.com/maxim-uvarov)   | add search_term "str extract" to `parse` command                             | [#12600](https://github.com/nushell/nushell/pull/12600) |
-| [@IanManske](https://github.com/IanManske)         | Improve the "input and output are the same file" error text                  | [#12619](https://github.com/nushell/nushell/pull/12619) |
+| [@deepanchal](https://github.com/deepanchal) | fix simple typo in commandline\_.rs | [#12387](https://github.com/nushell/nushell/pull/12387) |
+| [@SylvanBrocard](https://github.com/SylvanBrocard) | Update list of supported formats in dfr open error message. | [#12408](https://github.com/nushell/nushell/pull/12408) |
+| [@IanManske](https://github.com/IanManske) | Mention `print` in the `echo` help text | [#12436](https://github.com/nushell/nushell/pull/12436) |
+| [@oornaque](https://github.com/oornaque) | Fix typo in help stor import | [#12442](https://github.com/nushell/nushell/pull/12442) |
+| [@KAAtheWiseGit](https://github.com/KAAtheWiseGit) | Fix example wording in `seq date` | [#12665](https://github.com/nushell/nushell/pull/12665) |
+| [@IanManske](https://github.com/IanManske) | Fix an `into bits` example | [#12668](https://github.com/nushell/nushell/pull/12668) |
+| [@fdncred](https://github.com/fdncred) | improve `nu --lsp` command tooltips | [#12589](https://github.com/nushell/nushell/pull/12589) |
+| [@NotTheDr01ds](https://github.com/NotTheDr01ds) | Fixes #12482 by pointing help links for ndjson to a non-spam source (take 2) | [#12509](https://github.com/nushell/nushell/pull/12509) |
+| [@woosaaahh](https://github.com/woosaaahh) | Change `cal --week-start` examples + error message | [#12597](https://github.com/nushell/nushell/pull/12597) |
+| [@maxim-uvarov](https://github.com/maxim-uvarov) | add search_term "str extract" to `parse` command | [#12600](https://github.com/nushell/nushell/pull/12600) |
+| [@IanManske](https://github.com/IanManske) | Improve the "input and output are the same file" error text | [#12619](https://github.com/nushell/nushell/pull/12619) |
 
 ## Our set of commands is evolving [[toc](#table-of-content)]
 
@@ -376,6 +383,8 @@ The commands will still remain in scope, but will not be present the next time `
 Loads a plugin from the plugin registry file (default `$nu.plugin-path`) **at parse time**.
 
 This replaces the other part of `register` - actually adding the commands to scope. It does not run the plugin executable, though, it just loads the [previously added](#plugin-add-toc) commands from the registry file.
+
+It is not necessary to add this to your config file to use plugins that are in the registry file that `nu` was started with. Those are all automatically loaded at startup, just as they were before.
 
 #### `from msgpack` [[toc](#table-of-content)]
 
@@ -494,6 +503,7 @@ The new `metadata set` command added in [#12564](https://github.com/nushell/nush
 allows one to modify the metadata of a pipeline/value.
 
 For example, you can set the data source to be `ls`, which will activate coloring using `LS_COLORS`:
+
 ```nushell
 [[name]; [Cargo.lock] [Cargo.toml] [README.md]] | metadata set --datasource-ls
 ```
@@ -553,6 +563,7 @@ To be consistent with `first` and other commands, `last` now errors if the input
 ([#12478](https://github.com/nushell/nushell/pull/12478)).
 
 To suppress the error and return null if an input is empty, wrap `last` in a `try` block:
+
 ```nushell
 [] | try { last }
 ```
@@ -616,10 +627,13 @@ This parameter was removed some time ago, and the signature has been updated in
 
 Instead of a single optional path, the `ls` command now takes a rest argument of paths
 ([#12327](https://github.com/nushell/nushell/pull/12327)). I.e., you can spread a list into `ls`:
+
 ```nushell
 ls ...[directory1 directory2]
 ```
+
 or simply `ls` multiple directories:
+
 ```nushell
 ls directory1 directory2
 ```
@@ -732,194 +746,194 @@ See the [Rust docs for `EngineInterface`](https://docs.rs/nu-plugin/0.93.0/nu_pl
 # Full changelog [[toc](#table-of-content)]
 
 - [devyn](https://github.com/devyn) created
-    - [Fix missing local socket feature](https://github.com/nushell/nushell/pull/12698)
-    - [Split the plugin crate](https://github.com/nushell/nushell/pull/12563)
-    - [Fix inconsistent print behavior](https://github.com/nushell/nushell/pull/12675)
-    - [Add a bit more delay before `ps` calls in plugin persistence tests](https://github.com/nushell/nushell/pull/12673)
-    - [Add plugin error propagation on write/flush](https://github.com/nushell/nushell/pull/12670)
-    - [Msgpack commands](https://github.com/nushell/nushell/pull/12664)
-    - [Rename plugin cache file ⇒ plugin registry file](https://github.com/nushell/nushell/pull/12634)
-    - [Fix (and test) for a deadlock that can happen while waiting for protocol info](https://github.com/nushell/nushell/pull/12633)
-    - [Further improve messages related to error propagation on plugin calls](https://github.com/nushell/nushell/pull/12646)
-    - [Accept filenames in other plugin management commands](https://github.com/nushell/nushell/pull/12639)
-    - [Fix error message propagation on plugin call failure](https://github.com/nushell/nushell/pull/12632)
-    - [Deprecate `register` and add `plugin use`](https://github.com/nushell/nushell/pull/12607)
-    - [Add `ErrSpan` extension trait for `Result`](https://github.com/nushell/nushell/pull/12626)
-    - [update `toolkit register plugins` ⇒ `toolkit add plugins`](https://github.com/nushell/nushell/pull/12613)
-    - [stress_internals: exit(1) on io error](https://github.com/nushell/nushell/pull/12612)
-    - [Overhaul the plugin cache file with a new msgpack+brotli format](https://github.com/nushell/nushell/pull/12579)
-    - [Switch plugin msgpack protocol to named format](https://github.com/nushell/nushell/pull/12580)
-    - [Add an example Nushell plugin written in Nushell itself](https://github.com/nushell/nushell/pull/12574)
-    - [Fix the error output in the python plugin to match LabeledError](https://github.com/nushell/nushell/pull/12575)
-    - [Replace subtraction of Instants and Durations with saturating subtractions](https://github.com/nushell/nushell/pull/12549)
-    - [Improve safety of `get_unchecked_str` in `nu_system::macos`](https://github.com/nushell/nushell/pull/12550)
-    - [Add a panic unwind handler during plugin calls](https://github.com/nushell/nushell/pull/12526)
-    - [Python plugin: remove unnecessary fields from signature](https://github.com/nushell/nushell/pull/12533)
-    - [Local socket mode and foreground terminal control for plugins](https://github.com/nushell/nushell/pull/12448)
-    - [Improve error messages for plugin protocol by removing `#[serde(untagged)]`](https://github.com/nushell/nushell/pull/12510)
-    - [Copy-on-write for record values](https://github.com/nushell/nushell/pull/12305)
-    - [Switch the CI to use macos-13 instead of macos-latest, due to failures](https://github.com/nushell/nushell/pull/12493)
-    - [Isolate tests from user config](https://github.com/nushell/nushell/pull/12437)
-    - [Add --no-newline option to `nu`](https://github.com/nushell/nushell/pull/12410)
-    - [Add `GetSpanContents` engine call](https://github.com/nushell/nushell/pull/12439)
-    - [Use nu-cmd-lang default context for plugin tests](https://github.com/nushell/nushell/pull/12434)
-    - [Fix some of the tests in `tests::shell`](https://github.com/nushell/nushell/pull/12417)
-    - [Add BufWriter to ChildStdin on the plugin interface](https://github.com/nushell/nushell/pull/12419)
-    - [Improve handling of custom values in plugin examples](https://github.com/nushell/nushell/pull/12409)
-    - [Fix deadlock on PluginCustomValue drop](https://github.com/nushell/nushell/pull/12418)
-    - [Fix testing.nu import of std log](https://github.com/nushell/nushell/pull/12392)
-    - [Fix #12391: mkdir uses process startup directory instead of current script directory](https://github.com/nushell/nushell/pull/12394)
-    - [Make drop notification timing for plugin custom values more consistent](https://github.com/nushell/nushell/pull/12341)
+  - [Fix missing local socket feature](https://github.com/nushell/nushell/pull/12698)
+  - [Split the plugin crate](https://github.com/nushell/nushell/pull/12563)
+  - [Fix inconsistent print behavior](https://github.com/nushell/nushell/pull/12675)
+  - [Add a bit more delay before `ps` calls in plugin persistence tests](https://github.com/nushell/nushell/pull/12673)
+  - [Add plugin error propagation on write/flush](https://github.com/nushell/nushell/pull/12670)
+  - [Msgpack commands](https://github.com/nushell/nushell/pull/12664)
+  - [Rename plugin cache file ⇒ plugin registry file](https://github.com/nushell/nushell/pull/12634)
+  - [Fix (and test) for a deadlock that can happen while waiting for protocol info](https://github.com/nushell/nushell/pull/12633)
+  - [Further improve messages related to error propagation on plugin calls](https://github.com/nushell/nushell/pull/12646)
+  - [Accept filenames in other plugin management commands](https://github.com/nushell/nushell/pull/12639)
+  - [Fix error message propagation on plugin call failure](https://github.com/nushell/nushell/pull/12632)
+  - [Deprecate `register` and add `plugin use`](https://github.com/nushell/nushell/pull/12607)
+  - [Add `ErrSpan` extension trait for `Result`](https://github.com/nushell/nushell/pull/12626)
+  - [update `toolkit register plugins` ⇒ `toolkit add plugins`](https://github.com/nushell/nushell/pull/12613)
+  - [stress_internals: exit(1) on io error](https://github.com/nushell/nushell/pull/12612)
+  - [Overhaul the plugin cache file with a new msgpack+brotli format](https://github.com/nushell/nushell/pull/12579)
+  - [Switch plugin msgpack protocol to named format](https://github.com/nushell/nushell/pull/12580)
+  - [Add an example Nushell plugin written in Nushell itself](https://github.com/nushell/nushell/pull/12574)
+  - [Fix the error output in the python plugin to match LabeledError](https://github.com/nushell/nushell/pull/12575)
+  - [Replace subtraction of Instants and Durations with saturating subtractions](https://github.com/nushell/nushell/pull/12549)
+  - [Improve safety of `get_unchecked_str` in `nu_system::macos`](https://github.com/nushell/nushell/pull/12550)
+  - [Add a panic unwind handler during plugin calls](https://github.com/nushell/nushell/pull/12526)
+  - [Python plugin: remove unnecessary fields from signature](https://github.com/nushell/nushell/pull/12533)
+  - [Local socket mode and foreground terminal control for plugins](https://github.com/nushell/nushell/pull/12448)
+  - [Improve error messages for plugin protocol by removing `#[serde(untagged)]`](https://github.com/nushell/nushell/pull/12510)
+  - [Copy-on-write for record values](https://github.com/nushell/nushell/pull/12305)
+  - [Switch the CI to use macos-13 instead of macos-latest, due to failures](https://github.com/nushell/nushell/pull/12493)
+  - [Isolate tests from user config](https://github.com/nushell/nushell/pull/12437)
+  - [Add --no-newline option to `nu`](https://github.com/nushell/nushell/pull/12410)
+  - [Add `GetSpanContents` engine call](https://github.com/nushell/nushell/pull/12439)
+  - [Use nu-cmd-lang default context for plugin tests](https://github.com/nushell/nushell/pull/12434)
+  - [Fix some of the tests in `tests::shell`](https://github.com/nushell/nushell/pull/12417)
+  - [Add BufWriter to ChildStdin on the plugin interface](https://github.com/nushell/nushell/pull/12419)
+  - [Improve handling of custom values in plugin examples](https://github.com/nushell/nushell/pull/12409)
+  - [Fix deadlock on PluginCustomValue drop](https://github.com/nushell/nushell/pull/12418)
+  - [Fix testing.nu import of std log](https://github.com/nushell/nushell/pull/12392)
+  - [Fix #12391: mkdir uses process startup directory instead of current script directory](https://github.com/nushell/nushell/pull/12394)
+  - [Make drop notification timing for plugin custom values more consistent](https://github.com/nushell/nushell/pull/12341)
 - [fdncred](https://github.com/fdncred) created
-    - [fixes a rust-analyzer warning](https://github.com/nushell/nushell/pull/12694)
-    - [restore `query web --as-table` to working order](https://github.com/nushell/nushell/pull/12693)
-    - [update wix to include nu_plugin_polars](https://github.com/nushell/nushell/pull/12687)
-    - [update to latest reedline](https://github.com/nushell/nushell/pull/12644)
-    - [update to latest reedline 455b9a3](https://github.com/nushell/nushell/pull/12630)
-    - [improve `nu --lsp` command tooltips](https://github.com/nushell/nushell/pull/12589)
-    - [add ability to set metadata](https://github.com/nushell/nushell/pull/12564)
-    - [bump nushell to latest reedline](https://github.com/nushell/nushell/pull/12497)
-    - [better logging for shell_integration ansi escapes + better plugin perf logging](https://github.com/nushell/nushell/pull/12494)
-    - [try to be a bit more precise with repl logging](https://github.com/nushell/nushell/pull/12449)
-    - [bump python plugin nushell version](https://github.com/nushell/nushell/pull/12367)
+  - [fixes a rust-analyzer warning](https://github.com/nushell/nushell/pull/12694)
+  - [restore `query web --as-table` to working order](https://github.com/nushell/nushell/pull/12693)
+  - [update wix to include nu_plugin_polars](https://github.com/nushell/nushell/pull/12687)
+  - [update to latest reedline](https://github.com/nushell/nushell/pull/12644)
+  - [update to latest reedline 455b9a3](https://github.com/nushell/nushell/pull/12630)
+  - [improve `nu --lsp` command tooltips](https://github.com/nushell/nushell/pull/12589)
+  - [add ability to set metadata](https://github.com/nushell/nushell/pull/12564)
+  - [bump nushell to latest reedline](https://github.com/nushell/nushell/pull/12497)
+  - [better logging for shell_integration ansi escapes + better plugin perf logging](https://github.com/nushell/nushell/pull/12494)
+  - [try to be a bit more precise with repl logging](https://github.com/nushell/nushell/pull/12449)
+  - [bump python plugin nushell version](https://github.com/nushell/nushell/pull/12367)
 - [maxim-uvarov](https://github.com/maxim-uvarov) created
-    - [add tests to `polars unique`](https://github.com/nushell/nushell/pull/12683)
-    - [add search_term "str extract" to `parse` command](https://github.com/nushell/nushell/pull/12600)
+  - [add tests to `polars unique`](https://github.com/nushell/nushell/pull/12683)
+  - [add search_term "str extract" to `parse` command](https://github.com/nushell/nushell/pull/12600)
 - [hustcer](https://github.com/hustcer) created
-    - [Upgrade hustcer/setup-nu to v3.10 to fix macOS arm64 build errors](https://github.com/nushell/nushell/pull/12681)
+  - [Upgrade hustcer/setup-nu to v3.10 to fix macOS arm64 build errors](https://github.com/nushell/nushell/pull/12681)
 - [IanManske](https://github.com/IanManske) created
-    - [Add deprecation warning to `describe --collect-lazyrecords`](https://github.com/nushell/nushell/pull/12667)
-    - [Make exit code available in `catch` block](https://github.com/nushell/nushell/pull/12648)
-    - [Fix an `into bits` example](https://github.com/nushell/nushell/pull/12668)
-    - [`each` signature fix](https://github.com/nushell/nushell/pull/12666)
-    - [Remove deprecated flags on `run-external`](https://github.com/nushell/nushell/pull/12659)
-    - [Remove deprecated flags on `commandline`](https://github.com/nushell/nushell/pull/12658)
-    - [`nu-cmd-lang` cleanup](https://github.com/nushell/nushell/pull/12609)
-    - [Lazy record deprecation](https://github.com/nushell/nushell/pull/12656)
-    - [Shrink the size of `Expr`](https://github.com/nushell/nushell/pull/12610)
-    - [Improve the "input and output are the same file" error text](https://github.com/nushell/nushell/pull/12619)
-    - [Refactor using `ClosureEval` types](https://github.com/nushell/nushell/pull/12541)
-    - [Make the same file error more likely to appear](https://github.com/nushell/nushell/pull/12601)
-    - [Remove the `Value::Block` case](https://github.com/nushell/nushell/pull/12582)
-    - [Box `ImportPattern` in `Expr`](https://github.com/nushell/nushell/pull/12568)
-    - [Add `ListItem` type for `Expr::List`](https://github.com/nushell/nushell/pull/12529)
-    - [Make `group-by` return errors in closure](https://github.com/nushell/nushell/pull/12508)
-    - [Add `Record::into_columns`](https://github.com/nushell/nushell/pull/12324)
-    - [Fix clippy lint](https://github.com/nushell/nushell/pull/12504)
-    - [Refactor `first` and `last`](https://github.com/nushell/nushell/pull/12478)
-    - [Return value instead of stream from `kill`](https://github.com/nushell/nushell/pull/12480)
-    - [`drop` refactor](https://github.com/nushell/nushell/pull/12479)
-    - [Rename `IoStream` to `OutDest`](https://github.com/nushell/nushell/pull/12433)
-    - [Mention `print` in the `echo` help text](https://github.com/nushell/nushell/pull/12436)
-    - [`explain` refactor](https://github.com/nushell/nushell/pull/12432)
-    - [Prevent panic on date overflow](https://github.com/nushell/nushell/pull/12427)
-    - [Fix merging child stack into parent](https://github.com/nushell/nushell/pull/12426)
-    - [`Range` refactor](https://github.com/nushell/nushell/pull/12405)
-    - [Fix hooks on 0.92.0](https://github.com/nushell/nushell/pull/12383)
+  - [Add deprecation warning to `describe --collect-lazyrecords`](https://github.com/nushell/nushell/pull/12667)
+  - [Make exit code available in `catch` block](https://github.com/nushell/nushell/pull/12648)
+  - [Fix an `into bits` example](https://github.com/nushell/nushell/pull/12668)
+  - [`each` signature fix](https://github.com/nushell/nushell/pull/12666)
+  - [Remove deprecated flags on `run-external`](https://github.com/nushell/nushell/pull/12659)
+  - [Remove deprecated flags on `commandline`](https://github.com/nushell/nushell/pull/12658)
+  - [`nu-cmd-lang` cleanup](https://github.com/nushell/nushell/pull/12609)
+  - [Lazy record deprecation](https://github.com/nushell/nushell/pull/12656)
+  - [Shrink the size of `Expr`](https://github.com/nushell/nushell/pull/12610)
+  - [Improve the "input and output are the same file" error text](https://github.com/nushell/nushell/pull/12619)
+  - [Refactor using `ClosureEval` types](https://github.com/nushell/nushell/pull/12541)
+  - [Make the same file error more likely to appear](https://github.com/nushell/nushell/pull/12601)
+  - [Remove the `Value::Block` case](https://github.com/nushell/nushell/pull/12582)
+  - [Box `ImportPattern` in `Expr`](https://github.com/nushell/nushell/pull/12568)
+  - [Add `ListItem` type for `Expr::List`](https://github.com/nushell/nushell/pull/12529)
+  - [Make `group-by` return errors in closure](https://github.com/nushell/nushell/pull/12508)
+  - [Add `Record::into_columns`](https://github.com/nushell/nushell/pull/12324)
+  - [Fix clippy lint](https://github.com/nushell/nushell/pull/12504)
+  - [Refactor `first` and `last`](https://github.com/nushell/nushell/pull/12478)
+  - [Return value instead of stream from `kill`](https://github.com/nushell/nushell/pull/12480)
+  - [`drop` refactor](https://github.com/nushell/nushell/pull/12479)
+  - [Rename `IoStream` to `OutDest`](https://github.com/nushell/nushell/pull/12433)
+  - [Mention `print` in the `echo` help text](https://github.com/nushell/nushell/pull/12436)
+  - [`explain` refactor](https://github.com/nushell/nushell/pull/12432)
+  - [Prevent panic on date overflow](https://github.com/nushell/nushell/pull/12427)
+  - [Fix merging child stack into parent](https://github.com/nushell/nushell/pull/12426)
+  - [`Range` refactor](https://github.com/nushell/nushell/pull/12405)
+  - [Fix hooks on 0.92.0](https://github.com/nushell/nushell/pull/12383)
 - [merelymyself](https://github.com/merelymyself) created
-    - [make `grid` throw an error when not enough columns](https://github.com/nushell/nushell/pull/12672)
-    - [use abbreviated string instead of debug string for `DatetimeParseError`s](https://github.com/nushell/nushell/pull/12517)
-    - [prevent `select` (negative number) from hanging shell](https://github.com/nushell/nushell/pull/12393)
-    - [Make auto-cd check for permissions](https://github.com/nushell/nushell/pull/12342)
-    - [Make `view source` more robust](https://github.com/nushell/nushell/pull/12359)
-    - [prevent parser from parsing variables as units](https://github.com/nushell/nushell/pull/12378)
+  - [make `grid` throw an error when not enough columns](https://github.com/nushell/nushell/pull/12672)
+  - [use abbreviated string instead of debug string for `DatetimeParseError`s](https://github.com/nushell/nushell/pull/12517)
+  - [prevent `select` (negative number) from hanging shell](https://github.com/nushell/nushell/pull/12393)
+  - [Make auto-cd check for permissions](https://github.com/nushell/nushell/pull/12342)
+  - [Make `view source` more robust](https://github.com/nushell/nushell/pull/12359)
+  - [prevent parser from parsing variables as units](https://github.com/nushell/nushell/pull/12378)
 - [KAAtheWiseGit](https://github.com/KAAtheWiseGit) created
-    - [Fix example wording in `seq date`](https://github.com/nushell/nushell/pull/12665)
+  - [Fix example wording in `seq date`](https://github.com/nushell/nushell/pull/12665)
 - [app/dependabot](https://github.com/app/dependabot) created
-    - [Bump serial_test from 3.0.0 to 3.1.0](https://github.com/nushell/nushell/pull/12638)
-    - [Bump rust-ini from 0.20.0 to 0.21.0](https://github.com/nushell/nushell/pull/12637)
-    - [Bump actions/checkout from 4.1.2 to 4.1.3](https://github.com/nushell/nushell/pull/12635)
-    - [Bump crate-ci/typos from 1.20.9 to 1.20.10](https://github.com/nushell/nushell/pull/12636)
-    - [Bump rmp-serde from 1.1.2 to 1.2.0](https://github.com/nushell/nushell/pull/12547)
-    - [Bump crate-ci/typos from 1.20.7 to 1.20.9](https://github.com/nushell/nushell/pull/12543)
-    - [Bump crate-ci/typos from 1.20.3 to 1.20.7](https://github.com/nushell/nushell/pull/12456)
-    - [Bump similar from 2.4.0 to 2.5.0](https://github.com/nushell/nushell/pull/12375)
-    - [Bump h2 from 0.3.24 to 0.3.26](https://github.com/nushell/nushell/pull/12413)
-    - [Bump rust-embed from 8.2.0 to 8.3.0](https://github.com/nushell/nushell/pull/12374)
-    - [Bump shadow-rs from 0.26.1 to 0.27.1](https://github.com/nushell/nushell/pull/12372)
+  - [Bump serial_test from 3.0.0 to 3.1.0](https://github.com/nushell/nushell/pull/12638)
+  - [Bump rust-ini from 0.20.0 to 0.21.0](https://github.com/nushell/nushell/pull/12637)
+  - [Bump actions/checkout from 4.1.2 to 4.1.3](https://github.com/nushell/nushell/pull/12635)
+  - [Bump crate-ci/typos from 1.20.9 to 1.20.10](https://github.com/nushell/nushell/pull/12636)
+  - [Bump rmp-serde from 1.1.2 to 1.2.0](https://github.com/nushell/nushell/pull/12547)
+  - [Bump crate-ci/typos from 1.20.7 to 1.20.9](https://github.com/nushell/nushell/pull/12543)
+  - [Bump crate-ci/typos from 1.20.3 to 1.20.7](https://github.com/nushell/nushell/pull/12456)
+  - [Bump similar from 2.4.0 to 2.5.0](https://github.com/nushell/nushell/pull/12375)
+  - [Bump h2 from 0.3.24 to 0.3.26](https://github.com/nushell/nushell/pull/12413)
+  - [Bump rust-embed from 8.2.0 to 8.3.0](https://github.com/nushell/nushell/pull/12374)
+  - [Bump shadow-rs from 0.26.1 to 0.27.1](https://github.com/nushell/nushell/pull/12372)
 - [WindSoilder](https://github.com/WindSoilder) created
-    - [Avoid panic when pipe a variable to a custom command which have recursive call](https://github.com/nushell/nushell/pull/12491)
-    - [set the type of default NU_LIB_DIRS and NU_PLUGIN_DIRS to list\<string\>](https://github.com/nushell/nushell/pull/12573)
-    - [Don't allow skip on external stream](https://github.com/nushell/nushell/pull/12559)
-    - [Unify `working_set.error` usage.](https://github.com/nushell/nushell/pull/12531)
-    - [remove useless path.rs](https://github.com/nushell/nushell/pull/12534)
-    - [making `ls` and `du` supports rest parameters.](https://github.com/nushell/nushell/pull/12327)
-    - [Force timeit to not capture stdout](https://github.com/nushell/nushell/pull/12465)
+  - [Avoid panic when pipe a variable to a custom command which have recursive call](https://github.com/nushell/nushell/pull/12491)
+  - [set the type of default NU_LIB_DIRS and NU_PLUGIN_DIRS to list\<string\>](https://github.com/nushell/nushell/pull/12573)
+  - [Don't allow skip on external stream](https://github.com/nushell/nushell/pull/12559)
+  - [Unify `working_set.error` usage.](https://github.com/nushell/nushell/pull/12531)
+  - [remove useless path.rs](https://github.com/nushell/nushell/pull/12534)
+  - [making `ls` and `du` supports rest parameters.](https://github.com/nushell/nushell/pull/12327)
+  - [Force timeit to not capture stdout](https://github.com/nushell/nushell/pull/12465)
 - [stormasm](https://github.com/stormasm) created
-    - [bump reedline to latest commit point on main](https://github.com/nushell/nushell/pull/12621)
+  - [bump reedline to latest commit point on main](https://github.com/nushell/nushell/pull/12621)
 - [sholderbach](https://github.com/sholderbach) created
-    - [Update `ratatui` to deduplicate `syn` in build](https://github.com/nushell/nushell/pull/12606)
-    - [Small refactor in `cal`](https://github.com/nushell/nushell/pull/12604)
-    - [Update crate feature flags](https://github.com/nushell/nushell/pull/12566)
-    - [Impl `FusedIterator` for record iterators](https://github.com/nushell/nushell/pull/12542)
-    - [Minor housekeeping in the parser](https://github.com/nushell/nushell/pull/12540)
-    - [Improve `with-env` robustness](https://github.com/nushell/nushell/pull/12523)
-    - [Disallow setting the `PWD` via `load-env` input](https://github.com/nushell/nushell/pull/12522)
-    - [Also use old mac workers for `plugins` job](https://github.com/nushell/nushell/pull/12495)
-    - [Bump version to `0.92.3`](https://github.com/nushell/nushell/pull/12476)
-    - [Bump our Rust version to stable](https://github.com/nushell/nushell/pull/12471)
-    - [Update MSRV following `rust-toolchain.toml`](https://github.com/nushell/nushell/pull/12455)
-    - [Implement `De`-/`Serialize` for `Record` manually](https://github.com/nushell/nushell/pull/12365)
-    - [Tweak release workflow after `0.92.1` lessons](https://github.com/nushell/nushell/pull/12401)
-    - [Bump version to `0.92.2`](https://github.com/nushell/nushell/pull/12402)
-    - [Bump version to `0.92.1`](https://github.com/nushell/nushell/pull/12380)
-    - [Bump `crate-ci/typos` and fix typos](https://github.com/nushell/nushell/pull/12381)
-    - [Make default config conservative about clipboard](https://github.com/nushell/nushell/pull/12385)
-    - [Bump version for `0.92.0` release](https://github.com/nushell/nushell/pull/12349)
+  - [Update `ratatui` to deduplicate `syn` in build](https://github.com/nushell/nushell/pull/12606)
+  - [Small refactor in `cal`](https://github.com/nushell/nushell/pull/12604)
+  - [Update crate feature flags](https://github.com/nushell/nushell/pull/12566)
+  - [Impl `FusedIterator` for record iterators](https://github.com/nushell/nushell/pull/12542)
+  - [Minor housekeeping in the parser](https://github.com/nushell/nushell/pull/12540)
+  - [Improve `with-env` robustness](https://github.com/nushell/nushell/pull/12523)
+  - [Disallow setting the `PWD` via `load-env` input](https://github.com/nushell/nushell/pull/12522)
+  - [Also use old mac workers for `plugins` job](https://github.com/nushell/nushell/pull/12495)
+  - [Bump version to `0.92.3`](https://github.com/nushell/nushell/pull/12476)
+  - [Bump our Rust version to stable](https://github.com/nushell/nushell/pull/12471)
+  - [Update MSRV following `rust-toolchain.toml`](https://github.com/nushell/nushell/pull/12455)
+  - [Implement `De`-/`Serialize` for `Record` manually](https://github.com/nushell/nushell/pull/12365)
+  - [Tweak release workflow after `0.92.1` lessons](https://github.com/nushell/nushell/pull/12401)
+  - [Bump version to `0.92.2`](https://github.com/nushell/nushell/pull/12402)
+  - [Bump version to `0.92.1`](https://github.com/nushell/nushell/pull/12380)
+  - [Bump `crate-ci/typos` and fix typos](https://github.com/nushell/nushell/pull/12381)
+  - [Make default config conservative about clipboard](https://github.com/nushell/nushell/pull/12385)
+  - [Bump version for `0.92.0` release](https://github.com/nushell/nushell/pull/12349)
 - [ayax79](https://github.com/ayax79) created
-    - [Added commands for working with the plugin cache.](https://github.com/nushell/nushell/pull/12576)
-    - [Removed the polars dtypes command](https://github.com/nushell/nushell/pull/12577)
-    - [Only mark collected dataframes as from_lazy=false when collect is called from the collect command.](https://github.com/nushell/nushell/pull/12571)
-    - [Upgrading nu-cmd-dataframe to polars 0.39](https://github.com/nushell/nushell/pull/12554)
-    - [Upgrading nu_plugin_polars to polars 0.39.1](https://github.com/nushell/nushell/pull/12551)
-    - [Fixing NuLazyFrame/NuDataFrame conversion issues](https://github.com/nushell/nushell/pull/12538)
-    - [Cleaning up to_pipe_line_data and cache_and_to_value, making them part of CustomValueSupport](https://github.com/nushell/nushell/pull/12528)
-    - [Ensure that lazy frames converted via to-lazy are not converted back to eager frames later in the pipeline.](https://github.com/nushell/nushell/pull/12525)
-    - [Added a PluginTest method that will call custom_value_to_base_value](https://github.com/nushell/nushell/pull/12502)
-    - [Two consecutive calls to into-lazy should not fail](https://github.com/nushell/nushell/pull/12505)
-    - [Polars 0.38 upgrade](https://github.com/nushell/nushell/pull/12506)
-    - [Ensure that two columns named index don't exist when converting a Dataframe to a nu Value.](https://github.com/nushell/nushell/pull/12501)
-    - [Handle relative paths correctly on polars to-(parquet|jsonl|arrow|etc) commands](https://github.com/nushell/nushell/pull/12486)
-    - [Added a short flag -c to polars append --col](https://github.com/nushell/nushell/pull/12487)
-    - [displaying span information, creation time, and size with polars ls](https://github.com/nushell/nushell/pull/12472)
-    - [Showing full help when running the polars command](https://github.com/nushell/nushell/pull/12462)
-    - [Move dataframes support to a plugin](https://github.com/nushell/nushell/pull/12220)
-    - [Added let command to PluginTest](https://github.com/nushell/nushell/pull/12431)
+  - [Added commands for working with the plugin cache.](https://github.com/nushell/nushell/pull/12576)
+  - [Removed the polars dtypes command](https://github.com/nushell/nushell/pull/12577)
+  - [Only mark collected dataframes as from_lazy=false when collect is called from the collect command.](https://github.com/nushell/nushell/pull/12571)
+  - [Upgrading nu-cmd-dataframe to polars 0.39](https://github.com/nushell/nushell/pull/12554)
+  - [Upgrading nu_plugin_polars to polars 0.39.1](https://github.com/nushell/nushell/pull/12551)
+  - [Fixing NuLazyFrame/NuDataFrame conversion issues](https://github.com/nushell/nushell/pull/12538)
+  - [Cleaning up to_pipe_line_data and cache_and_to_value, making them part of CustomValueSupport](https://github.com/nushell/nushell/pull/12528)
+  - [Ensure that lazy frames converted via to-lazy are not converted back to eager frames later in the pipeline.](https://github.com/nushell/nushell/pull/12525)
+  - [Added a PluginTest method that will call custom_value_to_base_value](https://github.com/nushell/nushell/pull/12502)
+  - [Two consecutive calls to into-lazy should not fail](https://github.com/nushell/nushell/pull/12505)
+  - [Polars 0.38 upgrade](https://github.com/nushell/nushell/pull/12506)
+  - [Ensure that two columns named index don't exist when converting a Dataframe to a nu Value.](https://github.com/nushell/nushell/pull/12501)
+  - [Handle relative paths correctly on polars to-(parquet|jsonl|arrow|etc) commands](https://github.com/nushell/nushell/pull/12486)
+  - [Added a short flag -c to polars append --col](https://github.com/nushell/nushell/pull/12487)
+  - [displaying span information, creation time, and size with polars ls](https://github.com/nushell/nushell/pull/12472)
+  - [Showing full help when running the polars command](https://github.com/nushell/nushell/pull/12462)
+  - [Move dataframes support to a plugin](https://github.com/nushell/nushell/pull/12220)
+  - [Added let command to PluginTest](https://github.com/nushell/nushell/pull/12431)
 - [amtoine](https://github.com/amtoine) created
-    - [fix typo in the documentation of `nuon::ToStyle`](https://github.com/nushell/nushell/pull/12608)
-    - [add "to nuon" enumeration of possible styles](https://github.com/nushell/nushell/pull/12591)
-    - [create `nuon` crate from `from nuon` and `to nuon`](https://github.com/nushell/nushell/pull/12553)
-    - [fix std log](https://github.com/nushell/nushell/pull/12470)
+  - [fix typo in the documentation of `nuon::ToStyle`](https://github.com/nushell/nushell/pull/12608)
+  - [add "to nuon" enumeration of possible styles](https://github.com/nushell/nushell/pull/12591)
+  - [create `nuon` crate from `from nuon` and `to nuon`](https://github.com/nushell/nushell/pull/12553)
+  - [fix std log](https://github.com/nushell/nushell/pull/12470)
 - [woosaaahh](https://github.com/woosaaahh) created
-    - [Change `cal --week-start` examples + error message](https://github.com/nushell/nushell/pull/12597)
+  - [Change `cal --week-start` examples + error message](https://github.com/nushell/nushell/pull/12597)
 - [poliorcetics](https://github.com/poliorcetics) created
-    - [Ab/version details](https://github.com/nushell/nushell/pull/12593)
+  - [Ab/version details](https://github.com/nushell/nushell/pull/12593)
 - [YizhePKU](https://github.com/YizhePKU) created
-    - [Fix circular source causing Nushell to crash](https://github.com/nushell/nushell/pull/12262)
+  - [Fix circular source causing Nushell to crash](https://github.com/nushell/nushell/pull/12262)
 - [TheLostLambda](https://github.com/TheLostLambda) created
-    - [fix(shell_integration): set window title on startup](https://github.com/nushell/nushell/pull/12569)
+  - [fix(shell_integration): set window title on startup](https://github.com/nushell/nushell/pull/12569)
 - [schrieveslaach](https://github.com/schrieveslaach) created
-    - [Set Up Config in LSP Mode](https://github.com/nushell/nushell/pull/12454)
+  - [Set Up Config in LSP Mode](https://github.com/nushell/nushell/pull/12454)
 - [NotTheDr01ds](https://github.com/NotTheDr01ds) created
-    - [Fixes #12482 by pointing help links for ndjson to a non-spam source (take 2)](https://github.com/nushell/nushell/pull/12509)
+  - [Fixes #12482 by pointing help links for ndjson to a non-spam source (take 2)](https://github.com/nushell/nushell/pull/12509)
 - [texastoland](https://github.com/texastoland) created
-    - [Lex whitespace in input-output types.](https://github.com/nushell/nushell/pull/12339)
-    - [Ensure `currently_parsed_cwd` is set for config files](https://github.com/nushell/nushell/pull/12338)
+  - [Lex whitespace in input-output types.](https://github.com/nushell/nushell/pull/12339)
+  - [Ensure `currently_parsed_cwd` is set for config files](https://github.com/nushell/nushell/pull/12338)
 - [singh-priyank](https://github.com/singh-priyank) created
-    - [Fix negative value file size for "into filesize" (issue #12396)](https://github.com/nushell/nushell/pull/12443)
+  - [Fix negative value file size for "into filesize" (issue #12396)](https://github.com/nushell/nushell/pull/12443)
 - [oornaque](https://github.com/oornaque) created
-    - [Fix typo in help stor import](https://github.com/nushell/nushell/pull/12442)
+  - [Fix typo in help stor import](https://github.com/nushell/nushell/pull/12442)
 - [ysthakur](https://github.com/ysthakur) created
-    - [Don't check if stderr empty in test_xdg_config_symlink](https://github.com/nushell/nushell/pull/12435)
-    - [Fix #12416 by canonicalizing XDG_CONFIG_HOME before comparing to config_dir()](https://github.com/nushell/nushell/pull/12420)
+  - [Don't check if stderr empty in test_xdg_config_symlink](https://github.com/nushell/nushell/pull/12435)
+  - [Fix #12416 by canonicalizing XDG_CONFIG_HOME before comparing to config_dir()](https://github.com/nushell/nushell/pull/12420)
 - [friaes](https://github.com/friaes) created
-    - [Fix nushell#10591: encode returns error with utf-16le and utf-16be encodings (nushell#10591)](https://github.com/nushell/nushell/pull/12411)
+  - [Fix nushell#10591: encode returns error with utf-16le and utf-16be encodings (nushell#10591)](https://github.com/nushell/nushell/pull/12411)
 - [eopb](https://github.com/eopb) created
-    - [Fix stop suggesting `--trash` when already enabled (issue #12361)](https://github.com/nushell/nushell/pull/12362)
+  - [Fix stop suggesting `--trash` when already enabled (issue #12361)](https://github.com/nushell/nushell/pull/12362)
 - [SylvanBrocard](https://github.com/SylvanBrocard) created
-    - [Update list of supported formats in dfr open error message.](https://github.com/nushell/nushell/pull/12408)
+  - [Update list of supported formats in dfr open error message.](https://github.com/nushell/nushell/pull/12408)
 - [deepanchal](https://github.com/deepanchal) created
-    - [fix simple typo in commandline_.rs](https://github.com/nushell/nushell/pull/12387)
+  - [fix simple typo in commandline\_.rs](https://github.com/nushell/nushell/pull/12387)
 - [kubouch](https://github.com/kubouch) created
-    - [Add missing crate description to nu-plugin-test-support](https://github.com/nushell/nushell/pull/12368)
-    - [Bump reedline to 0.31.0](https://github.com/nushell/nushell/pull/12366)
+  - [Add missing crate description to nu-plugin-test-support](https://github.com/nushell/nushell/pull/12368)
+  - [Bump reedline to 0.31.0](https://github.com/nushell/nushell/pull/12366)

--- a/book/plugins.md
+++ b/book/plugins.md
@@ -68,6 +68,8 @@ You can also immediately reload a plugin in the current session by calling `plug
 > plugin use cool
 ```
 
+It is not necessary to add `plugin use` to your config file. All previously added plugins are automatically loaded at startup.
+
 Note that `plugin use` is a parser keyword, so when evaluating a script, it will be evaluated first. This means that while you can execute `plugin add` and then `plugin use` at the REPL on separate lines, you can't do this in a single script. If you need to run `nu` with a specific plugin or set of plugins without preparing a cache file, you can pass the `--plugins` option to `nu` with a list of plugin executable files:
 
 ```nu


### PR DESCRIPTION
At least one user on Discord found this surprising, as the `use` command for modules generally does need to be in the config file. Be more clear that it isn't.
