### PR TITLE
Warn about Windows Installer on the 0.93.0 release notes

### DIFF
--- a/blog/2024-04-30-nushell_0_93_0.md
+++ b/blog/2024-04-30-nushell_0_93_0.md
@@ -24,11 +24,7 @@ The optional dataframe functionality is available by `cargo install nu --feature
 ::: warning Note for Windows users
 During the release we had to change our Windows installer to install to the user profile rather than the system program files directory. When upgrading from 0.92.2 or earlier, we advise that you uninstall the package and then reinstall it. We do not recommend using `winget upgrade` for this release.
 
-If you end up with two versions installed in WinGet, you can remove the previous one using:
-
-```sh
-winget uninstall --name nu --version 0.92.2
-```
+If you end up with two versions installed, you must remove it from Apps » Installed Apps in the Windows settings. WinGet will not be able to remove the duplicate version.
 :::
 
 As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.

--- a/blog/2024-04-30-nushell_0_93_0.md
+++ b/blog/2024-04-30-nushell_0_93_0.md
@@ -21,6 +21,16 @@ Nu 0.93.0 is available as [pre-built binaries](https://github.com/nushell/nushel
 The optional dataframe functionality is available by `cargo install nu --features=dataframe`.
 :::
 
+::: warning Note for Windows users
+During the release we had to change our Windows installer to install to the user profile rather than the system program files directory. When upgrading from 0.92.2 or earlier, we advise that you uninstall the package and then reinstall it. We do not recommend using `winget upgrade` for this release.
+
+If you end up with two versions installed in WinGet, you can remove the previous one using:
+
+```sh
+winget uninstall --name nu --version 0.92.2
+```
+:::
+
 As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
 
 # Table of content


### PR DESCRIPTION
Some users are confused that Nushell installed again to their user profile, because we never mentioned it (as we changed it during release). Clear this up.
