### PR TITLE
Fix Keychain instructions in ssh_agent.md

### DIFF
--- a/cookbook/ssh_agent.md
+++ b/cookbook/ssh_agent.md
@@ -58,9 +58,9 @@ do --env {
 load-env (
     keychain --eval --quiet <your ssh keys, eg. id_ed25519>
     | lines
+    | where not ($it | is-empty)
     | split column ";"
     | get column1
-    | first 2
     | split column "="
     | rename name value
     | reduce -f {} {|it, acc| $acc | upsert $it.name $it.value }

--- a/cookbook/ssh_agent.md
+++ b/cookbook/ssh_agent.md
@@ -55,16 +55,14 @@ do --env {
 ### [Keychain](https://www.funtoo.org/Funtoo:Keychain)
 
 ```nushell
-load-env (
-    keychain --eval --quiet <your ssh keys, eg. id_ed25519>
+keychain --eval --quiet <your ssh keys, eg. id_ed25519>
     | lines
     | where not ($it | is-empty)
-    | split column ";"
-    | get column1
-    | split column "="
-    | rename name value
-    | reduce -f {} {|it, acc| $acc | upsert $it.name $it.value }
-    )
+    | parse "{k}={v}; export {k2};"
+    | select k v
+    | transpose --header-row
+    | into record
+    | load-env
 ```
 
 ## Non-nushell workarounds


### PR DESCRIPTION
Currently, the Keychain instructions in the cookbook don't work if you're trying to use GPG and SSH. The instructions assumes you're only using SSH.

With this change, it now removes the empty lines and uses the remaining ones, instead of only using the first 2.

Imo, ideally the page should also mention GPG. But my knowledge is superficial in this matter so I'll leave it to others.