### PR TITLE
fix: wrong result in an example from 'lang-guide'

### DIFF
--- a/lang-guide/lang-guide.md
+++ b/lang-guide/lang-guide.md
@@ -152,7 +152,7 @@ if $q {
   $x = 'false'
 }
 $x
-# =>'true' a string
+# =>'false' a string
 ```
 
 #### Example 2:


### PR DESCRIPTION
[Lang Ref Guide > Basic Types > Any > Example 1](https://www.nushell.sh/lang-guide/lang-guide.html#example-1)

The result in the example is `'true'` but the right value is `'false'`