### PR TITLE
Fix typo in C#/PowerShell examples

### DIFF
--- a/book/nushell_map.md
+++ b/book/nushell_map.md
@@ -27,7 +27,7 @@ Note: this table assumes Nu 0.43 or later.
 | group-by               | group by                      | GroupBy, group                                       | Group-Object, group                        |                                                 |
 | help                   | sp_help                       |                                                      | Get-Help, help, man                        | man                                             |
 | history                |                               |                                                      | Get-History, history                       | history                                         |
-| is-empty               | is null                       | String.InNullOrEmpty                                 | String.InNullOrEmpty                       |                                                 |
+| is-empty               | is null                       | String.IsNullOrEmpty                                 | String.IsNullOrEmpty                       |                                                 |
 | kill                   |                               |                                                      | Stop-Process, kill                         | kill                                            |
 | last                   |                               | Last, LastOrDefault                                  | Select-Object -Last                        | tail                                            |
 | length                 | count                         | Count                                                | Measure-Object, measure                    | wc                                              |


### PR DESCRIPTION
`InNullOrEmpty` -> `IsNullOrEmpty`