### PR TITLE
Corrections to `Operators precedence` chapter

### DIFF
--- a/book/operators.md
+++ b/book/operators.md
@@ -50,11 +50,11 @@ Operations are evaluated in the following order (from highest precedence to lowe
 - Bitwise and (`bit-and`)
 - Bitwise xor (`bit-xor`)
 - Bitwise or (`bit-or`)
-- Logical not (`not`)
 - Logical and (`and`)
 - Logical xor (`xor`)
 - Logical or (`or`)
 - Assignment operations
+- Logical not (`not`)
 
 ```
 > 3 * (1 + 2)

--- a/book/operators.md
+++ b/book/operators.md
@@ -41,7 +41,7 @@ Parentheses can be used for grouping to specify evaluation order or for calling 
 
 The precedence order of operations can be found using the command: `help operators | sort-by precedence -r`
 
-Article form of the order (from highest to lowest precedence):
+The order of the operators in article form (from highest to lowest precedence):
 
 - Parentheses (`()`)
 - Exponentiation/Power (`**`)

--- a/book/operators.md
+++ b/book/operators.md
@@ -39,7 +39,9 @@ Parentheses can be used for grouping to specify evaluation order or for calling 
 
 ## Order of Operations
 
-Operations are evaluated in the following order (from highest precedence to lowest):
+The precedence order of operations can be found using the command: `help operators | sort-by precedence -r`
+
+Article form of the order (from highest to lowest precedence):
 
 - Parentheses (`()`)
 - Exponentiation/Power (`**`)

--- a/book/operators.md
+++ b/book/operators.md
@@ -39,9 +39,9 @@ Parentheses can be used for grouping to specify evaluation order or for calling 
 
 ## Order of Operations
 
-The precedence order of operations can be found using the command: `help operators | sort-by precedence -r`
+To understand the precedence of operations, you can run the command: `help operators | sort-by precedence -r`.
 
-The order of the operators in article form (from highest to lowest precedence):
+Presented in descending order of precedence, the article details the operations as follows:
 
 - Parentheses (`()`)
 - Exponentiation/Power (`**`)


### PR DESCRIPTION
There was a mistake with the order of the `not` operator. It has been fixed, and information about the command `help operators | sort-by precedence -r` has been added.

P.S. I'm not a native English speaker. Even though I have consulted with ChatGPT several times, any corrections from native English speakers are welcome!