### PR TITLE
Fix ru link in configuration file

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -76,7 +76,7 @@ export default defineUserConfig({
       title: 'Nushell',
       description: 'Um novo tipo de shell.',
     },
-    '/ru': {
+    '/ru/': {
       lang: 'ru-RU',
       title: 'Nushell',
       description: 'Новый тип оболочки.',


### PR DESCRIPTION
Currently, on [nushell.sh](https://nushell.sh), using the dropdown menu and clicking ru-RU redirects you to [nushell.sh/ru.html](https://nushell.sh/ru.html) which results in a 404 page.

This PR updates the configuration file, by appending the path value for the Russian locale `/ru/`.

This also fixes the text displayed on the dropdown as well. 

Hope this helps 😄 