### PR TITLE
Delete wrong vi motion command `d`

### DIFF
--- a/book/line_editor.md
+++ b/book/line_editor.md
@@ -86,7 +86,6 @@ Vi Normal motions
 | Key | motion            |
 | --- | ----------------- |
 | w   | Word              |
-| d   | Line end          |
 | 0   | Line start        |
 | $   | Line end          |
 | f   | Right until char  |


### PR DESCRIPTION
There is no Line End motion implemented for `d` in https://github.com/nushell/reedline/blob/main/src/edit_mode/vi/motion.rs

I looked to see if three are other characters defined for Line End. `$` is already listed. No other keybindings defined for `d`. Hence deleting from the list in the book.