### PR TITLE
update testing doc

### DIFF
--- a/book/testing.md
+++ b/book/testing.md
@@ -116,7 +116,7 @@ Now that we are able to write tests by calling commands from `std assert`, it wo
 In this first case, we will assume that the code you are trying to test is part of a [Nupm] package.
 
 In that case, it is as easy as following the following steps
-- create a `tests/` directory next to the `nupm.nuon` package file of your pacakge
+- create a `tests/` directory next to the `nupm.nuon` package file of your package
 - make the `tests/` directory a valid module by adding a `mod.nu` file into it
 - write commands inside `tests/`
 - call `nupm test`

--- a/book/testing.md
+++ b/book/testing.md
@@ -1,60 +1,5 @@
 # Testing your Nushell code
 
-To ensure that your code works as expected, you can use the [testing module](https://github.com/nushell/nushell/blob/main/crates/nu-std/testing.nu).
-
-## Quick start
-
-Download the [testing module](https://raw.githubusercontent.com/nushell/nushell/main/crates/nu-std/testing.nu) and save it as `testing.nu` in the folder with your project.
-
-Have a file, called `test_math.nu`:
-
-```nu
-use std assert
-
-#[test]
-def test_addition [] {
-    assert equal (1 + 2) 3
-}
-
-#[test]
-#[ignore]
-def test_skip [] {
-    # this won't be run
-}
-
-#[test]
-def test_failing [] {
-    assert false "This is just for testing"
-}
-```
-
-Run the tests:
-
-```nu
-❯ use testing.nu run-tests
-❯ run-tests
-INF|2023-04-12T10:42:29.099|Running tests in test_math
-Error:
-  × This is just for testing
-    ╭─[C:\wip\test_math.nu:13:1]
- 13 │ def test_failing [] {
- 14 │     assert false "This is just for testing"
-    ·            ──┬──
-    ·              ╰── It is not true.
- 15 │ }
-    ╰────
-
-
-WRN|2023-04-12T10:42:31.086|Test case test_skip is skipped
-Error:
-  × some tests did not pass (see complete errors above):
-  │
-  │       test_math test_addition
-  │     ⨯ test_math test_failing
-  │     s test_math test_skip
-  │
-```
-
 ## Assert commands
 
 The foundation for every assertion is the `std assert` command. If the condition is not true, it makes an error. For example:
@@ -136,31 +81,4 @@ Error:
    ·             ─┬
    ·              ╰── 13 is not an even number
    ╰────
-```
-
-## Test modules & test cases
-
-The naming convention for test modules is `test_<your_module>.nu` and `test_<test name>` for test cases.
-
-In order for a function to be recognized as a test by the test runner it needs to be annotated with `#[test]`.
-
-The following annotations are supported by the test runner:
-
-- test - test case to be executed during test run
-- test-skip - test case to be skipped during test run
-- before-all - function to run at the beginning of test run. Returns a global context record that is piped into every test function
-- before-each - function to run before every test case. Returns a per-test context record that is merged with global context and piped into test functions
-- after-each - function to run after every test case. Receives the context record just like the test cases
-- after-all - function to run after all test cases have been executed. Receives the global context record
-
-The standard library itself is tested with this framework, so you can find many examples in the [Nushell repository](https://github.com/nushell/nushell/blob/main/crates/nu-std/tests/).
-
-## Setting verbosity
-
-The `testing.nu` module uses the `log` commands from the standard library to display information, so you can set `NU_LOG_LEVEL` if you want more or less details:
-
-```nu
-❯ use testing.nu run-tests
-❯ NU_LOG_LEVEL=DEBUG run-tests
-❯ NU_LOG_LEVEL=WARNING run-tests
 ```

--- a/book/testing.md
+++ b/book/testing.md
@@ -105,3 +105,64 @@ Error:
    ·              ╰── 13 is not an even number
    ╰────
 ```
+
+## Running the tests
+
+Now that we are able to write tests by calling commands from `std assert`, it would be great to be able to run them and see our tests fail when there is an issue and pass when everything is correct :)
+
+
+### Nupm package
+
+In this first case, we will assume that the code you are trying to test is part of a [Nupm] package.
+
+In that case, it is as easy as following the following steps
+- create a `tests/` directory next to the `nupm.nuon` package file of your pacakge
+- make the `tests/` directory a valid module by adding a `mod.nu` file into it
+- write commands inside `tests/`
+- call `nupm test`
+
+The convention is that any command fully exported from the `tests` module will be run as a test, e.g.
+- `export def some-test` in `tests/mod.nu` will run
+- `def just-an-internal-cmd` in `tests/mod.nu` will NOT run
+- `export def another-test` in `tests/spam.nu` will run if and only if there is something like `export use spam.nu *` in `tests/mod.nu`
+
+
+### Standalone tests
+
+If your Nushell script or module is not part of a [Nupm] package, the simplest way is to write tests in standalone scripts and then call them, either from a `Makefile` or in a CI:
+
+Let's say we have a simple `math.nu` module which contains a simple Fibonacci command:
+```nushell
+# `fib n` is the n-th Fibonacci number
+export def fib [n: int] [ nothing -> int ] {
+    if $n == 0 {
+        return 0
+    } else if $n == 1 {
+        return 1
+    }
+
+    (fib ($n - 1)) + (fib ($n - 2))
+}
+```
+then a test script called `tests.nu` could look like
+```nushell
+use math.nu fib
+use std assert
+
+for t in [
+    [input, expected];
+    [0, 0],
+    [1, 1],
+    [2, 1],
+    [3, 2],
+    [4, 3],
+    [5, 5],
+    [6, 8],
+    [7, 13],
+] {
+    assert equal (fib $t.input) $t.expected
+}
+```
+and be invoked as `nu tests.nu`
+
+[Nupm]: https://github.com/nushell/nupm


### PR DESCRIPTION
`std testing` has been _deprecated_ -hidden to the users to be more precise- for quite some time now...

this PR updates the _testing_ documentation page to not nudge people to have a look at that hiddent module, especially because downloading `testing.nu` manually and putting it anywhere is not a very good workflow :confused: 

i removed all mentions to `testing.nu` and wrote a new section to run tests, which is split into two parts
- running tests from a Nupm package
- running tests for standalon modules or scripts