### PR TITLE
fix: Fixed broken link pointing to localhost

### DIFF
--- a/blog/2024-05-28-nushell_0_94_0.md
+++ b/blog/2024-05-28-nushell_0_94_0.md
@@ -264,6 +264,7 @@ See a full overview of the [breaking changes](#breaking-changes)
 
 To support streaming output, `parse` now operates/matches on a single line at a time **only if provided with the streaming output of an external command, file, or raw byte stream**.
 For example, these snippets will try to match each line separately:
+
 ```nushell
 ^cat file.txt | parse -r "some regex"
 ^cat file.txt | take 1024 | parse -r "some regex"
@@ -274,6 +275,7 @@ open --raw file.txt | skip 1024 | parse -r "some regex"
 ```
 
 The old behavior was to collect all of the output the external command or byte stream and then run the regex across the whole string. To mimic this behavior, you can use the `collect` command or store the output in a variable:
+
 ```nushell
 ^cat file.txt | collect | parse -r "some regex"
 
@@ -282,9 +284,11 @@ $text | parse -r "some regex"
 ```
 
 Note that this change does not affect normal value streams like:
+
 ```nushell
 [(open foo.txt) (open bar.txt)] | parse -r "some regex"
 ```
+
 In this case, the regex is run separately over each string value in the stream. With the proper regex flags, the regex is able to match across multiple lines within the same string value.
 
 Note that `parse` may see more breaking changes in the next release to simplify these behaviors.
@@ -439,7 +443,7 @@ The `--collect-lazyrecords` flag has been removed from `describe`, since lazy re
 
 #### List of environment variables support in `with-env` [[toc](#table-of-content)]
 
-This release removes support for the list of environment variable form of `with-env` that was [deprecated](http://localhost:8080/blog/2024-04-30-nushell_0_93_0.html#with-env-toc) in the previous release. Going forward, only the record form is supported.
+This release removes support for the list of environment variable form of `with-env` that was [deprecated](https://www.nushell.sh/blog/2024-04-30-nushell_0_93_0.html#with-env-toc) in the previous release. Going forward, only the record form is supported.
 
 ## For plugin developers [[toc](#table-of-content)]
 

--- a/book/pipelines.md
+++ b/book/pipelines.md
@@ -118,7 +118,7 @@ With most filters, the second version would refer to the entire `file` record (w
 
 ### Pipeline input in custom command definitions and scripts
 
-See: [Custom Commands -> Pipeline Input](http://localhost:8080/book/custom_commands.html#pipeline-input)
+See: [Custom Commands -> Pipeline Input](custom_commands.html#pipeline-input)
 
 ### When is `$in` valid?
 


### PR DESCRIPTION
## Fix: Correct broken link pointing to localhost

This pull request addresses an issue with a broken link that was incorrectly pointing to localhost. The link has been updated to point to the correct relative URL within the documentation.