### PR TITLE
Add reference to bash-env to cookbook

### DIFF
--- a/cookbook/foreign_shell_scripts.md
+++ b/cookbook/foreign_shell_scripts.md
@@ -63,6 +63,13 @@ This quickly gets tricky though, for example when the script is declaring a
 There are ways to implement some form of expansion too, but at some point it
 might make more sense to leave the parsing to the shell it was meant for.
 
+## Bash Env Plugin
+
+There is a third-party Nu plugin [bash-env](https://github.com/tesujimath/nu_plugin_bash_env)
+for importing environment variables from Bash format files and pipes.
+This plugin uses Bash itself to parse the environment definitions,
+and can therefore cope with arbitrarily complex Bash sources.
+
 ## Capturing the environment from a foreign shell script
 
 A more complex approach is to run the script in the shell it is written for and

--- a/cookbook/ssh_agent.md
+++ b/cookbook/ssh_agent.md
@@ -21,6 +21,12 @@ Adding this to your `env.nu` will however start a new ssh-agent process every ti
 See the workarounds.
 :::
 
+Alternatively, use the third-party Nu plugin [bash-env](https://github.com/tesujimath/nu_plugin_bash_env) as follows.
+
+```nushell
+^ssh-agent | bash-env | load-env
+```
+
 ## Workarounds
 
 You can work around this behavior by checking if a ssh-agent is already running on your user, and start one if none is:


### PR DESCRIPTION
Using bash-env is a lot simpler than using the convoluted work-arounds currently described there.