### PR TITLE
remove feature from frontmatter and commands page

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -28,6 +28,5 @@ To see all commands from inside Nushell, run [`help commands`](/commands/docs/he
    <td><a :href="$withBase(command.path)">{{ command.title }}</a></td>
    <td style="white-space: pre-wrap;">{{ command.frontmatter.categories }}</td>
    <td style="white-space: pre-wrap;">{{ command.frontmatter.usage }}</td>
-   <td style="white-space: pre-wrap;">{{ command.frontmatter.feature }}</td>
   </tr>
 </table>

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -107,7 +107,6 @@ version: ($nu_version)
 ($category_matter)
 usage: |
 ($indented_usage)
-feature: ($feature)
 ---"
 }
 


### PR DESCRIPTION
because Nushell doesn't have features anymore apart from the default pool of commands, i propose to remove the `$.feature` column from the "commands" page and remove it from the `make_docs.nu` script as well for it not to appear in the frontmatter of the commands anymore.

> **Note**  
> i wanted to run `nu make_docs.nu` and generate the new commands frontmatter sections but the script does not appear to work on 0.94.1 anymore :confused: 