### PR TITLE
Add C toolchain to Ubuntu install instructions

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -58,7 +58,7 @@ If you'd rather not install Rust via `rustup`, you can also install it via other
 
 #### Debian/Ubuntu
 
-You will need to install the "pkg-config" and "libssl-dev" package:
+You will need to install the "pkg-config", "build-essential" and "libssl-dev" packages:
 
 @[code](@snippets/installation/install_pkg_config_libssl_dev.sh)
 

--- a/snippets/installation/install_pkg_config_libssl_dev.sh
+++ b/snippets/installation/install_pkg_config_libssl_dev.sh
@@ -1,1 +1,1 @@
-apt install pkg-config libssl-dev
+apt install pkg-config libssl-dev build-essential


### PR DESCRIPTION
A C toolchain is required to build a number of Rust crates. At least on WSL I ran into an error complaining about a "missin cc linker".