### PR TITLE
Release notes for 0.95.0 devyn

### DIFF
--- a/blog/2024-06-25-nushell_0_95_0.md
+++ b/blog/2024-06-25-nushell_0_95_0.md
@@ -22,15 +22,20 @@ As part of this release, we also publish a set of optional plugins you can insta
 
 # Table of content
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
+  - [_External command parsing improvements_](#external-command-parsing-improvements-toc)
+  - [_Plugin version reporting_](#plugin-version-reporting-toc)
 - [_Changes to commands_](#changes-to-commands-toc)
   - [_Additions_](#additions-toc)
   - [_Breaking changes_](#breaking-changes-toc)
+    - [_`run-external`_](#run-external-toc)
   - [_Deprecations_](#deprecations-toc)
   - [_Removals_](#removals-toc)
   - [_Other changes_](#other-changes-toc)
   - [_Bug fixes_](#bug-fixes-toc)
 - [_All breaking changes_](#all-breaking-changes-toc)
-  - [_Notes for plugin developers_](#notes-for-plugin-developers)
+  - [_Notes for plugin developers_](#notes-for-plugin-developers-toc)
+    - [_API_](#api-toc)
+    - [_Protocol_](#protocol-toc)
 - [_Hall of fame_](#hall-of-fame-toc)
 - [_Full changelog_](#full-changelog-toc)
 <!-- TODO: please add links to the other sections here
@@ -64,11 +69,80 @@ As part of this release, we also publish a set of optional plugins you can insta
     for the list of available *containers*
 -->
 
+## External command parsing improvements [[toc](#table-of-content)]
+
+::: warning Breaking change
+See a full overview of the [breaking changes](#breaking-changes)
+:::
+
+A lot of the quirks of external command parsing have been cleaned up in [#13089](https://github.com/nushell/nushell/pull/13089), with most of the actual string handling work being moved into `nu-parser` itself. Previously, the parser was doing some very special things to create expressions in a way that `run-external` would then finish parsing in order to handle quotes in external options, globs, tilde expansion, etc., but this was error prone and did not have great test coverage.
+
+Resolving this made it easier to find some of the edge cases that were not being handled, as well as making some syntax behave in a way that feels more consistent with the rest of Nushell:
+
+- Bare word interpolation works for external command options, and otherwise embedded in other strings:
+  ```nushell
+  ^echo --foo=(2 + 2) # prints --foo=4
+  ^echo -foo=$"(2 + 2)" # prints -foo=4
+  ^echo foo="(2 + 2)" # prints (no interpolation!) foo=(2 + 2)
+  ^echo foo,(2 + 2),bar # prints foo,4,bar
+  ```
+
+- Bare word interpolation expands for external command head/args:
+  ```nushell
+  let name = "exa"
+  ~/.cargo/bin/($name) # this works, and expands the tilde
+  ^$"~/.cargo/bin/($name)" # this doesn't expand the tilde
+  ^echo ~/($name)/* # this glob is expanded
+  ^echo $"~/($name)/*" # this isn't expanded
+  ```
+
+- Ndots are now supported for the head/args of an external command (`^.../foo` works, expanding to `^../../foo`)
+    - Because our ndots handling requires path normalization, it is disabled for bare arguments that don't contain at least three consecutive dots, and for arguments that contain the string `://` as that is likely to be a URL.
+
+- Glob values are now supported for head/args of an external command, and expanded appropriately:
+  ```nushell
+  ^("~/.cargo/bin/exa" | into glob) # the tilde is expanded
+  ^echo ("*.txt" | into glob) # this glob is expanded
+  ```
+
+## Plugin version reporting [[toc](#table-of-content)]
+
+::: warning Breaking change
+See a full overview of the [breaking changes](#breaking-changes)
+:::
+
+Plugins can now report their own version to Nushell, and have it displayed in `plugin list` and `version`. This can help users understand exactly which plugin version they have active in their shell.
+
+This is a breaking change for the Rust API, as implementing it on the `Plugin` trait is now required. We recommend the following implementation, which will take the plugin version directly from the cargo package metadata:
+
+```rust
+fn version(&self) -> String {
+    env!("CARGO_PKG_VERSION").into()
+}
+```
+
+If not using the Rust plugin API, you need to implement the new [`Metadata`](/contributor-book/plugin_protocol_reference.md#metadata-plugin-call) call. Providing a version is optional, but highly recommended.
+
 # Changes to commands [[toc](#table-of-content)]
 
 ## Additions [[toc](#table-of-content)]
 
 ## Breaking changes [[toc](#table-of-content)]
+
+### `run-external` [[toc](#table-of-content)]
+
+`run-external` now works more like any other command, without expecting a special call convention for its args:
+
+  ```nushell
+  > run-external echo "'foo'"
+  # 0.94: 'foo'
+  # 0.95: foo
+  > run-external echo "*.txt"
+  # 0.94: (glob is expanded)
+  # 0.95: *.txt
+  ```
+
+This argument handling is now implemented in the parser instead. [See the previous section](#external-command-parsing-improvements-toc) for more information on these changes.
 
 ## Deprecations [[toc](#table-of-content)]
 
@@ -114,7 +188,21 @@ As part of this release, we also publish a set of optional plugins you can insta
     here
 -->
 
-## Notes for plugin developers
+## Notes for plugin developers [[toc](#table-of-content)]
+
+### API [[toc](#table-of-content)]
+
+- The `Plugin` trait now has a required method `fn version(&self) -> String`. The following implementation should suffice in most cases:
+    ```rust
+    fn version(&self) -> String {
+        env!("CARGO_PKG_VERSION").into()
+    }
+    ```
+- A new derive macro has been added ([#13031](https://github.com/nushell/nushell/pull/13031)) for `FromValue` and `IntoValue` conversion traits to make serialization to and from Nushell values easier. The API design is similar to `serde-derive`. We expect this to make certain kinds of plugins much easier to develop! Many thanks to [@cptpiepmatz](https://github.com/cptpiepmatz).
+
+### Protocol [[toc](#table-of-content)]
+
+- The plugin protocol has a new required call, [`Metadata`](/contributor-book/plugin_protocol_reference.md#metadata-plugin-call), which is currently used to report version information on registration, but may be used for other plugin metadata in the future. The intention is that all fields are optional, and `version` is currently optional. This means that although the Rust API requires a version to be reported, it is perfectly allowed (but not recommended) for a plugin to not report a version.
 
 # Hall of fame [[toc](#table-of-content)]
 


### PR DESCRIPTION
- `run-external` changes
- Plugin version reporting
- @cptpiepmatz' new derive macro added to plugin API section, since that's a big target of it
