### PR TITLE
Update installation instructions with `cargo`

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -82,10 +82,6 @@ Nu releases are published as source to the popular Rust package registry [crates
 
 That's it! The `cargo` tool will do the work of downloading Nu and its source dependencies, building it, and installing it into the cargo bin path.
 
-If you want to install with support for [dataframes](dataframes.md), you can install using the `--features=dataframe` flag.
-
-@[code](@snippets/installation/cargo_install_nu_more_features.sh)
-
 ### Building from the GitHub repository
 
 You can also build Nu from the latest source on GitHub. This gives you immediate access to the latest features and bug fixes. First, clone the repo:

--- a/snippets/installation/cargo_install_nu.sh
+++ b/snippets/installation/cargo_install_nu.sh
@@ -1,1 +1,1 @@
-> cargo install nu
+> cargo install --locked nu

--- a/snippets/installation/cargo_install_nu.sh
+++ b/snippets/installation/cargo_install_nu.sh
@@ -1,1 +1,1 @@
-> cargo install --locked nu
+> cargo install nu

--- a/snippets/installation/cargo_install_nu_more_features.sh
+++ b/snippets/installation/cargo_install_nu_more_features.sh
@@ -1,1 +1,0 @@
-> cargo install nu --locked --features=dataframe


### PR DESCRIPTION
Hi,

This is only a small change.

I have removed the paragraph about including the `dataframes` feature, as it no longer exists (I presume it's just enabled by default?). At least the command `cargo install nu --locked --features=dataframe` given in the book fails with:

```
error: failed to compile `nu v0.95.0`, intermediate artifacts can be found at `/tmp/cargo-install0x8JXF`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  none of the selected packages contains these features: dataframe
```

I also added `--locked` to the remaining `cargo install` command.