### PR TITLE
Document std path add breaking change

### DIFF
--- a/blog/2024-07-23-nushell_0_96_0.md
+++ b/blog/2024-07-23-nushell_0_96_0.md
@@ -25,6 +25,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 - [_Changes to commands_](#changes-to-commands-toc)
   - [_Additions_](#additions-toc)
   - [_Breaking changes_](#breaking-changes-toc)
+    - [`std path add`](#std-path-add-toc)
   - [_Deprecations_](#deprecations-toc)
   - [_Removals_](#removals-toc)
   - [_Other changes_](#other-changes-toc)
@@ -69,6 +70,10 @@ As part of this release, we also publish a set of optional plugins you can insta
 ## Additions [[toc](#table-of-content)]
 
 ## Breaking changes [[toc](#table-of-content)]
+
+### `std path add` [[toc](#table-of-content)]
+
+To be less surprising, [#13258](https://github.com/nushell/nushell/pull/13258) made the `std path add` function no longer resolve symlinks in either the newly added paths, nor expand paths already in the variable. To mimic the previous resolving behavior, you can use, for example, `std path add ("foo/bar" | path expand)`.
 
 ## Deprecations [[toc](#table-of-content)]
 


### PR DESCRIPTION
As instructed in #1457, this is a suggestion for the release notes related to <https://github.com/nushell/nushell/pull/13258>, a breaking change for `std path add`.

To retain the univocality these blog posts seem to have, I offer full editorial control for things like structure, style, grammar, list ordering, etc.