### PR TITLE
Update 00_flow_control_overview.md

### DIFF
--- a/lang-guide/chapters/flow_control/00_flow_control_overview.md
+++ b/lang-guide/chapters/flow_control/00_flow_control_overview.md
@@ -11,5 +11,5 @@ However, keep in mind that many Nushell operations will be performed using struc
 See:
 
 ```nu
-help commands | where category == filter
+help commands | where category == filters
 ```


### PR DESCRIPTION
There is missing "s" in the example command:
help commands | where category == filter
should be
help commands | where category == filters