### PR TITLE
Update `CustomValue` usage example

### DIFF
--- a/contributor-book/plugins.md
+++ b/contributor-book/plugins.md
@@ -583,8 +583,7 @@ impl CustomValue for Animal {
         Value::custom_value(Box::new(self.clone()), span)
     }
 
-    fn value_string(&self) -> String {
-        // The type name
+    fn type_name(&self) -> String {
         "Animal".into()
     }
 
@@ -606,6 +605,10 @@ impl CustomValue for Animal {
     }
 
     fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn Any {
         self
     }
 }


### PR DESCRIPTION
The example given in `contributor_book/plugins` was out of date. `value_string()` was renamed to `type_name()` quite a while ago to reflect what it is actually used for, and `as_mut_any()` was added to support mutating the custom value without having to clone it first.
