### PR TITLE
Fix line numbers having different line height in code blocks

### DIFF
--- a/.vuepress/styles/index.scss
+++ b/.vuepress/styles/index.scss
@@ -15,6 +15,12 @@
   line-height: 1;
 }
 
+/* Make sure the line numbers have the same line-height as the code lines
+ */
+div[class*="language-"].line-numbers-mode .line-numbers {
+  line-height: 1;
+}
+
 /* Add DejaVu Sans Mono to the list of monospaced fonts.
  * This allows tables to be rendered seamlessly with box-drawing characters.
  */


### PR DESCRIPTION
The index.scss style sheet override the line height for codeblocks to 1 but it does not do the same for the line numbers at the left gutter. This commit fixes this.

![grafik](https://github.com/user-attachments/assets/6fb7f218-6fb7-4e99-878e-0b253f45a3f0)
