### PR TITLE
Remove dead snippets from translated Installation chapters

### DIFF
--- a/de/book/installation.md
+++ b/de/book/installation.md
@@ -86,20 +86,6 @@ Wenn alle die Abhängigkeitenn, die für Nu benötigt werden, installiert sind, 
 
 Das war's! Cargo wird Nu und seine anderen Abhängigkeiten herunterladen, kompilieren und schließlich im cargo `bin` Pfad installieren, damit es benutzt werden kann.
 
-Wenn mehr Funktionalitäten installiert werden sollen, kann der folgende Befehl verwendet werden:
-
-@[code](@snippets/installation/cargo_install_nu_more_features.sh)
-
-Um alle verfügbaren Funktionalitäten zu bekommen, ist es am einfachsten einen Checkout durchzuführen und es selbst mit Hilfe der Rust-Tools zu kompilieren:
-
-@[code](@snippets/installation/build_nu_yourself.sh)
-
-Damit das funktioniert, sollte sichergestellt werden, dass alle oben genannten Abhängigkeiten auf dem System installiert sind.
-
-Wenn Nu schließlich installiert ist, kann die Shell mit dem `nu`-Befehl gestartet werden:
-
-@[code](@snippets/installation/run_nu.sh)
-
 ## Kompilieren von Quelldateien
 
 Nu kann auch direkt aus den Quelldateien, die auf GitHub verfügbar sind, kompiliert werden. Das stellt unmittelbar die neuesten Funktionen und Fehlerbehebungen von Nu zur Verfügung.

--- a/ja/book/installation.md
+++ b/ja/book/installation.md
@@ -85,10 +85,6 @@ Nu はソースの形で、Rust で人気のパッケージレジストリ [crat
 
 これでおしまいです！`cargo`は Nu のソースコードとその依存関係をダウンロードしてビルドし、`cargo`のバイナリーパスにインストールすることで Nu を実行できるようにします。
 
-もし [dataframes (EN)](/book/dataframes.md) サポートをともにインストールしたいなら、 `--features=dataframe` フラグを使ってインストールすることができます。
-
-@[code](@snippets/installation/cargo_install_nu_more_features.sh)
-
 ### GitHub リポジトリからのビルド
 
 GitHub の最新のソースから直接ビルドすることもできます。こうすることで、最新の機能やバグ修正にすぐにアクセスすることができます。まず、リポジトリをクローンします。

--- a/zh-CN/book/installation.md
+++ b/zh-CN/book/installation.md
@@ -86,10 +86,6 @@ Nu 发行版会作为源码发布到流行的 Rust 包仓库 [crates.io](https:/
 
 如此即可！`cargo` 工具将完成下载 Nu 及其源码依赖，构建并将其安装到 cargo bin 路径中，以便我们能够运行它。
 
-如果你想要安装并支持 [dataframes](/zh-CN/book/dataframes.md) 功能，你可以在安装命令附上 `--features=dataframe`：
-
-@[code](@snippets/installation/cargo_install_nu_more_features.sh)
-
 ### 从 GitHub 仓库构建
 
 我们也可以从 GitHub 上的最新源码构建自己的 Nu。这让我们可以立即获得最新的功能和错误修复。首先，克隆源码仓库：


### PR DESCRIPTION
Vuepress was giving several warnings on startup of the dev server related to a missing snippet:

```
/snippets/installation/cargo_install_nu_more_features.sh
```

Running the translations through ChatGPT, this was in the (removed from the English version) section on the `--features` flag which isn't needed currently.  I've removed the relevant sections on building with `--features=all` and `--features=dataframe`.

> Wenn mehr Funktionalitäten installiert werden sollen, kann der folgende Befehl verwendet werden:

That is:

> If you want to install more functionalities, you can use the following command:

Removed the offending sections from German, Japanese, and Chinese translations.

The guides are probably desperately out of date in other areas, of course, and probably need some automated "warning" inserted, but at least we don't get any more "missing snippet" related warnings on the server-side.