### PR TITLE
History and keybindings in Coming from Bash

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -78,7 +78,7 @@ $env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 | Bash                                 | Nu                                                            | Task                                                              |
 | ------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------- |
 | `!!`                                 | `!!`                                                          | Repeat last commandline from history                              |
-| `!$`                                 | `!$`                                                          | Repeat last commandline from history                              |
+| `!$`                                 | `!$`                                                          | Repeat last spatially separated token from history                |
 | `!<n>` (e.g., `!5`)                  | `!<n>`                                                        | Repeat \<n\>th command from the beginning of the history          |
 |                                      |                                                               | Tip: `history \| enumerate \| last 10` to show recent positions   |
 | `!<-n>` (e.g., `!-5`)                | `!<-n>`                                                       | Repeat \<n\>th command from the end of the history                |

--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -1,11 +1,15 @@
 # Coming from Bash
 
-If you're coming from `Git Bash` on Windows, then the external commands you're used to (bash, grep, etc) will not be available in `nu` by default (unless you had explicitly made them available in the Windows Path environment variable).
-To make these commands available in `nu` as well, add the following line to your `config.nu` with either `append` or `prepend`.
+::: tip
+If you're coming from `Git Bash` on Windows, then the external commands you're used to (e.g, `ln`, `grep`, `vi`, etc) will not be available in Nushell by default unless you have already explicitly made them available in the Windows Path environment variable.
+To make these commands available in Nushell as well, add the following line to your `config.nu` with either `append` or `prepend`.
 
 ```
 $env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 ```
+:::
+
+## Command equivalents:
 
 | Bash                                 | Nu                                                            | Task                                                              |
 | ------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------- |
@@ -69,3 +73,17 @@ $env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 | `pwd`                                | `$env.PWD`                                                    | Display the current directory                                     |
 | `read var`                           | `let var = input`                                             | Get input from the user                                           |
 
+## History and Default Keybindings:
+
+| Bash                                 | Nu                                                            | Task                                                              |
+| ------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `!!`                                 | `!!`                                                          | Repeat last commandline from history                              |
+| `!$`                                 | `!$`                                                          | Repeat last commandline from history                              |
+| `!<n>` (e.g., `!5`)                  | `!<n>`                                                        | Repeat \<n\>th command from the beginning of the history          |
+|                                      |                                                               | Tip: `history \| enumerate \| last 10` to show recent positions   |
+| `!<-n>` (e.g., `!-5`)                | `!<-n>`                                                       | Repeat \<n\>th command from the end of the history                |
+| <kbd>Ctrl/Cmd</kbd>+<kbd>R</kbd>     | <kbd>Ctrl/Cmd</kbd>+<kbd>R</kbd>                              | Reverse history search                                            |
+| (Emacs Mode) <kbd>Ctrl</kbd>+<kbd>X</kbd><kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd> | Edit the commandline in the editor defined by `$env.EDITOR`   |
+| (Vi Command Mode) <kbd>V</kbd>       | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd>                              | Edit the commandline in the editor defined by `$env.EDITOR`       |
+
+Most common Emacs-mode and Vi-mode keybindings are also available. See the [Reedline Chapter](line_editor.html#editing-mode).

--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -73,7 +73,7 @@ $env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 | `pwd`                                | `$env.PWD`                                                    | Display the current directory                                     |
 | `read var`                           | `let var = input`                                             | Get input from the user                                           |
 
-## History and Default Keybindings:
+## History Substitutions and Default Keybindings:
 
 | Bash                                 | Nu                                                            | Task                                                              |
 | ------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------- |

--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -77,14 +77,26 @@ $env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 
 | Bash                                 | Nu                                                            | Task                                                              |
 | ------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `!!`                                 | `!!`                                                          | Repeat last commandline from history                              |
-| `!$`                                 | `!$`                                                          | Repeat last spatially separated token from history                |
-| `!<n>` (e.g., `!5`)                  | `!<n>`                                                        | Repeat \<n\>th command from the beginning of the history          |
+| `!!`                                 | `!!`                                                          | Insert last command-line from history                              |
+| `!$`                                 | `!$`                                                          | Insert last spatially separated token from history                |
+| `!<n>` (e.g., `!5`)                  | `!<n>`                                                        | Insert \<n\>th command from the beginning of the history          |
 |                                      |                                                               | Tip: `history \| enumerate \| last 10` to show recent positions   |
-| `!<-n>` (e.g., `!-5`)                | `!<-n>`                                                       | Repeat \<n\>th command from the end of the history                |
-| `!<string>` (e.g., `!ls`)            | `!<string>`                                                   | Repeat the most recent history item beginning with the string     |
+| `!<-n>` (e.g., `!-5`)                | `!<-n>`                                                       | Insert \<n\>th command from the end of the history                |
+| `!<string>` (e.g., `!ls`)            | `!<string>`                                                   | Insert the most recent history item that begins with the string   |
 | <kbd>Ctrl/Cmd</kbd>+<kbd>R</kbd>     | <kbd>Ctrl/Cmd</kbd>+<kbd>R</kbd>                              | Reverse history search                                            |
-| (Emacs Mode) <kbd>Ctrl</kbd>+<kbd>X</kbd><kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd> | Edit the commandline in the editor defined by `$env.EDITOR`   |
-| (Vi Command Mode) <kbd>V</kbd>       | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd>                              | Edit the commandline in the editor defined by `$env.EDITOR`       |
+| (Emacs Mode) <kbd>Ctrl</kbd>+<kbd>X</kbd><kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd> | Edit the command-line in the editor defined by `$env.EDITOR`   |
+| (Vi Command Mode) <kbd>V</kbd>       | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd>                              | Edit the command-line in the editor defined by `$env.EDITOR`       |
 
 Most common Emacs-mode and Vi-mode keybindings are also available. See the [Reedline Chapter](line_editor.html#editing-mode).
+
+::: tip
+In Bash, history substitution occurs immediately after pressing <kbd>Enter</kbd> 
+to execute the command-line. Nushell, however, *inserts* the substitution into
+the command-line after pressing <kbd>Enter</kbd>. This allows you to confirm
+the substitution and, if needed, make additional edits before execution.
+
+This behavior extends to "Edit command-line in Editor" as well. While Bash immediately
+executes the command after exiting the editor, Nushell (like other, more modern shells
+such as Fish and Zsh) inserts the editor contents into the command-line, allowing you
+to review and make changes before committing it to execution.
+:::

--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -82,6 +82,7 @@ $env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 | `!<n>` (e.g., `!5`)                  | `!<n>`                                                        | Repeat \<n\>th command from the beginning of the history          |
 |                                      |                                                               | Tip: `history \| enumerate \| last 10` to show recent positions   |
 | `!<-n>` (e.g., `!-5`)                | `!<-n>`                                                       | Repeat \<n\>th command from the end of the history                |
+| `!<string>` (e.g., `!ls`)            | `!<string>`                                                   | Repeat the most recent history item beginning with the string     |
 | <kbd>Ctrl/Cmd</kbd>+<kbd>R</kbd>     | <kbd>Ctrl/Cmd</kbd>+<kbd>R</kbd>                              | Reverse history search                                            |
 | (Emacs Mode) <kbd>Ctrl</kbd>+<kbd>X</kbd><kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd> | Edit the commandline in the editor defined by `$env.EDITOR`   |
 | (Vi Command Mode) <kbd>V</kbd>       | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd>                              | Edit the commandline in the editor defined by `$env.EDITOR`       |


### PR DESCRIPTION
Implemented suggestion in #1072:

* Added `!!`, `!$`, `!<n>`, and `!<-n>` history substitutions
* Also added a few Bashism keybindings and pointed to the Reedline chapter for the rest.