### PR TITLE
Dropdown for doc on main page

### DIFF
--- a/.vuepress/configs/navbar/en.ts
+++ b/.vuepress/configs/navbar/en.ts
@@ -13,14 +13,5 @@ export const navbarEn: NavbarConfig = [
       { text: 'Contributing Guide', link: '/contributor-book/' },
     ],
   },
-  {
-    text: 'News',
-    children: [
-      { text: 'Blog', link: '/blog/' },
-      {
-        text: 'This Week in Nu!',
-        link: 'https://github.com/nushell/this_week_in_nu/blob/main/This%20week%20in%20Nu%20261.md',
-      },
-    ],
-  },
+  { text: 'Blog', link: '/blog/' },
 ];

--- a/.vuepress/configs/navbar/en.ts
+++ b/.vuepress/configs/navbar/en.ts
@@ -1,15 +1,17 @@
 import type { NavbarConfig } from '@vuepress/theme-default';
 
 export const navbarEn: NavbarConfig = [
+  { text: 'Get Nu!', link: '/book/installation' },
+  { text: 'Getting Started', link: '/book/getting_started' },
   {
     text: 'Documentation',
     children: [
-      { text: 'Nushell Book', link: '/book/' },
+      { text: 'The Nushell Book', link: '/book/' },
       { text: 'Command Reference', link: '/commands/' },
       { text: 'Cookbook', link: '/cookbook/' },
       { text: 'Language Reference Guide', link: '/lang-guide/' },
+      { text: 'Contributing Guide', link: '/contributor-book/' },
     ],
   },
-  { text: 'Contributing', link: '/contributor-book/' },
   { text: 'Blog', link: '/blog/' },
 ];

--- a/.vuepress/configs/navbar/en.ts
+++ b/.vuepress/configs/navbar/en.ts
@@ -13,5 +13,14 @@ export const navbarEn: NavbarConfig = [
       { text: 'Contributing Guide', link: '/contributor-book/' },
     ],
   },
-  { text: 'Blog', link: '/blog/' },
+  {
+    text: 'News',
+    children: [
+      { text: 'Blog', link: '/blog/' },
+      {
+        text: 'This Week in Nu!',
+        link: 'https://github.com/nushell/this_week_in_nu/blob/main/This%20week%20in%20Nu%20261.md',
+      },
+    ],
+  },
 ];

--- a/.vuepress/configs/navbar/en.ts
+++ b/.vuepress/configs/navbar/en.ts
@@ -1,10 +1,15 @@
 import type { NavbarConfig } from '@vuepress/theme-default';
 
 export const navbarEn: NavbarConfig = [
-  { text: 'Book', link: '/book/' },
-  { text: 'Commands', link: '/commands/' },
-  { text: 'Contrib', link: '/contributor-book/' },
-  { text: 'Cookbook', link: '/cookbook/' },
+  {
+    text: 'Documentation',
+    children: [
+      { text: 'Nushell Book', link: '/book/' },
+      { text: 'Command Reference', link: '/commands/' },
+      { text: 'Cookbook', link: '/cookbook/' },
+      { text: 'Language Reference Guide', link: '/lang-guide/' },
+    ],
+  },
+  { text: 'Contributing', link: '/contributor-book/' },
   { text: 'Blog', link: '/blog/' },
-  { text: 'Ref', link: '/lang-guide/' },
 ];


### PR DESCRIPTION
Floating an idea ...

*"Ref"* is just too short and ambiguous to describe the *"Language Reference Guide"* on the main page navbar.

What about grouping the *"Documentation"* together into its own dropdown?  This allows us to provide a full and descriptive name for each doc link.