### PR TITLE
Fix 13541 description

### DIFF
--- a/blog/2024-08-20-nushell_0_97_0.md
+++ b/blog/2024-08-20-nushell_0_97_0.md
@@ -141,7 +141,12 @@ After [#13612](https://github.com/nushell/nushell/pull/13612), `glob` now also t
 
 ### `into datetime` [[toc](#table-of-content)]
 
-Thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds) in [#13541](https://github.com/nushell/nushell/pull/13541), integer values can now be piped into `into datetime` in combination with a format string. The integers will be interpreted based on the format string.
+Thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds) in [#13541](https://github.com/nushell/nushell/pull/13541), integer values can now be piped into `into datetime` in combination with a format string. The integers will be interpreted based on the format string. Example:
+
+```nu
+1724112000 | into datetime -f '%s'
+# => Tue, 20 Aug 2024 00:00:00 +0000 (now)
+```
 
 ### `reduce` [[toc](#table-of-content)]
 

--- a/blog/2024-08-20-nushell_0_97_0.md
+++ b/blog/2024-08-20-nushell_0_97_0.md
@@ -141,7 +141,7 @@ After [#13612](https://github.com/nushell/nushell/pull/13612), `glob` now also t
 
 ### `into datetime` [[toc](#table-of-content)]
 
-Thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds) in [#13541](https://github.com/nushell/nushell/pull/13541), integer values can now be piped into `into datetime` in combination with a format string. The integers will be interpreted as nanosecond-precision UNIX timestamps.
+Thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds) in [#13541](https://github.com/nushell/nushell/pull/13541), integer values can now be piped into `into datetime` in combination with a format string. The integers will be interpreted based on the format string.
 
 ### `reduce` [[toc](#table-of-content)]
 


### PR DESCRIPTION
Slight correction on my PR 13541 - Integers passed to `into datetime` *without* a format string have always been interpreted as nanoseconds.  With this change, they are able to be interpreted based on the format string as well.