### PR TITLE
make-docs: Run in different Nu with plugins

### DIFF
--- a/make_docs.nu
+++ b/make_docs.nu
@@ -1,12 +1,13 @@
-const PLUGINS = [
-    nu_plugin_inc,
-    nu_plugin_gstat,
-    nu_plugin_query,
-    nu_plugin_polars,
-    nu_plugin_formats,
-]
 
 def plugin-paths [ nu_path?: path ] {
+    const PLUGINS = [
+        nu_plugin_inc,
+        nu_plugin_gstat,
+        nu_plugin_query,
+        nu_plugin_polars,
+        nu_plugin_formats,
+    ]
+
     # If no custom path is provided, default to the
     # directory of the currently running nu
     let nu_dir = match $nu_path {


### PR DESCRIPTION
* Uses `$nu.current-exe` to determine the path of plugins rather than `which nu` - This fixes #1516 to allow users with Nu install by `cargo install` to still use `make_docs` with a different `nu`
* Moves plugin retrieval logic to a new function since it's now used in two places
* Slight refactor on plugin retrieval to use `each` rather than a mut-with-for
* Adds an *optional* helper command that will run `make_docs` in a new, temporary subshell with all core plugins installed, even if the user doesn't have them installed already. This implements/fixes #1517.

  ```nu
  source make_docs.nu
  make_docs
  # or
  make docs <path_to_nu>
  ```