### PR TITLE
Replace `it` with `elt` / `row` / `line` etc

### DIFF
--- a/blog/2022-03-22-nushell_0_60.md
+++ b/blog/2022-03-22-nushell_0_60.md
@@ -272,7 +272,7 @@ In this release, we're also moving to keeping the current directory in the envir
 This allows you to more easily loop over subdirectories without having to do the bookkeeping of remembering to change back to the previous directory:
 
 ```
-> ls | where type == dir | each { |it| cd $it.name; ls | length }
+> ls | where type == dir | each { |row| cd $row.name; ls | length }
 ```
 
 That said, it takes a little getting used to. It does mean that changing a directory in a traditional custom command won't work, as the `PWD` environment variable will reset after the call completes. To help with this, we're also introducing `def-env`, a way to work inside the caller's environment and not lose any environment changes made by the custom command:
@@ -685,18 +685,18 @@ The new engine has a fun trick up it's sleeve: you can effortlessly convert your
 For example, if we had a script that opened files that fit a certain pattern and counted their number of lines:
 
 ```
-ls **/*.rs | each { |it|
-  let num_lines = (open $it.name | lines | length)
-  {name: $it.name, loc: $num_lines}
+ls **/*.rs | each { |row|
+  let num_lines = (open $row.name | lines | length)
+  {name: $row.name, loc: $num_lines}
 }
 ```
 
 We can turn this into a script that runs in parallel by changing the `each` to `par-each`:
 
 ```
-ls **/*.rs | par-each { |it|
-  let num_lines = (open $it.name | lines | length)
-  {name: $it.name, loc: $num_lines}
+ls **/*.rs | par-each { |row|
+  let num_lines = (open $row.name | lines | length)
+  {name: $row.name, loc: $num_lines}
 }
 ```
 

--- a/blog/2022-11-29-nushell-0.72.md
+++ b/blog/2022-11-29-nushell-0.72.md
@@ -82,7 +82,7 @@ We have now split closures and blocks into two separate value types. A closure c
 An example closure:
 
 ```nu
-ls | each {|it| print $it.name }
+ls | each {|row| print $row.name }
 ```
 
 You can also think of creating a custom command like `def foo [] { ... }` as creating a closure.

--- a/blog/2024-01-09-nushell_0_89_0.md
+++ b/blog/2024-01-09-nushell_0_89_0.md
@@ -197,7 +197,7 @@ Setting the limits is done via flags available in `help ulimit`.
     let prs = list-merged-prs nushell/nushell $last_release_date
         | where author != "app/dependabot"
         | sort-by mergedAt
-        | update url {|it| $"[#($it.number)]\(($it.url)\)" }
+        | update url {|row| $"[#($row.number)]\(($row.url)\)" }
         | update author { $"[@($in)]\(https://github.com/($in)\)" }
         | select author title url
         | rename --column {url: pr}

--- a/blog/2024-02-06-nushell_0_90_0.md
+++ b/blog/2024-02-06-nushell_0_90_0.md
@@ -113,7 +113,7 @@ So if you have the following files: `aac.txt`, `abc.txt`, `a[ab]c.txt`, then:
 But if you save a file name in a variable, e.g: `let f = "a[ab]c.txt"`, then `ls $f` matches `aac.txt`, `abc.txt`.
 To escape the glob pattern to match a file named `a[bc]c.txt`, `str escape-glob` comes to play: `ls ($f | str escape-glob)`.
 
-The new `str escape-glob` command ([#11663](https://github.com/nushell/nushell/pull/11664)) is useful when you want to prevent globs from expanding, for example when using a closure: `ls | str escape-glob name | each {|it| ls $it.name }`, so you won't get error occasionally.
+The new `str escape-glob` command ([#11663](https://github.com/nushell/nushell/pull/11664)) is useful when you want to prevent globs from expanding, for example when using a closure: `ls | str escape-glob name | each {|row| ls $row.name }`, so you won't get error occasionally.
 
 ## (Breaking Change!) For existing plugin
 

--- a/blog/2024-05-15-top-nushell-hacks.md
+++ b/blog/2024-05-15-top-nushell-hacks.md
@@ -71,7 +71,7 @@ git whatchanged -p --abbrev-commit --pretty=medium
       source: { |buffer, position|
         scope aliases
         | where name == $buffer
-        | each { |it| {value: $it.expansion }}
+        | each { |elt| {value: $elt.expansion }}
       }
     }
 ```

--- a/book/cheat_sheet.md
+++ b/book/cheat_sheet.md
@@ -180,7 +180,7 @@ iterate over a list; `it` is current list value:
 
 ```nu
 > let planets = [Mercury Venus Earth Mars Jupiter Saturn Uranus Neptune]
-> $planets | each { |it| $"($it) is a planet of the solar system" }
+> $planets | each { |elt| $"($elt) is a planet of the solar system" }
 ╭───┬─────────────────────────────────────────╮
 │ 0 │ Mercury is a planet of the solar system │
 │ 1 │ Venus is a planet of the solar system   │
@@ -196,7 +196,7 @@ iterate over a list; `it` is current list value:
 iterate over a list with an index and value:
 
 ```nu
-> $planets | enumerate | each { |it| $"($it.index + 1) - ($it.item)" }
+> $planets | enumerate | each { |elt| $"($elt.index + 1) - ($elt.item)" }
 ╭───┬─────────────╮
 │ 0 │ 1 - Mercury │
 │ 1 │ 2 - Venus   │
@@ -213,7 +213,7 @@ reduce the list to a single value; `reduce` gives access to accumulator that is 
 
 ```nu
 > let scores = [3 8 4]
-> $"total = ($scores | reduce { |it, acc| $acc + $it })"
+> $"total = ($scores | reduce { |elt, acc| $acc + $elt })"
 total = 15
 ```
 
@@ -221,7 +221,7 @@ reduce with an initial value (`--fold`):
 
 ```nu
 > let scores = [3 8 4]
-> $"total = ($scores | reduce --fold 1 { |it, acc| $acc * $it })"
+> $"total = ($scores | reduce --fold 1 { |elt, acc| $acc * $elt })"
 total = 96
 ```
 
@@ -237,7 +237,7 @@ check if any string in the list starts with `E`:
 
 ```nu
 > let planets = [Mercury Venus Earth Mars Jupiter Saturn Uranus Neptune]
-> $planets | any {|it| $it | str starts-with "E" }
+> $planets | any {|elt| $elt | str starts-with "E" }
 true
 ```
 

--- a/book/control_flow.md
+++ b/book/control_flow.md
@@ -351,7 +351,7 @@ positive
 > positive-check (-3)
 non-positive
 
-> let positive_check = {|it| if $it > 0 { return 'positive' }; 'non-positive' }
+> let positive_check = {|elt| if $elt > 0 { return 'positive' }; 'non-positive' }
 
 > do $positive_check 3
 positive

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -467,7 +467,7 @@ Let's make our own command that doubles every value it receives as input:
 
 ```nu
 def double [] {
-  each { |it| 2 * $it }
+  each { |elt| 2 * $elt }
 }
 ```
 

--- a/book/line_editor.md
+++ b/book/line_editor.md
@@ -288,7 +288,7 @@ first clears the prompt, inserts a string and then enters that value
       event:[
           { edit: Clear }
           { edit: InsertString,
-            value: "cd (ls | where type == dir | each { |it| $it.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
+            value: "cd (ls | where type == dir | each { |row| $row.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
 
           }
           { send: Enter }
@@ -318,7 +318,7 @@ event to the engine
       mode: emacs
       event: {
         send: executehostcommand,
-        cmd: "cd (ls | where type == dir | each { |it| $it.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
+        cmd: "cd (ls | where type == dir | each { |row| $row.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
       }
     }
   ]
@@ -763,7 +763,7 @@ With that in mind, the desired menu would look like this
             scope variables
             | where name =~ $buffer
             | sort-by name
-            | each { |it| {value: $it.name description: $it.type} }
+            | each { |row| {value: $row.name description: $row.type} }
         }
       }
       ...

--- a/book/operators.md
+++ b/book/operators.md
@@ -148,7 +148,7 @@ operator can let you do it more easily.
 > [
     ...$dogs
     Polly
-    ...($cats | each { |it| $"($it) \(cat\)" })
+    ...($cats | each { |elt| $"($elt) \(cat\)" })
     ...[Porky Bessie]
     ...Nemo
   ]
@@ -169,7 +169,7 @@ The below code is an equivalent version using `append`:
 ```nushell
 > $dogs |
     append Polly |
-    append ($cats | each { |it| $"($it) \(cat\)" }) |
+    append ($cats | each { |elt| $"($elt) \(cat\)" }) |
     append [Porky Bessie] |
     append ...Nemo
 ```

--- a/book/parallelism.md
+++ b/book/parallelism.md
@@ -13,8 +13,8 @@ Like [`each`](/commands/docs/each.md), [`par-each`](/commands/docs/par-each.md) 
 Let's say you wanted to count the number of files in each sub-directory of the current directory. Using [`each`](/commands/docs/each.md), you could write this as:
 
 ```nu
-> ls | where type == dir | each { |it|
-    { name: $it.name, len: (ls $it.name | length) }
+> ls | where type == dir | each { |row|
+    { name: $row.name, len: (ls $row.name | length) }
 }
 ```
 
@@ -25,8 +25,8 @@ On your machine, the times may vary. For this machine, it took 21 milliseconds f
 Now, since this operation can be run in parallel, let's convert the above to parallel by changing [`each`](/commands/docs/each.md) to [`par-each`](/commands/docs/par-each.md):
 
 ```nu
-> ls | where type == dir | par-each { |it|
-    { name: $it.name, len: (ls $it.name | length) }
+> ls | where type == dir | par-each { |row|
+    { name: $row.name, len: (ls $row.name | length) }
 }
 ```
 
@@ -35,8 +35,8 @@ On this machine, it now runs in 6ms. That's quite a difference!
 As a side note: Because [environment variables are scoped](environment.md#scoping), you can use [`par-each`](/commands/docs/par-each.md) to work in multiple directories in parallel (notice the [`cd`](/commands/docs/cd.md) command):
 
 ```nu
-> ls | where type == dir | par-each { |it|
-    { name: $it.name, len: (cd $it.name; ls | length) }
+> ls | where type == dir | par-each { |row|
+    { name: $row.name, len: (cd $row.name; ls | length) }
 }
 ```
 

--- a/book/style_guide.md
+++ b/book/style_guide.md
@@ -69,8 +69,8 @@ Correct:
 
 ```nu
 [[status]; [UP] [UP]] | all {|el| $el.status == UP }
-[1 2 3 4] | reduce {|it, acc| $it + $acc }
-[1 2 3 4] | reduce {|it acc| $it + $acc }
+[1 2 3 4] | reduce {|elt, acc| $elt + $acc }
+[1 2 3 4] | reduce {|elt acc| $elt + $acc }
 {x: 1, y: 2}
 {x: 1 y: 2}
 [1 2] | zip [3 4]
@@ -85,7 +85,7 @@ Incorrect:
 [[status]; [UP] [UP]] | all { |el| $el.status == UP }
 
 # too many spaces before ",": no space is allowed
-[1 2 3 4] | reduce {|it , acc| $it + $acc }
+[1 2 3 4] | reduce {|elt , acc| $elt + $acc }
 
 # too many spaces before "x": no space is allowed
 { x: 1, y: 2}
@@ -134,8 +134,8 @@ Correct:
     $el.status == UP
 }
 
-[1 2 3 4] | reduce {|it, acc|
-    $it + $acc
+[1 2 3 4] | reduce {|elt, acc|
+    $elt + $acc
 }
 
 {x: 1, y: 2}
@@ -159,8 +159,8 @@ Incorrect:
     $el.status == UP}
 
 # too many spaces before "2": one space is required (like in one-line format)
-[1  2 3 4] | reduce {|it, acc|
-    $it + $acc
+[1  2 3 4] | reduce {|elt, acc|
+    $elt + $acc
 }
 
 {

--- a/book/thinking_in_nu.md
+++ b/book/thinking_in_nu.md
@@ -80,8 +80,8 @@ In Nushell, blocks control their own environment. Changes to the environment are
 In practice, this lets you write some concise code for working with subdirectories, for example, if you wanted to build each sub-project in the current directory, you could run:
 
 ```nu
-> ls | each { |it|
-    cd $it.name
+> ls | each { |row|
+    cd $row.name
     make
 }
 ```

--- a/book/variables.md
+++ b/book/variables.md
@@ -105,7 +105,7 @@ Many, if not most, use-cases for mutable variables in Nushell have a functional 
 For instance, loop counters are a common pattern for mutable variables and are built into most iterating commands. For example, you can get both each item and the index of each item using [`each`](/commands/docs/each.md) with [`enumerate`](/commands/docs/enumerate.md):
 
 ```nu
-> ls | enumerate | each { |it| $"Item #($it.index) is size ($it.item.size)" }
+> ls | enumerate | each { |elt| $"Item #($elt.index) is size ($elt.item.size)" }
 ╭───┬───────────────────────────╮
 │ 0 │ Item #0 is size 812 B     │
 │ 1 │ Item #1 is size 3.4 KiB   │

--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -103,15 +103,15 @@ To append one or more lists together, optionally with values interspersed in bet
 ## Iterating over lists
 
 To iterate over the items in a list, use the [`each`](/commands/docs/each.md) command with a [block](types_of_data.html#blocks)
-of Nu code that specifies what to do to each item. The block parameter (e.g. `|it|` in `{ |it| print $it }`) is the current list
+of Nu code that specifies what to do to each item. The block parameter (e.g. `|elt|` in `{ |elt| print $elt }`) is the current list
 item, but the [`enumerate`](/commands/docs/enumerate.md) filter can be used to provide `index` and `item` values if needed. For example:
 
 ```nu
 let names = [Mark Tami Amanda Jeremy]
-$names | each { |it| $"Hello, ($it)!" }
+$names | each { |elt| $"Hello, ($elt)!" }
 # Outputs "Hello, Mark!" and three more similar lines.
 
-$names | enumerate | each { |it| $"($it.index + 1) - ($it.item)" }
+$names | enumerate | each { |elt| $"($elt.index + 1) - ($elt.item)" }
 # Outputs "1 - Mark", "2 - Tami", etc.
 ```
 
@@ -141,13 +141,13 @@ For example:
 
 ```nu
 let scores = [3 8 4]
-$"total = ($scores | reduce { |it, acc| $acc + $it })" # total = 15
+$"total = ($scores | reduce { |elt, acc| $acc + $elt })" # total = 15
 
 $"total = ($scores | math sum)" # easier approach, same result
 
-$"product = ($scores | reduce --fold 1 { |it, acc| $acc * $it })" # product = 96
+$"product = ($scores | reduce --fold 1 { |elt, acc| $acc * $elt })" # product = 96
 
-$scores | enumerate | reduce --fold 0 { |it, acc| $acc + $it.index * $it.item } # 0*3 + 1*8 + 2*4 = 16
+$scores | enumerate | reduce --fold 0 { |elt, acc| $acc + $elt.index * $elt.item } # 0*3 + 1*8 + 2*4 = 16
 ```
 
 ## Accessing the list
@@ -203,17 +203,17 @@ For example:
 ```nu
 let colors = [red green blue]
 # Do any color names end with "e"?
-$colors | any {|it| $it | str ends-with "e" } # true
+$colors | any {|elt| $elt | str ends-with "e" } # true
 
 # Is the length of any color name less than 3?
-$colors | any {|it| ($it | str length) < 3 } # false
+$colors | any {|elt| ($elt | str length) < 3 } # false
 
 let scores = [3 8 4]
 # Are any scores greater than 7?
-$scores | any {|it| $it > 7 } # true
+$scores | any {|elt| $elt > 7 } # true
 
 # Are any scores odd?
-$scores | any {|it| $it mod 2 == 1 } # true
+$scores | any {|elt| $elt mod 2 == 1 } # true
 ```
 
 The [`all`](/commands/docs/all.md) command determines if every item in a list
@@ -223,17 +223,17 @@ For example:
 ```nu
 let colors = [red green blue]
 # Do all color names end with "e"?
-$colors | all {|it| $it | str ends-with "e" } # false
+$colors | all {|elt| $elt | str ends-with "e" } # false
 
 # Is the length of all color names greater than or equal to 3?
-$colors | all {|it| ($it | str length) >= 3 } # true
+$colors | all {|elt| ($elt | str length) >= 3 } # true
 
 let scores = [3 8 4]
 # Are all scores greater than 7?
-$scores | all {|it| $it > 7 } # false
+$scores | all {|elt| $elt > 7 } # false
 
 # Are all scores even?
-$scores | all {|it| $it mod 2 == 0 } # false
+$scores | all {|elt| $elt mod 2 == 0 } # false
 ```
 
 ## Converting the list
@@ -256,5 +256,5 @@ be converted to a separate row with a single column:
 let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
 
 # Show world clock for selected time zones
-$zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}
+$zones | wrap 'Zone' | upsert Time {|row| (date now | date to-timezone $row.Zone | format date '%Y.%m.%d %H:%M')}
 ```

--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -200,7 +200,7 @@ If you want to get one string out of the end then `str join` is your friend:
 You can also use reduce:
 
 ```nu
-1..10 | reduce -f "" {|it, acc| $acc + ($it | into string) + " + "} # 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 +
+1..10 | reduce -f "" {|elt, acc| $acc + ($elt | into string) + " + "} # 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 +
 ```
 
 Though in the cases of strings, especially if you don't have to operate on the strings, it's usually easier and more correct (notice the extra + at the end in the example above) to use `str join`.

--- a/book/working_with_tables.md
+++ b/book/working_with_tables.md
@@ -253,7 +253,7 @@ We could join all three tables together like this:
 Or we could use the [`reduce`](/commands/docs/reduce.md) command to dynamically merge all tables:
 
 ```nu
-> [$first $second $third] | reduce {|it, acc| $acc | merge $it }
+> [$first $second $third] | reduce {|elt, acc| $acc | merge $elt }
 ───┬───┬───┬───┬───┬───┬───
  # │ a │ b │ c │ d │ e │ f
 ───┼───┼───┼───┼───┼───┼───

--- a/cookbook/tables.md
+++ b/cookbook/tables.md
@@ -86,10 +86,10 @@ Or as mentioned in the [Cookbook](https://www.nushell.sh/book/working_with_table
 
 ```nu
 [$first_table $second_table $third_table]
-| reduce { |it, acc|
+| reduce { |elt, acc|
     $acc
-    | chunks ($it | length)
-    | each { merge $it }
+    | chunks ($elt | length)
+    | each { merge $elt }
     | flatten
   }
 ```

--- a/de/book/thinking_in_nushell.md
+++ b/de/book/thinking_in_nushell.md
@@ -88,7 +88,7 @@ Schleifenzähler sind ein anderes häufiges Muster für veränderliche Variablen
 Zum Beispiel kann sowohl jedes Element wie auch dessen Index mit dem `-n` Flag von [`each`](/commands/docs/each.md) erreicht werden:
 
 ```
-> ls | enumerate | each { |it| $"Number ($it.index) is size ($it.item.size)" }
+> ls | enumerate | each { |row| $"Number ($row.index) is size ($row.item.size)" }
 ```
 
 Mit dem [`reduce`](/commands/docs/reduce.md) kann eine ähnliche Funktionalität erreicht werden wie man es von Variablen in Schleifen kennt.
@@ -119,8 +119,8 @@ In der Praxis ist damit präziserer Code möglich, um zum Beispiel mit Unterverz
 erstellt werden soll:
 
 ```
-> ls | each { |it|
-    cd $it.name
+> ls | each { |elt|
+    cd $elt.name
     make
 }
 ```

--- a/de/book/types_of_data.md
+++ b/de/book/types_of_data.md
@@ -50,7 +50,7 @@ Nushell unterstützt Text Erweiterung, was es erlaubt, Unterausdrücke innerhalb
 ```
 
 ```
-> ls | each { |it| echo $"($it.name) is ($it.size)" }
+> ls | each { |row| echo $"($row.name) is ($row.size)" }
 ───┬─────────────────────
  0 │ genawait is 4.1 KB
  1 │ learncpp is 4.1 KB
@@ -284,10 +284,10 @@ Oder aus einer Liste von Wertepaaren:
 
 ## Blöcke (blocks)
 
-Unter einem Block versteht man einen Block aus Code. Wie im Befehl `each { |it| echo $it }` ist der Block der Teil in den geschweiften Klammern, also { |it| echo $it }`. Block Parameter werden zwischen zwei Pipe-Symbolen eingegeben (z.B. ` |it| `)
+Unter einem Block versteht man einen Block aus Code. Wie im Befehl `each { |elt| echo $elt }` ist der Block der Teil in den geschweiften Klammern, also `{ |elt| echo $elt }`. Block Parameter werden zwischen zwei Pipe-Symbolen eingegeben (z.B. ` |elt| `)
 
-Blöcke sind ein praktischer Weg Code einzugeben, der auf jeder Zeile der Daten ausgeführt wird. Es ist üblich `$it` als Parameter in [`each`](/commands/docs/each.md)
-zu benutzen, aber nicht zwingend. `each { |x| echo $x }`funktioniert gleich wie `each { |it| echo $it }`.
+Blöcke sind ein praktischer Weg Code einzugeben, der auf jeder Zeile der Daten ausgeführt wird. Es ist üblich `$elt` als Parameter in [`each`](/commands/docs/each.md)
+zu benutzen, aber nicht zwingend. `each { |x| echo $x }`funktioniert gleich wie `each { |elt| echo $elt }`.
 
 ## Gruppen (groups)
 

--- a/de/book/working_with_lists.md
+++ b/de/book/working_with_lists.md
@@ -39,16 +39,16 @@ echo $colors # [red yellow green purple]
 ## Durch Listen iterieren
 
 Um durch eine Liste zu iterieren, wird der [`each`](/commands/docs/each.md) Befehl vewendet, dem ein [block](types_of_data.html#blocks)
-mit Nu-Code folgt, der auf jedes Element der Liste angewendet wird. Der Block Parameter (z.B. `|it|` in `{ |it| echo $it }`)
+mit Nu-Code folgt, der auf jedes Element der Liste angewendet wird. Der Block Parameter (z.B. `|elt|` in `{ |elt| echo $elt }`)
 entspricht normalerweise dem Element der Liste, was jedoch mit dem `--numbered` (`-n`) Flag geändert werden kann in die zwei
 Parameter `index` und `item`. zum Beispiel:
 
 ```nu
 let names = [Mark Tami Amanda Jeremy]
-$names | each { |it| $"Hello, ($it)!" }
+$names | each { |elt| $"Hello, ($elt)!" }
 # Outputs "Hello, Mark!" and three more similar lines.
 
-$names | enumerate | each { |it| $"($it.index + 1) - ($it.item)" }
+$names | enumerate | each { |elt| $"($elt.index + 1) - ($elt.item)" }
 # Outputs "1 - Mark", "2 - Tami", etc.
 ```
 
@@ -79,13 +79,13 @@ Zum Beispiel:
 
 ```nu
 let scores = [3 8 4]
-echo "total =" ($scores | reduce { |it, acc| $acc + $it }) # 15
+echo "total =" ($scores | reduce { |elt, acc| $acc + $elt }) # 15
 
 echo "total =" ($scores | math sum) # easier approach, same result
 
-echo "product =" ($scores | reduce --fold 1 { |it, acc| $acc * $it }) # 96
+echo "product =" ($scores | reduce --fold 1 { |elt, acc| $acc * $elt }) # 96
 
-echo $scores | reduce -n { |it, acc| $acc.item + $it.index * $it.item } # 3 + 1*8 + 2*4 = 19
+echo $scores | reduce -n { |elt, acc| $acc.item + $elt.index * $elt.item } # 3 + 1*8 + 2*4 = 19
 ```
 
 ## Auf Listen zugreifen
@@ -135,16 +135,16 @@ Zum Beispiel:
 
 ```nu
 # Do any color names end with "e"?
-$colors | any {|it| $it | str ends-with "e" } # true
+$colors | any {|elt| $elt | str ends-with "e" } # true
 
 # Is the length of any color name less than 3?
-$colors | any {|it| ($it | str length) < 3 } # false
+$colors | any {|elt| ($elt | str length) < 3 } # false
 
 # Are any scores greater than 7?
-$scores | any {|it| $it > 7 } # true
+$scores | any {|elt| $elt > 7 } # true
 
 # Are any scores odd?
-$scores | any {|it| $it mod 2 == 1 } # true
+$scores | any {|elt| $elt mod 2 == 1 } # true
 ```
 
 Der [`all`](/commands/docs/all.md) Befehl wiederum ermittelt, ob jedes Element der Liste einer Bedingung entspricht.
@@ -152,16 +152,16 @@ Zum Beispiel:
 
 ```nu
 # Do all color names end with "e"?
-$colors | all {|it| $it | str ends-with "e" } # false
+$colors | all {|elt| $elt | str ends-with "e" } # false
 
 # Is the length of all color names greater than or equal to 3?
-$colors | all {|it| ($it | str length) >= 3 } # true
+$colors | all {|elt| ($elt | str length) >= 3 } # true
 
 # Are all scores greater than 7?
-$scores | all {|it| $it > 7 } # false
+$scores | all {|elt| $elt > 7 } # false
 
 # Are all scores even?
-$scores | all {|it| $it mod 2 == 0 } # false
+$scores | all {|elt| $elt mod 2 == 0 } # false
 ```
 
 ## Eine Liste konvertieren
@@ -184,5 +184,5 @@ Jedes Listen-Element wird in eine eigene Zeile mit einer einzigen Spalte überf�
 let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
 
 # Show world clock for selected time zones
-$zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}
+$zones | wrap 'Zone' | upsert Time {|row| (date now | date to-timezone $row.Zone | format date '%Y.%m.%d %H:%M')}
 ```

--- a/de/book/working_with_tables.md
+++ b/de/book/working_with_tables.md
@@ -225,7 +225,7 @@ Können nun alle drei Tabellen zusammengeführt werden wie hier:
 Oder mit dem [`reduce`](/commands/docs/reduce.md) Befehl alle dynamisch gemerged:
 
 ```
-> [$first $second $third] | reduce {|it, acc| $acc|merge { $it }}
+> [$first $second $third] | reduce {|elt, acc| $acc|merge { $elt }}
 ───┬───┬───┬───┬───┬───┬───
  # │ a │ b │ c │ d │ e │ f
 ───┼───┼───┼───┼───┼───┼───

--- a/lang-guide/chapters/types/basic_types/closure.md
+++ b/lang-guide/chapters/types/basic_types/closure.md
@@ -60,7 +60,7 @@ Closures are used in Nu extensively as parameters to iteration style commands li
    ```nu
    if true {
      mut x = 9
-     do {|it| $it + $x }
+     do {|p| $p + $x }
    }
    # => Error: Capture of mutable variable.
    ```

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -111,7 +111,7 @@ def command-frontmatter [commands_group, command_name] {
     let indented_usage = (
         $commands_list
         | get usage
-        | each {|it| $"  ($it)"}
+        | each {|elt| $"  ($elt)"}
         | str join (char newline)
     )
 
@@ -267,8 +267,8 @@ $"($example.description)
     let sub_commands = if $one_word_cmd and ($sub_commands | length) > 0 {
         let commands = $sub_commands
             | select name usage type
-            | update name {|it| $"[`($it.name)`]\(/commands/docs/($it.name | safe-path).md\)" }
-            | upsert usage {|it| $it.usage | str replace -a '<' '\<' | str replace -a '>' '\>' }
+            | update name {|row| $"[`($row.name)`]\(/commands/docs/($row.name | safe-path).md\)" }
+            | upsert usage {|row| $row.usage | str replace -a '<' '\<' | str replace -a '>' '\>' }
             | to md --pretty
         ['', '## Subcommands:', '', $commands, ''] | str join (char newline)
     } else { '' }
@@ -291,7 +291,7 @@ $"($example.description)
     let doc = (
         ($top + $plugin_warning + $signatures + $flags + $parameters + $in_out + $examples + $extra_usage + $sub_commands)
         | lines
-        | each {|it| ($it | str trim -r) }
+        | each {|line| ($line | str trim -r) }
         | str join (char newline)
     )
 

--- a/pt-BR/book/line_editor.md
+++ b/pt-BR/book/line_editor.md
@@ -242,7 +242,7 @@ A próxima tecla de atalho é um exemplo de uma série de eventos enviados para 
       event:[
           { edit: Clear }
           { edit: InsertString,
-            value: "cd (ls | where type == dir | each { |it| $it.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
+            value: "cd (ls | where type == dir | each { |row| $row.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
 
           }
           { send: Enter }
@@ -266,7 +266,7 @@ Uma desvantagem da tecla de atalho anterior é o fato de que o texto inserido se
       mode: emacs
       event: {
         send: executehostcommand,
-        cmd: "cd (ls | where type == dir | each { |it| $it.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
+        cmd: "cd (ls | where type == dir | each { |row| $row.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
       }
     }
   ]
@@ -604,7 +604,7 @@ $env.config = {
             scope variables
             | where name =~ $buffer
             | sort-by name
-            | each { |it| {value: $it.name description: $it.type} }
+            | each { |elt| {value: $elt.name description: $elt.type} }
         }
       }
       ...

--- a/snippets/introduction/sys_get_external_echo_example.sh
+++ b/snippets/introduction/sys_get_external_echo_example.sh
@@ -1,2 +1,2 @@
-> sys | get host.sessions.name | each { |it| ^echo $it }
+> sys | get host.sessions.name | each { |elt| ^echo $elt }
 sophiajt

--- a/tools/dataframes_md-update.nu
+++ b/tools/dataframes_md-update.nu
@@ -7,8 +7,8 @@ let path = '../book/dataframes.md'
 let chapter = open $path
 let book_table_str = $chapter
     | lines
-    | skip until {|it| $it starts-with '| Command Name '}
-    | take until {|it| $it starts-with '## Future'}
+    | skip until {|line| $line starts-with '| Command Name '}
+    | take until {|line| $line starts-with '## Future'}
 
 let book_table = $book_table_str
     | parse '| {command_name} | {applies_to} | {description} | {nushell_equivalent} |'

--- a/tools/i18n.nu
+++ b/tools/i18n.nu
@@ -24,14 +24,14 @@ def update-i18n-status [] {
         ls -s book/*.md
             | where type == file
             | select name
-            | upsert en {|it| get-cell $it.name en }
-            | upsert zh-CN {|it| get-cell $it.name zh-CN }
-            | upsert de {|it| get-cell $it.name de }
-            | upsert tr {|it| get-cell $it.name tr }
-            | upsert ja {|it| get-cell $it.name ja }
-            | upsert es {|it| get-cell $it.name es }
-            | upsert pt-BR {|it| get-cell $it.name pt-BR }
-            | upsert ru {|it| get-cell $it.name ru }
+            | upsert en {|elt| get-cell $elt.name en }
+            | upsert zh-CN {|elt| get-cell $elt.name zh-CN }
+            | upsert de {|elt| get-cell $elt.name de }
+            | upsert tr {|elt| get-cell $elt.name tr }
+            | upsert ja {|elt| get-cell $elt.name ja }
+            | upsert es {|elt| get-cell $elt.name es }
+            | upsert pt-BR {|elt| get-cell $elt.name pt-BR }
+            | upsert ru {|elt| get-cell $elt.name ru }
             | to md --pretty
     )
     print $status
@@ -75,14 +75,14 @@ def gen-i18n-meta [] {
     ls -s book/*.md
         | where type == file
         | select name
-        | upsert en {|it| get-cell $it.name en }
-        | upsert zh-CN {|it| get-cell $it.name zh-CN }
-        | upsert de {|it| get-cell $it.name de }
-        | upsert tr {|it| get-cell $it.name tr }
-        | upsert ja {|it| get-cell $it.name ja }
-        | upsert es {|it| get-cell $it.name es }
-        | upsert pt-BR {|it| get-cell $it.name pt-BR }
-        | upsert ru {|it| get-cell $it.name ru }
+        | upsert en {|elt| get-cell $elt.name en }
+        | upsert zh-CN {|elt| get-cell $elt.name zh-CN }
+        | upsert de {|elt| get-cell $elt.name de }
+        | upsert tr {|elt| get-cell $elt.name tr }
+        | upsert ja {|elt| get-cell $elt.name ja }
+        | upsert es {|elt| get-cell $elt.name es }
+        | upsert pt-BR {|elt| get-cell $elt.name pt-BR }
+        | upsert ru {|elt| get-cell $elt.name ru }
         | to json -i 2
         | save -rf $META_FILE
 }
@@ -100,8 +100,8 @@ def check-outdated-translation [
 ] {
     let columns = { 'zh-cn': 'zh-CN', 'pt-br': 'pt-BR' }
     let locale = if ($lng in $columns) { $columns | get $lng } else { $lng }
-    open $META_FILE | select name $locale | insert outdated { |it|
-        let val = ($it | get $locale)
+    open $META_FILE | select name $locale | insert outdated { |row|
+        let val = ($row | get $locale)
         if ($val | is-empty) or $val == '-' {
             '-'
         # Handle data like: "c13a71d11@hustcer"
@@ -109,12 +109,12 @@ def check-outdated-translation [
             let commit = ($val | split row '@')
             let id = ($commit | get 0)
             if ($commit | length) > 1 and (has-ref $id) {
-                has-change $it.name $id
+                has-change $row.name $id
             } else {
                 'N/A'
             }
         } else if (has-ref $val) {
-            has-change $it.name $val
+            has-change $row.name $val
         } else {
             'N/A'
         }

--- a/zh-CN/book/custom_commands.md
+++ b/zh-CN/book/custom_commands.md
@@ -410,7 +410,7 @@ def my-ls [] { ls }
 
 ```nu
 def double [] {
-  each { |it| 2 * $it }
+  each { |elt| 2 * $elt }
 }
 ```
 

--- a/zh-CN/book/line_editor.md
+++ b/zh-CN/book/line_editor.md
@@ -253,7 +253,7 @@ Reedline 按键绑定是一个强大的结构，它允许你建立一连串的�
       event:[
           { edit: Clear }
           { edit: InsertString,
-            value: "cd (ls | where type == dir | each { |it| $it.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
+            value: "cd (ls | where type == dir | each { |row| $row.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
 
           }
           { send: Enter }
@@ -278,7 +278,7 @@ Reedline 按键绑定是一个强大的结构，它允许你建立一连串的�
       mode: emacs
       event: {
         send: ExecuteHostCommand,
-        cmd: "cd (ls | where type == dir | each { |it| $it.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
+        cmd: "cd (ls | where type == dir | each { |row| $row.name} | str join (char nl) | fzf | decode utf-8 | str trim)"
       }
     }
   ]
@@ -643,7 +643,7 @@ let a = (ls | where size > 10MiB)
             scope variables
             | where name =~ $buffer
             | sort-by name
-            | each { |it| {value: $it.name description: $it.type} }
+            | each { |row| {value: $row.name description: $row.type} }
         }
       }
       ...

--- a/zh-CN/book/parallelism.md
+++ b/zh-CN/book/parallelism.md
@@ -13,8 +13,8 @@ Nushell 现在已经初步支持并行运行代码了，这允许你使用更多
 假设你想计算当前目录下每个子目录下的文件数量。使用[`each`](/commands/docs/each.md)你可以这样写。
 
 ```nu
-> ls | where type == dir | each { |it|
-    { name: $it.name, len: (ls $it.name | length) }
+> ls | where type == dir | each { |elt|
+    { name: $elt.name, len: (ls $elt.name | length) }
 }
 ```
 
@@ -25,8 +25,8 @@ Nushell 现在已经初步支持并行运行代码了，这允许你使用更多
 现在，由于这个操作可以并行运行，让我们把上面的操作转换为并行的，把[`each`](/commands/docs/each.md)改为[`par-each`](/commands/docs/par-each.md)：
 
 ```nu
-> ls | where type == dir | par-each { |it|
-    { name: $it.name, len: (ls $it.name | length) }
+> ls | where type == dir | par-each { |row|
+    { name: $row.name, len: (ls $row.name | length) }
 }
 ```
 
@@ -35,8 +35,8 @@ Nushell 现在已经初步支持并行运行代码了，这允许你使用更多
 顺便提一下：由于 [环境变量是有作用域的](environment.md#作用域)，你可以使用`par-each`在多个目录中并行工作（注意 `cd` 命令）：
 
 ```nu
-> ls | where type == dir | par-each { |it|
-    { name: $it.name, len: (cd $it.name; ls | length) }
+> ls | where type == dir | par-each { |row|
+    { name: $row.name, len: (cd $row.name; ls | length) }
 }
 ```
 

--- a/zh-CN/book/thinking_in_nu.md
+++ b/zh-CN/book/thinking_in_nu.md
@@ -101,7 +101,7 @@ let x = $x + 1
 循环计数器是可变变量的另一种常见模式，它被内置于大多数迭代命令中，例如，你可以使用 [`each`](/commands/docs/each.md) 上的 `-n` 标志同时获得每个元素的值和索引：
 
 ```nu
-> ls | enumerate | each { |it| $"Number ($it.index) is size ($it.item.size)" }
+> ls | enumerate | each { |elt| $"Number ($elt.index) is size ($elt.item.size)" }
 ```
 
 你也可以使用 [`reduce`](/commands/docs/reduce.md) 命令来达到上述目的，其方式与你在循环中修改一个变量相同。例如，如果你想在一个字符串列表中找到最长的字符串，你可以这样做：
@@ -127,8 +127,8 @@ Nushell 从编译型语言中获得了很多设计灵感，其中一个是语言
 在实践中，这可以让你用更简洁的代码来处理子目录，例如，如果你想在当前目录下构建每个子项目，你可以运行：
 
 ```nu
-> ls | each { |it|
-    cd $it.name
+> ls | each { |row|
+    cd $row.name
     make
 }
 ```

--- a/zh-CN/book/types_of_data.md
+++ b/zh-CN/book/types_of_data.md
@@ -62,7 +62,7 @@ Nushell 支持字符串插值，允许你在以`$`为前缀的字符串中运行
 ```
 
 ```
-> ls | each { |it| echo $"($it.name) is ($it.size)" }
+> ls | each { |elt| echo $"($elt.name) is ($elt.size)" }
 ───┬─────────────────────
  0 │ genawait is 4.1 KB
  1 │ learncpp is 4.1 KB
@@ -290,9 +290,9 @@ Eg) `1wk`是一个星期的时间间隔。
 
 ## 块
 
-块(Blocks)表示 Nu 中的一个代码块。例如，在命令 `each { |it| echo $it }` 中，块是包含在大括号中的部分，`{ |it| echo $it }`。如果有必要，可以在一对管道符号（例如，`|it|`）之间指定块参数。
+块(Blocks)表示 Nu 中的一个代码块。例如，在命令 `each { |elt| echo $elt }` 中，块是包含在大括号中的部分，`{ |elt| echo $elt }`。如果有必要，可以在一对管道符号（例如，`|elt|`）之间指定块参数。
 
-块是表示可以在每行数据上执行的代码的一种有效方法。在[`each`](/commands/docs/each.md)块中使用`$it`作为参数名是惯例，但并不是必须的：`each { |x| echo $x }`与`each { |it| echo $it }`的结果相同。
+块是表示可以在每行数据上执行的代码的一种有效方法。在[`each`](/commands/docs/each.md)块中使用`$elt`作为参数名是惯例，但并不是必须的：`each { |x| echo $x }`与`each { |elt| echo $elt }`的结果相同。
 
 ## 组
 

--- a/zh-CN/book/working_with_lists.md
+++ b/zh-CN/book/working_with_lists.md
@@ -33,14 +33,14 @@ $colors # [red yellow green purple]
 
 ## 迭代列表
 
-要遍历一个列表中的元素，可以使用[`each`](/commands/docs/each.md)命令和 [Nu 代码块](types_of_data.html#块) 指定对每一个元素做什么操作。块参数（例如`{ |it| echo $it }`中的`|it|`）通常是当前的列表元素，但如果需要，通过 `--numbered`(`-n`) 标志可以将其改为包含`index`和`item`值的元素。比如：
+要遍历一个列表中的元素，可以使用[`each`](/commands/docs/each.md)命令和 [Nu 代码块](types_of_data.html#块) 指定对每一个元素做什么操作。块参数（例如`{ |elt| echo $elt }`中的`|elt|`）通常是当前的列表元素，但如果需要，通过 `--numbered`(`-n`) 标志可以将其改为包含`index`和`item`值的元素。比如：
 
 ```nu
 let names = [Mark Tami Amanda Jeremy]
-$names | each { |it| $"Hello, ($it)!" }
+$names | each { |name| $"Hello, ($name)!" }
 # Outputs "Hello, Mark!" and three more similar lines.
 
-$names | enumerate | each { |it| $"($it.index + 1) - ($it.item)" }
+$names | enumerate | each { |item| $"($item.index + 1) - ($item.item)" }
 # Outputs "1 - Mark", "2 - Tami", etc.
 ```
 
@@ -64,19 +64,19 @@ $scores | where $it > 7 # [10 8]
 ```
 
 [`reduce`](/commands/docs/reduce.md)命令从一个列表计算一个单一的值。
-它使用了一个代码块，该块有两个参数：当前元素（即 `it`）和一个累加器 (即 `acc`)。如果想要给累加器指定一个初始值，请使用 `--fold` (`-f`) 标志。
-若要改变`it`使其具有`index`和`item`两个值，请添加`--numbered`（`-n`）标志。
+它使用了一个代码块，该块有两个参数：当前元素（即 `elt`）和一个累加器 (即 `acc`)。如果想要给累加器指定一个初始值，请使用 `--fold` (`-f`) 标志。
+若要改变`elt`使其具有`index`和`item`两个值，请添加`--numbered`（`-n`）标志。
 例如：
 
 ```nu
 let scores = [3 8 4]
-echo "total =" ($scores | reduce { |it, acc| $acc + $it }) # 15
+echo "total =" ($scores | reduce { |elt, acc| $acc + $elt }) # 15
 
 echo "total =" ($scores | math sum) # easier approach, same result
 
-echo "product =" ($scores | reduce --fold 1 { |it, acc| $acc * $it }) # 96
+echo "product =" ($scores | reduce --fold 1 { |elt, acc| $acc * $elt }) # 96
 
-$scores | reduce -n { |it, acc| $acc.item + $it.index * $it.item } # 3 + 1*8 + 2*4 = 19
+$scores | reduce -n { |elt, acc| $acc.item + $elt.index * $elt.item } # 3 + 1*8 + 2*4 = 19
 ```
 
 ## 访问列表
@@ -123,32 +123,32 @@ let colors = [red green blue]
 
 ```nu
 # Do any color names end with "e"?
-$colors | any {|it| $it | str ends-with "e" } # true
+$colors | any {|elt| $elt | str ends-with "e" } # true
 
 # Is the length of any color name less than 3?
-$colors | any {|it| ($it | str length) < 3 } # false
+$colors | any {|elt| ($elt | str length) < 3 } # false
 
 # Are any scores greater than 7?
-$scores | any {|it| $it > 7 } # true
+$scores | any {|elt| $elt > 7 } # true
 
 # Are any scores odd?
-$scores | any {|it| $it mod 2 == 1 } # true
+$scores | any {|elt| $elt mod 2 == 1 } # true
 ```
 
 [`all`](/commands/docs/all.md)命令确定一个列表中是否所有元素都匹配给定的条件。例如：
 
 ```nu
 # Do all color names end with "e"?
-$colors | all {|it| $it | str ends-with "e" } # false
+$colors | all {|elt| $elt | str ends-with "e" } # false
 
 # Is the length of all color names greater than or equal to 3?
-$colors | all {|it| ($it | str length) >= 3 } # true
+$colors | all {|elt| ($elt | str length) >= 3 } # true
 
 # Are all scores greater than 7?
-$scores | all {|it| $it > 7 } # false
+$scores | all {|elt| $elt > 7 } # false
 
 # Are all scores even?
-$scores | all {|it| $it mod 2 == 0 } # false
+$scores | all {|elt| $elt mod 2 == 0 } # false
 ```
 
 ## 转换列表
@@ -167,10 +167,10 @@ $scores | all {|it| $it mod 2 == 0 } # false
 let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
 
 # Show world clock for selected time zones
-$zones | wrap 'Zone' | upsert Time {|it|
+$zones | wrap 'Zone' | upsert Time {|row|
     (
         date now
-            | date to-timezone $it.Zone
+            | date to-timezone $row.Zone
             | format date '%Y.%m.%d %H:%M'
     )
 }

--- a/zh-CN/book/working_with_tables.md
+++ b/zh-CN/book/working_with_tables.md
@@ -215,7 +215,7 @@
 或者我们可以使用[`reduce`](/commands/docs/reduce.md)命令来动态地合并所有的表格：
 
 ```nu
-> [$first $second $third] | reduce {|it, acc| $acc | merge { $it }}
+> [$first $second $third] | reduce {|elt, acc| $acc | merge { $elt }}
 ───┬───┬───┬───┬───┬───┬───
  # │ a │ b │ c │ d │ e │ f
 ───┼───┼───┼───┼───┼───┼───


### PR DESCRIPTION
`$it` is a special variable used in `where`, so using it as a closure parameter name may lead to confusion.

For example:

* nushell/nushell#9443
* nushell/nushell#9271

To reduce possible confusion I suggest to _not_ use `$it` as a closure parameter name in documentation examples.

Refs: https://discord.com/channels/601130461678272522/729071784321876040/1278075102633791520
