### PR TITLE
Replace `it` with `elt` / `row` / `line` - batch 2

### DIFF
--- a/book/cheat_sheet.md
+++ b/book/cheat_sheet.md
@@ -176,7 +176,7 @@ slice first list values:
 ╰───┴───────────╯
 ```
 
-iterate over a list; `it` is current list value:
+iterate over a list; `elt` is current list value:
 
 ```nu
 > let planets = [Mercury Venus Earth Mars Jupiter Saturn Uranus Neptune]

--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -134,9 +134,9 @@ $scores | where $it > 7 # [10 8]
 ```
 
 The [`reduce`](/commands/docs/reduce.md) command computes a single value from a list.
-It uses a block which takes 2 parameters: the current item (conventionally named `it`) and an accumulator
+It uses a block which takes 2 parameters: the current item (conventionally named `elt`) and an accumulator
 (conventionally named `acc`). To specify an initial value for the accumulator, use the `--fold` (`-f`) flag.
-To change `it` to have `index` and `item` values, use the [`enumerate`](/commands/docs/enumerate.md) filter.
+To change `elt` to have `index` and `item` values, use the [`enumerate`](/commands/docs/enumerate.md) filter.
 For example:
 
 ```nu

--- a/de/book/working_with_lists.md
+++ b/de/book/working_with_lists.md
@@ -71,9 +71,9 @@ echo $scores | where $it > 7 # [10 8]
 ```
 
 Der [`reduce`](/commands/docs/reduce.md) Befehl berechnet einen einfachen Wert aus einer Liste.
-Der darauffolgende Block enthält 2 Parameter: Das momentane Element (üblicherweise `it` genannt)
+Der darauffolgende Block enthält 2 Parameter: Das momentane Element (üblicherweise `elt` genannt)
 und einen Sammler (Akkumulator) (üblicherweise `acc`). Um einen initialen Wert für den Akkumulator zu setzen,
-wird das `--fold` (`-f`) Flag gesetzt. Um den Iterator `it` zu ändern nach `index` und `item`, wird wiederum
+wird das `--fold` (`-f`) Flag gesetzt. Um den Iterator `elt` zu ändern nach `index` und `item`, wird wiederum
 das `--numbered` (`-n`) Flag verwendet.
 Zum Beispiel:
 


### PR DESCRIPTION
I missed several instances in the previous PR
