### PR TITLE
Promotes Installation to its own top-level Book chapter

### DIFF
--- a/.vuepress/configs/sidebar/en.ts
+++ b/.vuepress/configs/sidebar/en.ts
@@ -9,12 +9,16 @@ export const sidebarEn: SidebarConfig = {
       collapsible: false,
     },
     {
+      text: 'Installation',
+      link: '/book/installation.md',
+      collapsible: false,
+      children: ['/book/default_shell.md'],
+    },
+    {
       text: 'Getting Started',
       link: '/book/getting_started.md',
       collapsible: false,
       children: [
-        '/book/installation.md',
-        '/book/default_shell.md',
         '/book/quick_tour.md',
         '/book/moving_around.md',
         '/book/thinking_in_nu.md',

--- a/book/README.md
+++ b/book/README.md
@@ -15,7 +15,8 @@ Nu takes cues from a lot of familiar territory: traditional shells like bash, ob
 The book is split into chapters which are further broken down into sections.
 You can click on the chapter headers to get more information about it.
 
-- [Getting Started](getting_started.md) teaches you how to install Nushell and shows you the ropes. It also explains some of the design principles where Nushell differs from typical shells, such as bash.
+- [Installation](installation.md), of course, helps you get Nushell onto your system.
+- [Getting Started](getting_started.md) shows you the ropes. It also explains some of the design principles where Nushell differs from typical shells, such as Bash.
 - [Nu Fundamentals](nu_fundamentals.md) explains basic concepts of the Nushell language.
 - [Programming in Nu](programming_in_nu.md) dives more deeply into the language features and shows several ways how to organize and structure your code.
 - [Nu as a Shell](nu_as_a_shell.md) focuses on the shell features, most notably the configuration and environment.

--- a/book/getting_started.md
+++ b/book/getting_started.md
@@ -2,8 +2,6 @@
 
 Let's get started! :elephant:
 
-First, to be able to use Nushell, we need to [install it](installation.md).
+The next sections will give you a [short tour of Nushell by example](quick_tour.md) (including how to get help from within Nushell) and show you how to [move around your file system](moving_around.md).
 
-The next sections will give you a [short tour of Nushell by example](quick_tour.md) (including how to get help from within Nushell), and show you how to [move around your file system](moving_around.md).
-
-Finally, because Nushell takes some design decisions that are quite different from typical shells or dynamic scripting languages, make sure to check [Thinking in Nu](thinking_in_nu.md) that explains some of these concepts.
+Then, because Nushell takes some design decisions that are quite different from typical shells or dynamic scripting languages, make sure to check out [Thinking in Nu](thinking_in_nu.md) where we explain some of these concepts.


### PR DESCRIPTION
Related to #1508 - This is in preparation for changing the Navbar so that we can link directly to "Install" and "Getting Started".  It just makes *"Installation"* it's own top-level chapter instead of being a sub-section of *"Getting Started"*.