### PR TITLE
fix: use consistent headline capitalization

### DIFF
--- a/book/3rdpartyprompts.md
+++ b/book/3rdpartyprompts.md
@@ -1,4 +1,4 @@
-# How to configure 3rd party prompts
+# How to Configure 3rd Party Prompts
 
 ## nerdfonts
 

--- a/book/advanced.md
+++ b/book/advanced.md
@@ -1,4 +1,4 @@
-# (Not So) Advanced
+# (Not so) Advanced
 
 While the "Advanced" title might sound daunting and you might be tempted to skip this chapter, in fact, some of the most interesting and powerful features can be found here.
 

--- a/book/background_task.md
+++ b/book/background_task.md
@@ -1,4 +1,4 @@
-# Background tasks with Nu
+# Background Tasks with Nu
 
 Currently, Nushell doesn't have built-in background task management feature, but you can make it "support" background task with some tools, here are some examples:
 

--- a/book/cheat_sheet.md
+++ b/book/cheat_sheet.md
@@ -1,4 +1,4 @@
-# Nushell cheat sheet
+# Nushell Cheat Sheet
 
 ## Data types
 

--- a/book/command_signature.md
+++ b/book/command_signature.md
@@ -1,4 +1,4 @@
-# Command signature
+# Command Signature
 
 nu commands can be given explicit signatures; take [`str stats`](/commands/docs/str_stats.md) as an example, the signature is like this:
 

--- a/book/creating_errors.md
+++ b/book/creating_errors.md
@@ -1,4 +1,4 @@
-# Creating your own errors
+# Creating Your Own Errors
 
 Using the [metadata](metadata.md) information, you can create your own custom error messages. Error messages are built of multiple parts:
 

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -1,4 +1,4 @@
-# Custom commands
+# Custom Commands
 
 Nu's ability to compose long pipelines allows you a lot of control over your data and system, but it comes at the price of a lot of typing. Ideally, you'd be able to save your well-crafted pipelines to use again and again.
 

--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -1,4 +1,4 @@
-# Custom completions
+# Custom Completions
 
 Custom completions allow you to mix together two features of Nushell: custom commands and completions. With them, you're able to create commands that handle the completions for positional parameters and flag parameters. These custom completions work both for [custom commands](custom_commands.md) and [known external, or `extern`, commands](externs.md).
 

--- a/book/default_shell.md
+++ b/book/default_shell.md
@@ -1,4 +1,4 @@
-# Default shell
+# Default Shell
 
 ## Setting Nu as default shell on your terminal
 

--- a/book/escaping.md
+++ b/book/escaping.md
@@ -1,4 +1,4 @@
-# Escaping to the system
+# Escaping to the System
 
 Nu provides a set of commands that you can use across different OSes ("internal" commands), and having this consistency is helpful. Sometimes, though, you want to run an external command that has the same name as an internal Nu command. To run the external [`ls`](/commands/docs/ls.md) or [`date`](/commands/docs/date.md) command, for example, you use the caret (^) command. Escaping with the caret prefix calls the command that's in the user's PATH (e.g. `/bin/ls` instead of Nu's internal [`ls`](/commands/docs/ls.md) command).
 

--- a/book/line_editor.md
+++ b/book/line_editor.md
@@ -1,4 +1,4 @@
-# Reedline, Nu's line editor
+# Reedline, Nu's Line Editor
 
 Nushell's line editor [Reedline](https://github.com/nushell/reedline) is a
 cross-platform line reader designed to be modular and flexible. The engine is

--- a/book/loading_data.md
+++ b/book/loading_data.md
@@ -1,4 +1,4 @@
-# Loading data
+# Loading Data
 
 Earlier, we saw how you can use commands like [`ls`](/commands/docs/ls.md), [`ps`](/commands/docs/ps.md), [`date`](/commands/docs/date.md), and [`sys`](/commands/docs/sys.md) to load information about your files, processes, time of date, and the system itself. Each command gives us a table of information that we can explore. There are other ways we can load in a table of data to work with.
 

--- a/book/moving_around.md
+++ b/book/moving_around.md
@@ -1,4 +1,4 @@
-# Moving around the system
+# Moving around the System
 
 A defining characteristic of a shell is the ability to navigate and interact with the filesystem. Nushell is, of course, no exception. Here are some common commands you might use when interacting with the filesystem:
 

--- a/book/nushell_map_functional.md
+++ b/book/nushell_map_functional.md
@@ -1,4 +1,4 @@
-# Nu map from functional languages
+# Nu Map from Functional Languages
 
 The idea behind this table is to help you understand how Nu builtins and plugins relate to functional languages. We've tried to produce a map of relevant Nu commands and what their equivalents are in other languages. Contributions are welcome.
 

--- a/book/nushell_map_imperative.md
+++ b/book/nushell_map_imperative.md
@@ -1,4 +1,4 @@
-# Nu map from imperative languages
+# Nu Map from Imperative Languages
 
 The idea behind this table is to help you understand how Nu built-ins and plugins relate to imperative languages. We've tried to produce a map of programming-relevant Nu commands and what their equivalents are in other languages. Contributions are welcome.
 

--- a/book/regular_expressions.md
+++ b/book/regular_expressions.md
@@ -1,3 +1,3 @@
-# Regular expressions
+# Regular Expressions
 
 Regular expressions in Nushell's commands are handled by the `rust-lang/regex` crate. If you want to know more, check the crate documentation: "[regex](https://github.com/rust-lang/regex)".

--- a/book/shells_in_shells.md
+++ b/book/shells_in_shells.md
@@ -1,4 +1,4 @@
-# Shells in shells
+# Shells in Shells
 
 ## Working in multiple directories
 

--- a/book/style_guide.md
+++ b/book/style_guide.md
@@ -1,4 +1,4 @@
-# Best practices
+# Best Practices
 
 This page is a working document collecting syntax guidelines and best practices we have discovered so far.
 The goal of this document is to eventually land on a canonical Nushell code style, but as for now it is still work in

--- a/book/working_with_lists.md
+++ b/book/working_with_lists.md
@@ -1,4 +1,4 @@
-# Working with lists
+# Working with Lists
 
 :::tip
 Lists are equivalent to the individual columns of tables. You can think of a list as essentially being a "one-column table" (with no column name). Thus, any command which operates on a column _also_ operates on a list. For instance, [`where`](/commands/docs/where.md) can be used with lists:

--- a/book/working_with_strings.md
+++ b/book/working_with_strings.md
@@ -1,4 +1,4 @@
-# Working with strings
+# Working with Strings
 
 As with most languages, strings are a collection of 0 or more characters that represent text. This can include file names, file paths, names of columns,
 and much more. Strings are so common that Nushell offers multiple string formats to match your use-case:

--- a/book/working_with_tables.md
+++ b/book/working_with_tables.md
@@ -1,4 +1,4 @@
-# Working with tables
+# Working with Tables
 
 One of the common ways of seeing data in Nu is through a table. Nu comes with a number of commands for working with tables to make it convenient to find what you're looking for, and for narrowing down the data to just what you need.
 


### PR DESCRIPTION
I used  ¨Chicago Manual of Style" in https://headlinecapitalization.com/
