### PR TITLE
Fix link parentheses in Float type page

### DIFF
--- a/lang-guide/chapters/types/basic_types/float.md
+++ b/lang-guide/chapters/types/basic_types/float.md
@@ -6,7 +6,7 @@
 | **_Annotation:_**     | `float`                                                                          |
 | **_Literal syntax:_** | A decimal numeric value including a decimal place. E.g., `1.5`, `2.0`, `-15.333` |
 | **_Casts:_**          | [`into float`](/commands/docs/into_float.md)                                     |
-| **_See also:_**       | [Types of Data - Floats](/book/types_of_data.md#floatsdecimals                   |
+| **_See also:_**       | [Types of Data - Floats](/book/types_of_data.md#floatsdecimals)                  |
 
 ## Additional language notes
 


### PR DESCRIPTION
I've noticed a broken link in the float type page, so corrected it.