### PR TITLE
Fix nothing type literal: none → null

### DIFF
--- a/lang-guide/chapters/types/basic_types/nothing.md
+++ b/lang-guide/chapters/types/basic_types/nothing.md
@@ -4,7 +4,7 @@
 | --------------------- | --------------------------------------------------------------------------- |
 | **_Description:_**    | The `nothing` type is to be used to represent the absence of another value. |
 | **_Annotation:_**     | `nothing`                                                                   |
-| **_Literal Syntax:_** | `none`                                                                      |
+| **_Literal Syntax:_** | `null`                                                                      |
 | **_Casts:_**          | `ignore`                                                                    |
 | **_See also:_**       | [Types of Data - Nothing](/book/types_of_data.md#nothing-null)              |
 


### PR DESCRIPTION
I fixed wrong nothing type literal: `none` → `null`
This page says nothing type literal syntax is `null`.
https://www.nushell.sh/book/types_of_data.html#nothing-null