### PR TITLE
Fixes broken links

### DIFF
--- a/blog/2024-06-25-nushell_0_95_0.md
+++ b/blog/2024-06-25-nushell_0_95_0.md
@@ -54,7 +54,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 ## External command parsing improvements [[toc](#table-of-content)]
 
 ::: warning Breaking change
-See a full overview of the [breaking changes](#breaking-changes)
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
 :::
 
 A lot of the quirks of external command parsing have been cleaned up in [#13089](https://github.com/nushell/nushell/pull/13089), with most of the actual string handling work being moved into `nu-parser` itself. Previously, the parser was doing some very special things to create expressions in a way that `run-external` would then finish parsing in order to handle quotes in external options, globs, tilde expansion, etc., but this was error prone and did not have great test coverage.
@@ -93,7 +93,7 @@ Resolving this made it easier to find some of the edge cases that were not being
 ## Plugin version reporting [[toc](#table-of-content)]
 
 ::: warning Breaking change
-See a full overview of the [breaking changes](#breaking-changes)
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
 :::
 
 Plugins can now report their own version to Nushell, and have it displayed in `plugin list` and `version`. This can help users understand exactly which plugin version they have active in their shell.

--- a/blog/2024-07-23-nushell_0_96_0.md
+++ b/blog/2024-07-23-nushell_0_96_0.md
@@ -72,7 +72,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 
     ```md
     ::: warning Breaking change
-    See a full overview of the [breaking changes](#breaking-changes)
+    See a full overview of the [breaking changes](#all-breaking-changes-toc)
     :::
     ```
 -->
@@ -104,7 +104,7 @@ We expect to be able to replace the current evaluation engine with the IR evalua
 ## `$in` overhaul [[toc](#table-of-content)]
 
 ::: warning Breaking change
-See a full overview of the [breaking changes](#breaking-changes)
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
 :::
 
 The behavior of `$in` expressions has been made more consistent in [#13357](https://github.com/nushell/nushell/pull/13357), with the following rules generally applying:
@@ -187,7 +187,7 @@ Where `/usr` is used as the default, it can be customized by setting `$env.PREFI
 ## Consistent parsing for known externals [[toc](#table-of-content)]
 
 ::: warning Breaking change
-See a full overview of the [breaking changes](#breaking-changes)
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
 :::
 
 [#13414](https://github.com/nushell/nushell/pull/13414) modified how known externals (i.e., those declared with the `extern` command) are parsed to make them behave more like normal external commands when arguments that are outside of the declaration are provided.

--- a/blog/2024-08-20-nushell_0_97_1.md
+++ b/blog/2024-08-20-nushell_0_97_1.md
@@ -62,7 +62,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 
     ```md
     ::: warning Breaking change
-    See a full overview of the [breaking changes](#breaking-changes)
+    See a full overview of the [breaking changes](#all-breaking-changes-toc)
     :::
     ```
 -->
@@ -73,7 +73,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 ## More consistent parsing of assignment [[toc](#table-of-content)]
 
 ::: warning Breaking change
-See a full overview of the [breaking changes](#breaking-changes)
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
 :::
 
 The assignment operators and `const` have been changed ([#13385](https://github.com/nushell/nushell/pull/13385)) to better reflect the behavior used by `let` and `mut`. Before 0.97, these two statements would have been interpreted very differently:
@@ -125,7 +125,7 @@ $env.FOO = 'C:\foo\bar\baz.exe'
 ## Enhancements to path completions [[toc](#table-of-content)]
 
 ::: warning Breaking change
-See a full overview of the [breaking changes](#breaking-changes)
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
 :::
 
 Thanks to [@lavafroth](https://github.com/lavafroth) in [#13302](https://github.com/nushell/nushell/pull/13302), path completions now explicitly check for and prefer an exact match for a basename instead of longer or similar names.
@@ -331,7 +331,7 @@ Thanks to all the contributors below for helping us solve issues and improve doc
   - [Bump rust toolchain](https://github.com/nushell/nushell/pull/13499)
   - [Clippy fixes for toolchain bump](https://github.com/nushell/nushell/pull/13497)
   - [Create security policy](https://github.com/nushell/nushell/pull/13486)
-- [app/dependabot](https://github.com/app/dependabot) created
+- [app/dependabot](https://github.com/dependabot) created
   - [Bump indexmap from 2.3.0 to 2.4.0](https://github.com/nushell/nushell/pull/13617)
   - [Bump shadow-rs from 0.30.0 to 0.31.1](https://github.com/nushell/nushell/pull/13616)
   - [Bump sysinfo from 0.30.11 to 0.30.13](https://github.com/nushell/nushell/pull/13615)


### PR DESCRIPTION
The breaking changes were split up at some point in two sections but the internal link wasn't updated. This is now pointing at the full list of breaking changes again.