### PR TITLE
Release notes for `0.98.0`

### DIFF
--- a/blog/2024-09-17-nushell_0_98_0.md
+++ b/blog/2024-09-17-nushell_0_98_0.md
@@ -5,6 +5,7 @@ author_site: https://twitter.com/nu_shell
 author_image: https://www.nushell.sh/blog/images/nu_logo.png
 excerpt: Today, we're releasing version 0.98.0 of Nu. This release adds...
 ---
+
 <!-- TODO: complete the excerpt above -->
 
 # Nushell 0.98.0
@@ -12,6 +13,7 @@ excerpt: Today, we're releasing version 0.98.0 of Nu. This release adds...
 Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your command line. It works seamlessly with the data from your filesystem, operating system, and a growing number of file formats to make it easy to build powerful command line pipelines.
 
 <!-- TODO: write this excerpt -->
+
 Today, we're releasing version 0.98.0 of Nu. This release adds...
 
 # Where to get it
@@ -21,6 +23,7 @@ Nu 0.98.0 is available as [pre-built binaries](https://github.com/nushell/nushel
 As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
 
 # Table of content
+
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
 - [_Changes to commands_](#changes-to-commands-toc)
   - [_Additions_](#additions-toc)
@@ -49,6 +52,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 -->
 
 # Highlights and themes of this release [[toc](#table-of-content)]
+
 <!-- NOTE: if you wanna write a section about a breaking change, when it's a very important one,
     please add the following snippet to have a "warning" banner :)
     > see [an example](https://www.nushell.sh/blog/2023-09-19-nushell_0_85_0.html#pythonesque-operators-removal)
@@ -63,17 +67,85 @@ As part of this release, we also publish a set of optional plugins you can insta
     for the list of available *containers*
 -->
 
+## Removing support for the system clipboard
+
+With [#13694](https://github.com/nushell/nushell/pull/13694), support for the system clipboard in keybinds has been removed, as this is not something that we think we can provide good, cross-platform support for in a secure manner. Namely,
+
+- Tests for the clipboard feature are lacking due to the difficulty in setting up tests on each platform.
+- The clipboard feature is known to be problematic on certain systems, potentially affecting startup times. Due to the lack of tests, other unfound issues may be lurking.
+- The system clipboard adds a potential attack surface.
+- The clipboard feature adds 1MB to the binary size.
+
+So, going forward, users that want the system clipboard functionality will have to compile a custom build of nushell by enabling the `system-clipboard` cargo feature. As an alternative, we recommend users delegate system clipboard handling to their terminal.
+
 # Changes to commands [[toc](#table-of-content)]
 
 ## Additions [[toc](#table-of-content)]
 
+### `metadata access`
+
+Thanks to [@Bahex](https://github.com/Bahex) in [#13785](https://github.com/nushell/nushell/pull/13785), a new `metadata access` command was added. It takes a closure argument, and the first argument to the closure will be the metadata record. Additionally, the pipeline input to `metadata access` will be forwarded to the closure as is. So, unlike the `metadata` command, this new command allows you to get the metadata of a pipeline without consuming the pipeline.
+
+### `split column --numbered`
+
+Thanks to [@nome](https://github.com/nome) in [#13831](https://github.com/nushell/nushell/pull/13831), a `--numbered` flag was added to `split column` which limits the number of times to split the input string (just like `split row --numbered`).
+
 ## Breaking changes [[toc](#table-of-content)]
+
+### `into record`
+
+In [#13637](https://github.com/nushell/nushell/pull/13637), several changes/improvements were made to list inputs for `into record`:
+
+- A list of pairs of values will be converted into a record. For example:
+  ```nushell
+  [[a 1] [b 2]] | into record
+  # { a: 1, b: 2 }
+  ```
+- A list of records are merged into a single record (records at the end of the list have precedence):
+  ```nushell
+  [{ a: 1 } { b: 2 } { a: 3 }] | into record
+  # { a: 3, b: 2 }
+  ```
+
+As a consequence, the previous behavior for list inputs has been removed (the index of each item would be used as the key). Instead, this old behavior can now be accomplished through either of the following:
+
+```nushell
+0.. | zip $list | into record
+
+$list | enumerate | transpose -r -d | into record
+```
+
+Additionally, `into record` no longer supports range values as input.
+
+After [#13650](https://github.com/nushell/nushell/pull/13650), `into record` also now outputs `millisecond`, `microsecond`, and `nanosecond` columns when provided with a datetime value.
+
+### `clear`
+
+In [#13821](https://github.com/nushell/nushell/pull/13821), [@T3sT3ro](https://github.com/T3sT3ro) changed the `clear` command to clear the entire scrollback buffer. As such, the `--all` flag was removed, since it is now the default behavior. Instead, a `--keep-scrollback` flag was added, which when used, makes `clear` clear only the terminal (the previous default behavior).
+
+### `path exists`
+
+After [#13763](https://github.com/nushell/nushell/pull/13763), if an I/O error occurs when checking if a path exists, `false` is now returned instead of throwing an error (this includes errors due to insufficient permissions).
 
 ## Deprecations [[toc](#table-of-content)]
 
 ## Removals [[toc](#table-of-content)]
 
+### `str deunicode`
+
+In [#13693](https://github.com/nushell/nushell/pull/13693), the `str deunicode` command (added in v0.96.0) has been removed due to concerns with stability and support post v1.0.
+
 ## Bug fixes and other changes [[toc](#table-of-content)]
+
+### `find`
+
+After [#13848](https://github.com/nushell/nushell/pull/13848), the find command no longer strips tabs from its input.
+
+Also, regex patterns are now properly escaped after [#13792](https://github.com/nushell/nushell/pull/13792).
+
+### `detect columns`
+
+One source of panics was fixed in [#13752](https://github.com/nushell/nushell/pull/13752).
 
 <!-- NOTE: to start investigating the contributions of last release, i like to list them all in a raw table.
     to achieve this, one can use the [`list-merged-prs` script from `nu_scripts`](https://github.com/nushell/nu_scripts/blob/main/make_release/release-note/list-merged-prs)
@@ -103,6 +175,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 -->
 
 # All breaking changes [[toc](#table-of-content)]
+
 <!-- TODO:
     paste the output of
     ```nu
@@ -117,11 +190,13 @@ As part of this release, we also publish a set of optional plugins you can insta
 
 Thanks to all the contributors below for helping us solve issues and improve documentation :pray:
 
-| author                               | title       | url                                                     |
-| ------------------------------------ | ----------- | ------------------------------------------------------- |
-| [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
+| author                                           | title                     | url                                                     |
+| ------------------------------------------------ | ------------------------- | ------------------------------------------------------- |
+| [@author](https://github.com/author)             | ...                       | [#12345](https://github.com/nushell/nushell/pull/12345) |
+| [@poliorcetics](https://github.com/poliorcetics) | doc: fix broken doc links | [#13644](https://github.com/nushell/nushell/pull/13644) |
 
 # Full changelog [[toc](#table-of-content)]
+
 <!-- TODO:
     paste the output of
     ```nu

--- a/blog/2024-09-17-nushell_0_98_0.md
+++ b/blog/2024-09-17-nushell_0_98_0.md
@@ -1,0 +1,131 @@
+---
+title: Nushell 0.98.0
+author: The Nu Authors
+author_site: https://twitter.com/nu_shell
+author_image: https://www.nushell.sh/blog/images/nu_logo.png
+excerpt: Today, we're releasing version 0.98.0 of Nu. This release adds...
+---
+<!-- TODO: complete the excerpt above -->
+
+# Nushell 0.98.0
+
+Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your command line. It works seamlessly with the data from your filesystem, operating system, and a growing number of file formats to make it easy to build powerful command line pipelines.
+
+<!-- TODO: write this excerpt -->
+Today, we're releasing version 0.98.0 of Nu. This release adds...
+
+# Where to get it
+
+Nu 0.98.0 is available as [pre-built binaries](https://github.com/nushell/nushell/releases/tag/0.98.0) or from [crates.io](https://crates.io/crates/nu). If you have Rust installed you can install it using `cargo install nu`.
+
+As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
+
+# Table of content
+- [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
+- [_Changes to commands_](#changes-to-commands-toc)
+  - [_Additions_](#additions-toc)
+  - [_Breaking changes_](#breaking-changes-toc)
+  - [_Deprecations_](#deprecations-toc)
+  - [_Removals_](#removals-toc)
+  - [_Bug fixes and other changes_](#bug-fixes-and-other-changes-toc)
+- [_All breaking changes_](#all-breaking-changes-toc)
+- [_Notes for plugin developers_](#notes-for-plugin-developers-toc)
+- [_Hall of fame_](#hall-of-fame-toc)
+- [_Full changelog_](#full-changelog-toc)
+<!-- TODO: please add links to the other sections here
+
+    the following command should help pre-generate a great deal of the table of content.
+    be careful with the format and false-positives :wink:
+    ```nushell
+    rg '^#+ ' blog/...
+        | lines
+        | each {
+            str replace '# ' '- '
+                | str replace --all '#' '    '
+                | str replace --regex '- (.*)' '- [_$1_](#$1-toc)'
+        }
+        | to text
+    ```
+-->
+
+# Highlights and themes of this release [[toc](#table-of-content)]
+<!-- NOTE: if you wanna write a section about a breaking change, when it's a very important one,
+    please add the following snippet to have a "warning" banner :)
+    > see [an example](https://www.nushell.sh/blog/2023-09-19-nushell_0_85_0.html#pythonesque-operators-removal)
+
+    ```md
+    ::: warning Breaking change
+    See a full overview of the [breaking changes](#breaking-changes)
+    :::
+    ```
+-->
+<!-- NOTE: see https://vuepress.github.io/reference/default-theme/markdown.html#custom-containers
+    for the list of available *containers*
+-->
+
+# Changes to commands [[toc](#table-of-content)]
+
+## Additions [[toc](#table-of-content)]
+
+## Breaking changes [[toc](#table-of-content)]
+
+## Deprecations [[toc](#table-of-content)]
+
+## Removals [[toc](#table-of-content)]
+
+## Bug fixes and other changes [[toc](#table-of-content)]
+
+<!-- NOTE: to start investigating the contributions of last release, i like to list them all in a raw table.
+    to achieve this, one can use the [`list-merged-prs` script from `nu_scripts`](https://github.com/nushell/nu_scripts/blob/main/make_release/release-note/list-merged-prs)
+    as follows:
+
+    ```nushell
+    use ./make_release/release-note/list-merged-prs
+    use std clip
+
+    let last_release_date = ^gh api /repos/nushell/nushell/releases
+        | from json
+        | into datetime published_at
+        | get published_at
+        | sort
+        | last
+
+    let prs = list-merged-prs nushell/nushell $last_release_date
+        | sort-by mergedAt
+        | update url {|it| $"[#($it.number)]\(($it.url)\)" }
+        | update author { $"[@($in)]\(https://github.com/($in)\)" }
+        | select author title url
+        | rename -c {url: pr}
+        | to md --pretty
+
+    $prs | to md --pretty | clip
+    ```
+-->
+
+# All breaking changes [[toc](#table-of-content)]
+<!-- TODO:
+    paste the output of
+    ```nu
+    ./make_release/release-note/list-merged-prs nushell/nushell --label pr:breaking-change --pretty --no-author
+    ```
+    here
+-->
+
+# Notes for plugin developers [[toc](#table-of-content)]
+
+# Hall of fame [[toc](#table-of-content)]
+
+Thanks to all the contributors below for helping us solve issues and improve documentation :pray:
+
+| author                               | title       | url                                                     |
+| ------------------------------------ | ----------- | ------------------------------------------------------- |
+| [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
+
+# Full changelog [[toc](#table-of-content)]
+<!-- TODO:
+    paste the output of
+    ```nu
+    ./make_release/release-note/get-full-changelog
+    ```
+    here
+-->

--- a/blog/2024-09-17-nushell_0_98_0.md
+++ b/blog/2024-09-17-nushell_0_98_0.md
@@ -3,18 +3,14 @@ title: Nushell 0.98.0
 author: The Nu Authors
 author_site: https://twitter.com/nu_shell
 author_image: https://www.nushell.sh/blog/images/nu_logo.png
-excerpt: Today, we're releasing version 0.98.0 of Nu. This release adds...
+excerpt: Today, we're releasing version 0.98.0 of Nu. This release changes non-zero exit codes from external commands to be handled as errors, makes the IR evaluator the default, removes support for the system clipboard, and includes many command changes and bugfixes.
 ---
-
-<!-- TODO: complete the excerpt above -->
 
 # Nushell 0.98.0
 
 Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your command line. It works seamlessly with the data from your filesystem, operating system, and a growing number of file formats to make it easy to build powerful command line pipelines.
 
-<!-- TODO: write this excerpt -->
-
-Today, we're releasing version 0.98.0 of Nu. This release adds...
+Today, we're releasing version 0.98.0 of Nu. This release changes non-zero exit codes from external commands to be handled as errors, makes the IR evaluator the default, removes support for the system clipboard, and includes many command changes and bugfixes.
 
 # Where to get it
 
@@ -25,48 +21,51 @@ As part of this release, we also publish a set of optional plugins you can insta
 # Table of content
 
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
+  - [_Non-zero exit codes are now errors_](#non-zero-exit-codes-are-now-errors-toc)
+  - [_IR is now the default evaluator_](#ir-is-now-the-default-evaluator-toc)
+  - [_Removing support for the system clipboard_](#removing-support-for-the-system-clipboard-toc)
+  - [_Record parsing changes_](#record-parsing-changes-toc)
 - [_Changes_](#changes-toc)
   - [_Additions_](#additions-toc)
+    - [_`metadata access`_](#metadata-access-toc)
+    - [_`split cell-path`_](#split-cell-path-toc)
+    - [_`split column --numbered`_](#split-column-numbered-toc)
+    - [_`encode base32`, `decode base32`_](#encode-base32-decode-base32-toc)
+    - [_`encode base32hex`, `decode base32hex`_](#encode-base32hex-decode-base32hex-toc)
+    - [_`encode new-base64`, `decode new-base64`_](#encode-new-base64-decode-new-base64-toc)
   - [_Breaking changes_](#breaking-changes-toc)
+    - [_`into record`_](#into-record-toc)
+    - [_`clear`_](#clear-toc)
+    - [_`path exists`_](#path-exists-toc)
+    - [_`scope commands` and `help commands`_](#scope-commands-and-help-commands-toc)
+    - [_`tee`_](#tee-toc)
+    - [_`polars concatenate` renamed to `polars str-join`_](#polars-concatenate-renamed-to-polars-str-join-toc)
   - [_Deprecations_](#deprecations-toc)
+    - [_`encode base64`_](#encode-base64-toc)
   - [_Removals_](#removals-toc)
+    - [_`str deunicode`_](#str-deunicode-toc)
+    - [_`$env.config.use_grid_icons`_](#env-config-use-grid-icons-toc)
   - [_Bug fixes and other changes_](#bug-fixes-and-other-changes-toc)
+    - [_`find`_](#find-toc)
+    - [_`encode hex`_](#encode-hex-toc)
+    - [_Various Polars commands now support expressions_](#various-polars-commands-now-support-expressions-toc)
+    - [_Improved script help output_](#improved-script-help-output-toc)
+    - [_Bit operations and commands_](#bit-operations-and-commands-toc)
+    - [_`detect columns`_](#detect-columns-toc)
 - [_Notes for plugin developers_](#notes-for-plugin-developers-toc)
+  - [_Breaking plugin changes_](#breaking-plugin-changes-toc)
+  - [_Rust API improvements_](#rust-api-improvements-toc)
+  - [_Other changes_](#other-changes-toc)
 - [_Hall of fame_](#hall-of-fame-toc)
 - [_Full changelog_](#full-changelog-toc)
-<!-- TODO: please add links to the other sections here
-
-    the following command should help pre-generate a great deal of the table of content.
-    be careful with the format and false-positives :wink:
-    ```nushell
-    rg '^#+ ' blog/...
-        | lines
-        | each {
-            str replace '# ' '- '
-                | str replace --all '#' '    '
-                | str replace --regex '- (.*)' '- [_$1_](#$1-toc)'
-        }
-        | to text
-    ```
--->
 
 # Highlights and themes of this release [[toc](#table-of-content)]
 
-<!-- NOTE: if you wanna write a section about a breaking change, when it's a very important one,
-    please add the following snippet to have a "warning" banner :)
-    > see [an example](https://www.nushell.sh/blog/2023-09-19-nushell_0_85_0.html#pythonesque-operators-removal)
+## Non-zero exit codes are now errors [[toc](#table-of-content)]
 
-    ```md
-    ::: warning Breaking change
-    See a full overview of the [breaking changes](#breaking-changes)
-    :::
-    ```
--->
-<!-- NOTE: see https://vuepress.github.io/reference/default-theme/markdown.html#custom-containers
-    for the list of available *containers*
--->
-
-## Non-zero exit codes are now errors
+::: warning Breaking change
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
+:::
 
 One long-requested feature for nushell is to make non-zero exit codes throw an error. Before this release, non-zero exit codes would quietly stop execution. In some cases, execution would not even stop, but rather only skip over the remaining commands in the current code block. With this release, non-zero exit codes (and termination due to unix signals) are now errors just like any other error, so nushell now runs almost as if bash's `set -e` option was enabled ([#13515](https://github.com/nushell/nushell/pull/13515)).
 
@@ -101,7 +100,21 @@ With no config (e.g., when running a script), these config options are both `tru
 
 One last thing to note is that core dumps are treated as a separate error case and an error message will always be printed if the error is uncaught (i.e., there is no config option for this).
 
-## Removing support for the system clipboard
+## IR is now the default evaluator [[toc](#table-of-content)]
+
+Nushell [0.96.0](2024-07-23-nushell_0_96_0.html) introduced _internal representation_ (IR), with a new compiler and evaluator to take some of the work away from runtime, enable future optimizations, and create a well-known target for our ongoing parser replacement work.
+
+The IR evaluator has now been battle-tested by many Nushell contributors and power users and passes our entire test suite, so we've decided to make it the default now and hopefully remove the old evaluator in the next release if all goes well.
+
+This means that the `NU_USE_IR` environment variable is no longer respected, and instead we've added `NU_DISABLE_IR` which will go back to the old evaluator if present. If you find that you need to disable IR to make code that was previously working function, [please file a bug report](https://github.com/nushell/nushell/issues/new/choose) so that we can fix it before the next release.
+
+This may change the `debug profile` switches you need to use for useful output - expressions are not a valid mode for IR, you need to debug instructions instead.
+
+## Removing support for the system clipboard [[toc](#table-of-content)]
+
+::: warning Breaking change
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
+:::
 
 With [#13694](https://github.com/nushell/nushell/pull/13694), support for the system clipboard in keybinds has been removed, as this is not something that we think we can provide good, cross-platform support for in a secure manner. Namely,
 
@@ -112,7 +125,11 @@ With [#13694](https://github.com/nushell/nushell/pull/13694), support for the sy
 
 So, going forward, users that want the system clipboard functionality will have to compile a custom build of nushell by enabling the `system-clipboard` cargo feature. As an alternative, we recommend users delegate system clipboard handling to their terminal.
 
-## Record parsing changes
+## Record parsing changes [[toc](#table-of-content)]
+
+::: warning Breaking change
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
+:::
 
 Previously, it was impossible to use datetime literals with colons in record literals without adding parentheses. But thanks to [@cyradotpink](https://github.com/cyradotpink) in [#13413](https://github.com/nushell/nushell/pull/13413), this is now possible.
 
@@ -135,21 +152,33 @@ To make this possible, a few changes were made to record parsing. This should no
 
 ## Additions [[toc](#table-of-content)]
 
-### `metadata access`
+### `metadata access` [[toc](#table-of-content)]
 
 Thanks to [@Bahex](https://github.com/Bahex) in [#13785](https://github.com/nushell/nushell/pull/13785), a new `metadata access` command was added. It takes a closure argument, and the first argument to the closure will be the metadata record. Additionally, the pipeline input to `metadata access` will be forwarded to the closure as is. So, unlike the `metadata` command, this new command allows you to get the metadata of a pipeline without consuming the pipeline.
 
-### `split cell-path`
+### `split cell-path` [[toc](#table-of-content)]
 
 In [#13705](https://github.com/nushell/nushell/pull/13705), [@Bahex](https://github.com/Bahex) also added the `split cell-path` command. It is essentially the opposite of `into cell-path` and returns a list of the path members of the input cell path.
 
-### `split column --numbered`
+### `split column --numbered` [[toc](#table-of-content)]
 
 Thanks to [@nome](https://github.com/nome) in [#13831](https://github.com/nushell/nushell/pull/13831), a `--numbered` flag was added to `split column` which limits the number of times to split the input string (just like `split row --numbered`).
 
+### `encode base32`, `decode base32` [[toc](#table-of-content)]
+
+In [#13428](https://github.com/nushell/nushell/pull/13428), [@KAAtheWiseGit](https://github.com/KAAtheWiseGit) added this common variant of Base32 which uses letters A-Z followed by t he digits 2-7, specifically chosen to avoid letters and digits that look similar (RFC 4648 section 6).
+
+### `encode base32hex`, `decode base32hex` [[toc](#table-of-content)]
+
+In [#13428](https://github.com/nushell/nushell/pull/13428), [@KAAtheWiseGit](https://github.com/KAAtheWiseGit) added this variant of Base32 which only uses the 22 letters past 0-9 sequentially (RFC 4648 section 7).
+
+### `encode new-base64`, `decode new-base64` [[toc](#table-of-content)]
+
+In [#13428](https://github.com/nushell/nushell/pull/13428), [@KAAtheWiseGit](https://github.com/KAAtheWiseGit) added the `encode new-base64` and `decode new-base64` commands, which will eventually be renamed back to `encode base64` and `decode base64`. These commands are more standards-conformant and rather than taking a custom alphabet option, they support `--url` for the URL-safe base64 variant, and `--nopad` to handle Base64 without padding.
+
 ## Breaking changes [[toc](#table-of-content)]
 
-### `into record`
+### `into record` [[toc](#table-of-content)]
 
 In [#13637](https://github.com/nushell/nushell/pull/13637), several changes/improvements were made to list inputs for `into record`:
 
@@ -176,50 +205,79 @@ Additionally, `into record` no longer supports range values as input.
 
 After [#13650](https://github.com/nushell/nushell/pull/13650), `into record` also now outputs `millisecond`, `microsecond`, and `nanosecond` columns when provided with a datetime value.
 
-### `clear`
+### `clear` [[toc](#table-of-content)]
 
 In [#13821](https://github.com/nushell/nushell/pull/13821), [@T3sT3ro](https://github.com/T3sT3ro) changed the `clear` command to clear the entire scrollback buffer. As such, the `--all` flag was removed, since it is now the default behavior. Instead, a `--keep-scrollback` flag was added which, when used, makes `clear` clear only the terminal (the previous default behavior).
 
-### `path exists`
+### `path exists` [[toc](#table-of-content)]
 
 After [#13763](https://github.com/nushell/nushell/pull/13763), if an I/O error occurs when checking if a path exists, `false` is now returned instead of throwing an error (this includes errors due to insufficient permissions).
 
-### `scope commands` and `help commands`
+### `scope commands` and `help commands` [[toc](#table-of-content)]
 
 With [#13598](https://github.com/nushell/nushell/pull/13598), two output columns have been renamed for `scope commands` and `help commands`:
 
 1. `usage` has been renamed to `description`
 2. `extra_usage` is now `extra_description`
 
+### `tee` [[toc](#table-of-content)]
+
+`tee` now works as expected for non-collection input ([#13652](https://github.com/nushell/nushell/pull/13652)), and will no longer implicitly handle the input as if it were a singleton list. This does create some hairy situations for error handling, namely:
+
+- For `string` or `binary` input, the input will be converted to a stream (even if it wasn't one), and the closure provided to `tee` must finish in order for the output of `tee` to end. If an error is produced by the closure, it will be forwarded to the output stream.
+- For any other non-collection input, any error in the `tee` closure will be logged to standard error, but there isn't really anything else we can do because we can't wait for that closure to finish.
+
+### `polars concatenate` renamed to `polars str-join` [[toc](#table-of-content)]
+
+In [#13781](https://github.com/nushell/nushell/pull/13781), `polars concatenate` was renamed to `polars str-join` to match the name of the Nushell `str join` command. It also now has support for expressions.
+
 ## Deprecations [[toc](#table-of-content)]
+
+### `encode base64`, `decode base64` [[toc](#table-of-content)]
+
+In [#13428](https://github.com/nushell/nushell/pull/13428), [@KAAtheWiseGit](https://github.com/KAAtheWiseGit) added [`encode new-base64` / `decode new-base64`](#encode-new-base64-decode-new-base64-toc) to replace these.
 
 ## Removals [[toc](#table-of-content)]
 
-### `str deunicode`
+### `str deunicode` [[toc](#table-of-content)]
 
 In [#13693](https://github.com/nushell/nushell/pull/13693), the `str deunicode` command (added in v0.96.0) has been removed due to concerns with stability and support post v1.0.
 
-### `$env.config.use_grid_icons`
+### `$env.config.use_grid_icons` [[toc](#table-of-content)]
 
 After [#13788](https://github.com/nushell/nushell/pull/13788), the `use_grid_icons` config option has been removed. Instead, the `grid` command now has an `--icons` flag that has the same effect.
 
 ## Bug fixes and other changes [[toc](#table-of-content)]
 
-### `find`
+### `find` [[toc](#table-of-content)]
 
 After [#13848](https://github.com/nushell/nushell/pull/13848), the find command no longer strips tabs from its input.
 
 Also, regex patterns are now properly escaped after [#13792](https://github.com/nushell/nushell/pull/13792).
 
-### Improved script help output
+### `encode hex` [[toc](#table-of-content)]
+
+In [#13428](https://github.com/nushell/nushell/pull/13428), [@KAAtheWiseGit](https://github.com/KAAtheWiseGit) added the `--lower` flag to `encode hex`, to produce lowercase hex.
+
+### Various Polars commands now support expressions [[toc](#table-of-content)]
+
+In [#13724](https://github.com/nushell/nushell/pull/13724), [#13726](https://github.com/nushell/nushell/pull/13726), and [#13799](https://github.com/nushell/nushell/pull/13799), these Polars plugin commands were updated to support expressions:
+
+- `polars uppercase`
+- `polars lowercase`
+- `polars replace`
+- `polars replace-all`
+- `polars cumulative`
+
+### Improved script help output [[toc](#table-of-content)]
 
 Thanks to [@gwenya](https://github.com/gwenya) in [#13445](https://github.com/nushell/nushell/pull/13445), the help output for scripts now uses the name of the script instead of `main`. The available subcommands are now also listed in the help output.
 
-### Bit operations and commands
+### Bit operations and commands [[toc](#table-of-content)]
 
 `bits ror` and `bits rol` had undefined behavior in some cases and could also panic in others. This has been fixed in [#13673](https://github.com/nushell/nushell/pull/13673). Similarly, bugs for `bits shl`, `bits shr`, `bit-shl`, and `bit-shr` were fixed in [#13663](https://github.com/nushell/nushell/pull/13663).
 
-### `detect columns`
+### `detect columns` [[toc](#table-of-content)]
 
 One source of panics was fixed in [#13752](https://github.com/nushell/nushell/pull/13752).
 
@@ -252,21 +310,160 @@ One source of panics was fixed in [#13752](https://github.com/nushell/nushell/pu
 
 # Notes for plugin developers [[toc](#table-of-content)]
 
+## Breaking plugin changes [[toc](#table-of-content)]
+
+- `usage` in signatures has been changed to `description` ([#13598](https://github.com/nushell/nushell/pull/13598)). This affects both the Rust API and the plugin protocol.
+
+## Rust API improvements [[toc](#table-of-content)]
+
+- The `IntoValue` and `FromValue` traits now work well with `Vec<u8>` byte arrays and `bytes::Bytes` ([#13641](https://github.com/nushell/nushell/pull/13641)), converting to `binary` and from `string`/`binary`.
+- `IntoValue` is now supported for several Nushell types, as well as `HashMap`, `DateTime`, and `&str` ([#13744](https://github.com/nushell/nushell/pull/13744/commits))
+- The derive macros for `IntoValue` and `FromValue` now also take `#[nu_value(type_name = "...")]` to set a type name for the expected type. ([#13647](https://github.com/nushell/nushell/pull/13647))
+
+## Other changes [[toc](#table-of-content)]
+
+- The `nu-plugin` library now uses MessagePack instead of bincode internally for custom value serialization. This is not a protocol change as the representation of custom values is intentionally not defined, and they're treated as a black box by the engine. ([#13745](https://github.com/nushell/nushell/pull/13745))
+
+# All breaking changes [[toc](#table-of-content)]
+
+- [#13821](https://github.com/nushell/nushell/pull/13821) Improve #12008 UX, clear scrollback by default on `clear`
+- [#13763](https://github.com/nushell/nushell/pull/13763) fix path exists on a non-directory file
+- [#13515](https://github.com/nushell/nushell/pull/13515) Error on non-zero exit statuses
+- [#13788](https://github.com/nushell/nushell/pull/13788) remove config use_grid_icons, move to parameter of grid command
+- [#13781](https://github.com/nushell/nushell/pull/13781) Renamed `polars concatenate` and added expression support.
+- [#13652](https://github.com/nushell/nushell/pull/13652) Make `tee` work more nicely with non-collections
+- [#13745](https://github.com/nushell/nushell/pull/13745) Remove bincode and use MessagePack instead for plugin custom values
+- [#13694](https://github.com/nushell/nushell/pull/13694) Remove `system-clipboard` from the default build
+- [#13693](https://github.com/nushell/nushell/pull/13693) Remove `str deunicode`
+- [#13428](https://github.com/nushell/nushell/pull/13428) `encode`/`decode` for multiple alphabets
+- [#13598](https://github.com/nushell/nushell/pull/13598) Change the usage misnomer to "description"
+- [#13637](https://github.com/nushell/nushell/pull/13637) Change behavior of `into record` on lists to be more useful
+
 # Hall of fame [[toc](#table-of-content)]
 
 Thanks to all the contributors below for helping us solve issues and improve documentation :pray:
 
-| author                                           | title                     | url                                                     |
-| ------------------------------------------------ | ------------------------- | ------------------------------------------------------- |
-| [@author](https://github.com/author)             | ...                       | [#12345](https://github.com/nushell/nushell/pull/12345) |
-| [@poliorcetics](https://github.com/poliorcetics) | doc: fix broken doc links | [#13644](https://github.com/nushell/nushell/pull/13644) |
+| author                                             | title                                                                                                | PR                                                      |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| [@fdncred](https://github.com/fdncred)             | allow tab to be retained with `find`                                                                 | [#13848](https://github.com/nushell/nushell/pull/13848) |
+| [@zhiburt](https://github.com/zhiburt)             | Fix padding issue with header_on_border                                                              | [#13808](https://github.com/nushell/nushell/pull/13808) |
+| [@IanManske](https://github.com/IanManske)         | Fix IR for `try`                                                                                     | [#13811](https://github.com/nushell/nushell/pull/13811) |
+| [@ayax79](https://github.com/ayax79)               | String values should pass their content-type correctly on http requests with a body (e.g. http post) | [#13731](https://github.com/nushell/nushell/pull/13731) |
+| [@devyn](https://github.com/devyn)                 | Remove bincode and use MessagePack instead for plugin custom values                                  | [#13745](https://github.com/nushell/nushell/pull/13745) |
+| [@ysthakur](https://github.com/ysthakur)           | Use right options in custom completions                                                              | [#13698](https://github.com/nushell/nushell/pull/13698) |
+| [@KAAtheWiseGit](https://github.com/KAAtheWiseGit) | Fix encode/decode todo's                                                                             | [#13683](https://github.com/nushell/nushell/pull/13683) |
+| [@sholderbach](https://github.com/sholderbach)     | Fix `bits ror`/`bits rol` implementation                                                             | [#13673](https://github.com/nushell/nushell/pull/13673) |
+| [@sholderbach](https://github.com/sholderbach)     | Fix bugs and UB in bit shifting ops                                                                  | [#13663](https://github.com/nushell/nushell/pull/13663) |
 
 # Full changelog [[toc](#table-of-content)]
 
-<!-- TODO:
-    paste the output of
-    ```nu
-    ./make_release/release-note/get-full-changelog
-    ```
-    here
--->
+- [ayax79](https://github.com/ayax79) created
+  - [Improved null handling when converting from nu -> dataframe.](https://github.com/nushell/nushell/pull/13855)
+  - [catch unwrap on panics with `polars collect`](https://github.com/nushell/nushell/pull/13850)
+  - [Make `polars save` return an empty pipeline](https://github.com/nushell/nushell/pull/13833)
+  - [Migrating polars commands away from macros, removed custom DataFrame comparison.](https://github.com/nushell/nushell/pull/13829)
+  - [Added documentation explanation explaining how to select all columns with `polars col`](https://github.com/nushell/nushell/pull/13806)
+  - [Added expression support for `polars cumulative`](https://github.com/nushell/nushell/pull/13799)
+  - [Polars command reorg](https://github.com/nushell/nushell/pull/13798)
+  - [String values should pass their content-type correctly on http requests with a body (e.g. http post)](https://github.com/nushell/nushell/pull/13731)
+  - [Use String::contains instead of exact match when matching content types for http requests.](https://github.com/nushell/nushell/pull/13791)
+  - [Renamed `polars concatenate` and added expression support.](https://github.com/nushell/nushell/pull/13781)
+  - [Added expression support for `polars str-lengths`](https://github.com/nushell/nushell/pull/13782)
+  - [Expression support for `polars str-slice`](https://github.com/nushell/nushell/pull/13783)
+  - [Added expression support for `polars contains`](https://github.com/nushell/nushell/pull/13769)
+  - [Expression support for `polars strftime`](https://github.com/nushell/nushell/pull/13767)
+  - [Expression support `polars replace` and `polars replace-all`](https://github.com/nushell/nushell/pull/13726)
+  - [Expression support for `polars uppercase` and `polars lowercase`](https://github.com/nushell/nushell/pull/13724)
+  - [Added polars commands for converting string columns to integer and decimal columns](https://github.com/nushell/nushell/pull/13711)
+  - [Changed category for `panic` and added search terms and examples](https://github.com/nushell/nushell/pull/13707)
+- [devyn](https://github.com/devyn) created
+  - [Make IR the default evaluator](https://github.com/nushell/nushell/pull/13718)
+  - [Fix `try`: Add `set_last_error()` to `prepare_error_handler()` for IR eval](https://github.com/nushell/nushell/pull/13838)
+  - [Fix remaining mismatch for env handling in IR](https://github.com/nushell/nushell/pull/13796)
+  - [Make `tee` work more nicely with non-collections](https://github.com/nushell/nushell/pull/13652)
+  - [Remove bincode and use MessagePack instead for plugin custom values](https://github.com/nushell/nushell/pull/13745)
+  - [Change behavior of `into record` on lists to be more useful](https://github.com/nushell/nushell/pull/13637)
+- [hustcer](https://github.com/hustcer) created
+  - [Fix dockerfile and reset Nu config to default](https://github.com/nushell/nushell/pull/13851)
+  - [Update Nu for release workflow and fix build warning of musl targets](https://github.com/nushell/nushell/pull/13840)
+  - [Add aarch64-unknown-linux-musl and armv7-unknown-linux-musleabihf targets to release workflow](https://github.com/nushell/nushell/pull/13800)
+  - [Try to add aarch64-unknown-linux-musl and armv7-unknown-linux-musleabihf release target](https://github.com/nushell/nushell/pull/13775)
+- [fdncred](https://github.com/fdncred) created
+  - [allow tab to be retained with `find`](https://github.com/nushell/nushell/pull/13848)
+  - [bump rust version to 1.79.0](https://github.com/nushell/nushell/pull/13809)
+  - [update the latest reedline](https://github.com/nushell/nushell/pull/13797)
+  - [remove config use_grid_icons, move to parameter of grid command](https://github.com/nushell/nushell/pull/13788)
+  - [fixed issue with find not working with symbols that should be escaped](https://github.com/nushell/nushell/pull/13792)
+  - [fix --ide-ast when there are errors](https://github.com/nushell/nushell/pull/13737)
+  - [add version and path to plugin executable help](https://github.com/nushell/nushell/pull/13764)
+  - [remove cfg_atter tarpaulin](https://github.com/nushell/nushell/pull/13739)
+  - [update virtual terminal processing](https://github.com/nushell/nushell/pull/13710)
+  - [add more granularity for into record with dates](https://github.com/nushell/nushell/pull/13650)
+- [nome](https://github.com/nome) created
+  - [Add --number flag to split column](https://github.com/nushell/nushell/pull/13831)
+- [T3sT3ro](https://github.com/T3sT3ro) created
+  - [Improve #12008 UX, clear scrollback by default on `clear`](https://github.com/nushell/nushell/pull/13821)
+- [WindSoilder](https://github.com/WindSoilder) created
+  - [fix path exists on a non-directory file](https://github.com/nushell/nushell/pull/13763)
+  - [Config: change ctrl-k to `cuttolineend` event](https://github.com/nushell/nushell/pull/13801)
+  - [make a user friendly message when `use_grid_icons` is used in config](https://github.com/nushell/nushell/pull/13795)
+  - [Don't panic on `detect columns` with `--guess` flag](https://github.com/nushell/nushell/pull/13752)
+- [Bahex](https://github.com/Bahex) created
+  - [add `metadata access` command](https://github.com/nushell/nushell/pull/13785)
+  - [Add split cell-path](https://github.com/nushell/nushell/pull/13705)
+- [zhiburt](https://github.com/zhiburt) created
+  - [Fix padding issue with header_on_border](https://github.com/nushell/nushell/pull/13808)
+  - [Check fix for emojie, wrap issues](https://github.com/nushell/nushell/pull/13430)
+- [app/dependabot](https://github.com/app/dependabot) created
+  - [Bump crate-ci/typos from 1.24.4 to 1.24.5](https://github.com/nushell/nushell/pull/13826)
+  - [Bump hustcer/setup-nu from 3.12 to 3.13](https://github.com/nushell/nushell/pull/13827)
+  - [Bump shadow-rs from 0.33.0 to 0.34.0](https://github.com/nushell/nushell/pull/13825)
+  - [Bump crate-ci/typos from 1.24.1 to 1.24.4](https://github.com/nushell/nushell/pull/13770)
+  - [Bump nix from 0.28.0 to 0.29.0](https://github.com/nushell/nushell/pull/13773)
+  - [Bump itertools from 0.12.1 to 0.13.0](https://github.com/nushell/nushell/pull/13774)
+  - [Bump indexmap from 2.4.0 to 2.5.0](https://github.com/nushell/nushell/pull/13772)
+  - [Bump shadow-rs from 0.31.1 to 0.33.0](https://github.com/nushell/nushell/pull/13713)
+  - [Bump crate-ci/typos from 1.23.6 to 1.24.1](https://github.com/nushell/nushell/pull/13716)
+- [IanManske](https://github.com/IanManske) created
+  - [Fix IR for `try`](https://github.com/nushell/nushell/pull/13811)
+  - [Error on non-zero exit statuses](https://github.com/nushell/nushell/pull/13515)
+  - [Use `IntoValue` in config code](https://github.com/nushell/nushell/pull/13751)
+  - [Implement `IntoValue` for more types](https://github.com/nushell/nushell/pull/13744)
+  - [Be explicit about `reduce` args and input](https://github.com/nushell/nushell/pull/13646)
+- [Ancient77](https://github.com/Ancient77) created
+  - [Expand multiple dots in path in completions ](https://github.com/nushell/nushell/pull/13725)
+- [JTopanotti](https://github.com/JTopanotti) created
+  - [Refining error handling in http post](https://github.com/nushell/nushell/pull/13805)
+  - [Refactor send_request in client.rs](https://github.com/nushell/nushell/pull/13701)
+- [sholderbach](https://github.com/sholderbach) created
+  - [Fixup `serde` feature selection in `nu-protocol`](https://github.com/nushell/nushell/pull/13793)
+  - [Remove unneeded `serde` feature on `byte-unit` dep](https://github.com/nushell/nushell/pull/13749)
+  - [Setup global `cargo` lint configuration](https://github.com/nushell/nushell/pull/13691)
+  - [Remove `system-clipboard` from the default build](https://github.com/nushell/nushell/pull/13694)
+  - [Remove `str deunicode`](https://github.com/nushell/nushell/pull/13693)
+  - [Simplify our bug reporting form](https://github.com/nushell/nushell/pull/13695)
+  - [Remove unnecessary sort in `explore` search fn](https://github.com/nushell/nushell/pull/13690)
+  - [Fix `bits ror`/`bits rol` implementation](https://github.com/nushell/nushell/pull/13673)
+  - [Change the usage misnomer to "description"](https://github.com/nushell/nushell/pull/13598)
+  - [Fix bugs and UB in bit shifting ops](https://github.com/nushell/nushell/pull/13663)
+  - [Bump version to 0.97.2](https://github.com/nushell/nushell/pull/13666)
+- [cptpiepmatz](https://github.com/cptpiepmatz) created
+  - [Add `#[nu_value(rename = "...")]` as helper attribute on members for derive macros](https://github.com/nushell/nushell/pull/13761)
+  - [Use `heck` instead of `convert_case` for `nu-derive-value`](https://github.com/nushell/nushell/pull/13708)
+  - [Added record key renaming for derive macros `IntoValue` and `FromValue`](https://github.com/nushell/nushell/pull/13699)
+  - [Change expected type for derived `FromValue` implementations via attribute](https://github.com/nushell/nushell/pull/13647)
+  - [Improve working with `IntoValue` and `FromValue` for byte collections](https://github.com/nushell/nushell/pull/13641)
+- [cyradotpink](https://github.com/cyradotpink) created
+  - [Fix parsing record values containing colons](https://github.com/nushell/nushell/pull/13413)
+- [weirdan](https://github.com/weirdan) created
+  - [Respect user-defined `$env.NU_LOG_FORMAT` and `$env.NU_LOG_DATE_FORMAT`](https://github.com/nushell/nushell/pull/13692)
+- [ysthakur](https://github.com/ysthakur) created
+  - [Use right options in custom completions](https://github.com/nushell/nushell/pull/13698)
+- [KAAtheWiseGit](https://github.com/KAAtheWiseGit) created
+  - [Fix encode/decode todo's](https://github.com/nushell/nushell/pull/13683)
+  - [Remove unused `same-file` workspace dependency](https://github.com/nushell/nushell/pull/13678)
+  - [`encode`/`decode` for multiple alphabets](https://github.com/nushell/nushell/pull/13428)
+- [poliorcetics](https://github.com/poliorcetics) created
+  - [doc: fix broken doc links](https://github.com/nushell/nushell/pull/13644)
+- [gwenya](https://github.com/gwenya) created
+  - [Improve help output for scripts](https://github.com/nushell/nushell/pull/13445)

--- a/blog/2024-09-17-nushell_0_98_0.md
+++ b/blog/2024-09-17-nushell_0_98_0.md
@@ -25,13 +25,12 @@ As part of this release, we also publish a set of optional plugins you can insta
 # Table of content
 
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
-- [_Changes to commands_](#changes-to-commands-toc)
+- [_Changes_](#changes-toc)
   - [_Additions_](#additions-toc)
   - [_Breaking changes_](#breaking-changes-toc)
   - [_Deprecations_](#deprecations-toc)
   - [_Removals_](#removals-toc)
   - [_Bug fixes and other changes_](#bug-fixes-and-other-changes-toc)
-- [_All breaking changes_](#all-breaking-changes-toc)
 - [_Notes for plugin developers_](#notes-for-plugin-developers-toc)
 - [_Hall of fame_](#hall-of-fame-toc)
 - [_Full changelog_](#full-changelog-toc)
@@ -67,6 +66,41 @@ As part of this release, we also publish a set of optional plugins you can insta
     for the list of available *containers*
 -->
 
+## Non-zero exit codes are now errors
+
+One long-requested feature for nushell is to make non-zero exit codes throw an error. Before this release, non-zero exit codes would quietly stop execution. In some cases, execution would not even stop, but rather only skip over the remaining commands in the current code block. With this release, non-zero exit codes (and termination due to unix signals) are now errors just like any other error, so nushell now runs almost as if bash's `set -e` option was enabled ([#13515](https://github.com/nushell/nushell/pull/13515)).
+
+Errors due to non-zero exit codes can be caught in a `try`/`catch` block, and the error record passed to the catch closure will contain an `exit_code` column in this case.
+
+```nushell
+try {
+  nu -c 'exit 42'
+} catch {|e|
+  print $e.exit_code? # prints 42
+}
+```
+
+As such, `$env.LAST_EXIT_CODE` is no longer necessary in most cases. Rather, `try`/`catch` should suffice for both internal and external errors, unifying and simplifying error handling.
+
+Note that the `complete` command still works the same as it does today. If the previous command fails, its exit code and output will still be captured and returned by `complete`.
+
+Some other things to note about the current implementation:
+
+- Only the exit code of the last command of a pipeline is checked and can cause an error. The exit codes of all the previous commands in a pipeline are ignored. In the future, we may check and track the exit codes of all commands in a pipeline to provide an equivalent to bash's `set -o pipefail`, but this would require a major refactor. So for now, this functionality is only a potential future addition.
+
+- If a command was terminated by a unix signal (e.g., SIGTERM, SIGINT), then the `exit_code` value in the `catch` error record will contain the negation of the signal number. For example, if SIGINT is signal number 2, then `exit_code` would be reported as `-2`. This is similar to how Python reports exit codes.
+
+- The one exception is SIGPIPE. If a command is terminated due to SIGPIPE, then it is not treated as an error.
+
+One downside of having non-zero exit codes as errors is that uncaught errors will print a nushell error message to the terminal which may make it annoying to find any error messages printed by the external command that failed. Similarly, some commands use exit codes to indicate other things besides failure (e.g., `diff`). Having all these extra error message in the REPL can be annoying, so two new config options have been added as well:
+
+1. `$env.config.display_errors.exit_code`
+2. `$env.config.display_errors.termination_signal`
+
+With no config (e.g., when running a script), these config options are both `true` and the corresponding error cases will be printed as a nushell error message. However, the default config (i.e., `config nu --default`) sets `display_errors.exit_code` to `false`. So, if you use the default config, or set this option in your config, then an error message won't be printed for non-zero exit codes in the REPL.
+
+One last thing to note is that core dumps are treated as a separate error case and an error message will always be printed if the error is uncaught (i.e., there is no config option for this).
+
 ## Removing support for the system clipboard
 
 With [#13694](https://github.com/nushell/nushell/pull/13694), support for the system clipboard in keybinds has been removed, as this is not something that we think we can provide good, cross-platform support for in a secure manner. Namely,
@@ -78,13 +112,36 @@ With [#13694](https://github.com/nushell/nushell/pull/13694), support for the sy
 
 So, going forward, users that want the system clipboard functionality will have to compile a custom build of nushell by enabling the `system-clipboard` cargo feature. As an alternative, we recommend users delegate system clipboard handling to their terminal.
 
-# Changes to commands [[toc](#table-of-content)]
+## Record parsing changes
+
+Previously, it was impossible to use datetime literals with colons in record literals without adding parentheses. But thanks to [@cyradotpink](https://github.com/cyradotpink) in [#13413](https://github.com/nushell/nushell/pull/13413), this is now possible.
+
+```nushell
+# Previously, parentheses were necessary:
+{ foo: (2024-08-13T22:11:09) }
+
+# But this now works!
+{ foo: 2024-08-13T22:11:09 }
+```
+
+To make this possible, a few changes were made to record parsing. This should not affect most code, but some previously valid code no longer parses successfully. For example:
+
+```nushell
+{ :: 1 }
+# This used to parse as { ':': 1 }, but it is now an error.
+```
+
+# Changes [[toc](#table-of-content)]
 
 ## Additions [[toc](#table-of-content)]
 
 ### `metadata access`
 
 Thanks to [@Bahex](https://github.com/Bahex) in [#13785](https://github.com/nushell/nushell/pull/13785), a new `metadata access` command was added. It takes a closure argument, and the first argument to the closure will be the metadata record. Additionally, the pipeline input to `metadata access` will be forwarded to the closure as is. So, unlike the `metadata` command, this new command allows you to get the metadata of a pipeline without consuming the pipeline.
+
+### `split cell-path`
+
+In [#13705](https://github.com/nushell/nushell/pull/13705), [@Bahex](https://github.com/Bahex) also added the `split cell-path` command. It is essentially the opposite of `into cell-path` and returns a list of the path members of the input cell path.
 
 ### `split column --numbered`
 
@@ -121,11 +178,18 @@ After [#13650](https://github.com/nushell/nushell/pull/13650), `into record` als
 
 ### `clear`
 
-In [#13821](https://github.com/nushell/nushell/pull/13821), [@T3sT3ro](https://github.com/T3sT3ro) changed the `clear` command to clear the entire scrollback buffer. As such, the `--all` flag was removed, since it is now the default behavior. Instead, a `--keep-scrollback` flag was added, which when used, makes `clear` clear only the terminal (the previous default behavior).
+In [#13821](https://github.com/nushell/nushell/pull/13821), [@T3sT3ro](https://github.com/T3sT3ro) changed the `clear` command to clear the entire scrollback buffer. As such, the `--all` flag was removed, since it is now the default behavior. Instead, a `--keep-scrollback` flag was added which, when used, makes `clear` clear only the terminal (the previous default behavior).
 
 ### `path exists`
 
 After [#13763](https://github.com/nushell/nushell/pull/13763), if an I/O error occurs when checking if a path exists, `false` is now returned instead of throwing an error (this includes errors due to insufficient permissions).
+
+### `scope commands` and `help commands`
+
+With [#13598](https://github.com/nushell/nushell/pull/13598), two output columns have been renamed for `scope commands` and `help commands`:
+
+1. `usage` has been renamed to `description`
+2. `extra_usage` is now `extra_description`
 
 ## Deprecations [[toc](#table-of-content)]
 
@@ -135,6 +199,10 @@ After [#13763](https://github.com/nushell/nushell/pull/13763), if an I/O error o
 
 In [#13693](https://github.com/nushell/nushell/pull/13693), the `str deunicode` command (added in v0.96.0) has been removed due to concerns with stability and support post v1.0.
 
+### `$env.config.use_grid_icons`
+
+After [#13788](https://github.com/nushell/nushell/pull/13788), the `use_grid_icons` config option has been removed. Instead, the `grid` command now has an `--icons` flag that has the same effect.
+
 ## Bug fixes and other changes [[toc](#table-of-content)]
 
 ### `find`
@@ -142,6 +210,14 @@ In [#13693](https://github.com/nushell/nushell/pull/13693), the `str deunicode` 
 After [#13848](https://github.com/nushell/nushell/pull/13848), the find command no longer strips tabs from its input.
 
 Also, regex patterns are now properly escaped after [#13792](https://github.com/nushell/nushell/pull/13792).
+
+### Improved script help output
+
+Thanks to [@gwenya](https://github.com/gwenya) in [#13445](https://github.com/nushell/nushell/pull/13445), the help output for scripts now uses the name of the script instead of `main`. The available subcommands are now also listed in the help output.
+
+### Bit operations and commands
+
+`bits ror` and `bits rol` had undefined behavior in some cases and could also panic in others. This has been fixed in [#13673](https://github.com/nushell/nushell/pull/13673). Similarly, bugs for `bits shl`, `bits shr`, `bit-shl`, and `bit-shr` were fixed in [#13663](https://github.com/nushell/nushell/pull/13663).
 
 ### `detect columns`
 
@@ -172,16 +248,6 @@ One source of panics was fixed in [#13752](https://github.com/nushell/nushell/pu
 
     $prs | to md --pretty | clip
     ```
--->
-
-# All breaking changes [[toc](#table-of-content)]
-
-<!-- TODO:
-    paste the output of
-    ```nu
-    ./make_release/release-note/list-merged-prs nushell/nushell --label pr:breaking-change --pretty --no-author
-    ```
-    here
 -->
 
 # Notes for plugin developers [[toc](#table-of-content)]


### PR DESCRIPTION
Please add your new features and breaking changes to the release notes
by opening PRs against the `release-notes-0.98.0` branch.

## TODO
- [ ] look at interesting contributions
  - [ ] 13731
  - [ ] 13413
  - [ ] 13725 ?
  - [ ] Plugin breaking changes in 13598
  - [ ] 13652
  - [ ] 13428
- [ ] write all the sections
- [ ] order the sections by interest
- [ ] add the breaking changes
- [ ] detail the breaking changes
- [ ] add the full changelog
- [ ] complete all the `TODO`s inside the release note
- [ ] ... (PRs that need to land before the release, e.g. [deprecations](https://github.com/nushell/nushell/labels/deprecation) or [removals](https://github.com/nushell/nushell/pulls?q=is%3Apr+is%3Aopen+label%3Aremoval-after-deprecation))