### PR TITLE
Add `wrap` as a cast for table and record

### DIFF
--- a/lang-guide/chapters/types/basic_types/record.md
+++ b/lang-guide/chapters/types/basic_types/record.md
@@ -5,7 +5,7 @@
 | **_Description:_**    | The foundational associative map. Holds key-value pairs, which associate string keys with various data values. |
 | **_Annotation:_**     | `record`                                                                                                       |
 | **_Literal syntax:_** | See below                                                                                                      |
-| **_Casts:_**          | [`into record`](/commands/docs/into_record.md)                                                                 |
+| **_Casts:_**          | [`into record`](/commands/docs/into_record.md), [`wrap`](/commands/docs/wrap.md)                               |
 | **_See Also:_**       | [Working with Records](/book/working_with_records.md)                                                          |
 |                       | [Navigating and Accessing Structured Data](/book/navigating_structured_data.md)                                |
 |                       | [Types of Data - Records](/book/types_of_data.md#records)                                                      |

--- a/lang-guide/chapters/types/basic_types/table.md
+++ b/lang-guide/chapters/types/basic_types/table.md
@@ -5,7 +5,7 @@
 | **_Description:_**          | A two-dimensional container with both columns and rows where each cell can hold any basic or structured data type |
 | **_Annotation:_**           | `table`                                                                                                           |
 | **_Table-Literal Syntax:_** | See below                                                                                                         |
-| **_Casts:_**                | N/A                                                                                                               |
+| **_Casts:_**                | [`wrap`](/commands/docs/wrap.md)                                                                                  |
 | **_See Also:_**             | [Working with Tables](/book/working_with_tables.md)                                                               |
 |                             | [Navigating and Accessing Structured Data](/book/navigating_structured_data.md)                                   |
 |                             | [Types of Data - Tables](/book/types_of_data.md#tables)                                                           |


### PR DESCRIPTION
Based on a question in Discord today, I realized that `wrap` (while incredibly useful) isn't well promoted.

I'll also look at adding some help keywords to `wrap`, but at the least, it should be listed as a way to cast to `table` and `record`.