### PR TITLE
Documented the recommended MIME type for Nushell

### DIFF
--- a/.vuepress/configs/sidebar/en.ts
+++ b/.vuepress/configs/sidebar/en.ts
@@ -252,6 +252,7 @@ export const sidebarEn: SidebarConfig = {
         '/lang-guide/chapters/strings_and_text.md',
         '/lang-guide/chapters/helpers_and_debugging.md',
         '/lang-guide/chapters/pipelines.md',
+        '/lang-guide/chapters/mime_types.md',
       ],
     },
   ],

--- a/lang-guide/chapters/mime_types.md
+++ b/lang-guide/chapters/mime_types.md
@@ -1,0 +1,21 @@
+# MIME Types for Nushell
+
+[MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types),
+also known as media or content types, are used to identify data formats.
+Since Nushell is not officially recognized by the _Internet Assigned Numbers
+Authority (IANA)_, all Nushell MIME types are prefixed with "-x" to indicate
+their unofficial status.
+Despite this, some tools still rely on MIME types to identify data formats.
+
+The three MIME types we define and recommend for consistent use are:
+
+- **`application/x-nuscript`:**
+  This type is used for Nushell scripts and is similar to
+  `application/x-shellscript` for Bash scripts.
+  The "application" type is used because these scripts can be executable if the
+  correct shebang is included.
+- **`text/x-nushell`:**
+  This is an alias for `application/x-nuscript` but emphasizes that the script
+  is human-readable, similar to `text/x-python`.
+- **`application/x-nuon`:**
+  This type is used for the [NUON data format](../../book/loading_data.html#nuon).


### PR DESCRIPTION
In the [meeting of the 18.09.2024](https://hackmd.io/@nucore/H1bgUtLaC) we talked about adding recommended MIME types for Nushell to the documentation. This is the PR for that.

I added it to the `Language Reference Guide` as this part seems to more about the internals and not so much about using Nushell, so I though it would fit there. If not, let's change that.