### PR TITLE
Unify the language identifiers of the code blocks to 'sh'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ $ nix profile install nixpkgs#nushell
 
 #### Windows:
 
-```shell
-$ winget install nushell
+```powershell
+winget install nushell
 ```
 
 After installing, launch Nu by typing `nu`.

--- a/de/README.md
+++ b/de/README.md
@@ -40,8 +40,8 @@ $ brew install nushell
 
 #### Windows:
 
-```sh
-$ winget install nushell
+```powershell
+winget install nushell
 ```
 
 ## Community

--- a/de/README.md
+++ b/de/README.md
@@ -40,7 +40,7 @@ $ brew install nushell
 
 #### Windows:
 
-```powershell
+```sh
 $ winget install nushell
 ```
 

--- a/es/README.md
+++ b/es/README.md
@@ -37,12 +37,12 @@ $ brew install nushell
 
 En [Scoop](https://scoop.sh):
 
-```powershell
+```sh
 $ scoop install nu
 ```
 
 #### Inicia la shell
 
-```
+```sh
 $ nu
 ```

--- a/es/README.md
+++ b/es/README.md
@@ -37,8 +37,8 @@ $ brew install nushell
 
 En [Scoop](https://scoop.sh):
 
-```sh
-$ scoop install nu
+```powershell
+scoop install nu
 ```
 
 #### Inicia la shell

--- a/ja/README.md
+++ b/ja/README.md
@@ -40,8 +40,8 @@ $ brew install nushell
 
 #### Windows:
 
-```sh
-$ winget install nushell
+```powershell
+winget install nushell
 ```
 
 ## Nu を Github Actions で利用する

--- a/ja/README.md
+++ b/ja/README.md
@@ -40,7 +40,7 @@ $ brew install nushell
 
 #### Windows:
 
-```powershell
+```sh
 $ winget install nushell
 ```
 

--- a/pt-BR/README.md
+++ b/pt-BR/README.md
@@ -37,12 +37,12 @@ $ brew install nushell
 
 Com [Scoop](https://scoop.sh):
 
-```powershell
+```sh
 $ scoop install nu
 ```
 
 #### Inicializar o shell
 
-```
+```sh
 $ nu
 ```

--- a/pt-BR/README.md
+++ b/pt-BR/README.md
@@ -37,8 +37,8 @@ $ brew install nushell
 
 Com [Scoop](https://scoop.sh):
 
-```sh
-$ scoop install nu
+```powershell
+scoop install nu
 ```
 
 #### Inicializar o shell

--- a/ru/README.md
+++ b/ru/README.md
@@ -40,8 +40,8 @@ $ brew install nushell
 
 #### Windows:
 
-```shell
-$ winget install nushell
+```powershell
+winget install nushell
 ```
 
 После установки запустите Nu, набрав `nu`.

--- a/zh-CN/README.md
+++ b/zh-CN/README.md
@@ -40,8 +40,8 @@ $ brew install nushell
 
 #### Windows:
 
-```shell
-$ winget install nushell
+```powershell
+winget install nushell
 ```
 
 完成安装后，输入 `nu` 来启动 Nu。


### PR DESCRIPTION
This PR unifies the language identifiers of the code blocks for installation commands to 'sh'.
Syntax highlighting will be applied to the modified code blocks, and the extra $ sign at the beginning will be removed when copied.