### PR TITLE
One-liner for installing plugins with Cargo

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -6,6 +6,8 @@ The main Nushell binary is named `nu` (or `nu.exe` on Windows). After installati
 
 @[code](@snippets/installation/run_nu.sh)
 
+[[toc]]
+
 ## Pre-built Binaries
 
 Nu binaries are published for Linux, macOS, and Windows [with each GitHub release](https://github.com/nushell/nushell/releases). Just download, extract the binaries, then copy them to a location on your PATH.
@@ -74,13 +76,17 @@ Using [Homebrew](https://brew.sh/), you will need to install "openssl" and "cmak
 
 @[code](@snippets/installation/macos_deps.sh)
 
-### Build using [crates.io](https://crates.io)
+### Build from [crates.io](https://crates.io) using Cargo
 
-Nu releases are published as source to the popular Rust package registry [crates.io](https://crates.io/). This makes it easy to build and install the latest Nu release with `cargo`:
+Nushell releases are published as source to the popular Rust package registry [crates.io](https://crates.io/). This makes it easy to build and install the latest Nu release with `cargo`:
 
-@[code](@snippets/installation/cargo_install_nu.sh)
+```nu
+cargo install nu
+```
 
-That's it! The `cargo` tool will do the work of downloading Nu and its source dependencies, building it, and installing it into the cargo bin path.
+The `cargo` tool will do the work of downloading Nu and its source dependencies, building it, and installing it into the cargo bin path.
+
+Note that the default plugins must be installed separately when using `cargo`. See the [Plugins Installation](./plugins.html#core-plugins) section of the Book for instructions.
 
 ### Building from the GitHub repository
 

--- a/book/plugins.md
+++ b/book/plugins.md
@@ -28,6 +28,18 @@ Core plugins are typically distributed with the Nushell release and should alrea
 
 ::: tip Installing using Cargo
 For example, when installing or upgrading Nushell directly from crates.io using `cargo install nu`, the corresponding core plugins for that version may also be installed or updated using `cargo install nu_plugin_<plugin_name>`.
+
+To install all of the default plugins, from within Nushell run:
+
+```nu
+[ nu_plugin_inc
+  nu_plugin_polars
+  nu_plugin_gstat
+  nu_plugin_formats
+  nu_plugin_query
+] | each { cargo install $in; $in }
+```
+
 :::
 
 ### Third-party Plugins

--- a/book/plugins.md
+++ b/book/plugins.md
@@ -37,7 +37,7 @@ To install all of the default plugins, from within Nushell run:
   nu_plugin_gstat
   nu_plugin_formats
   nu_plugin_query
-] | each { cargo install $in; $in }
+] | each { cargo install $in } | ignore
 ```
 
 :::


### PR DESCRIPTION
Just a quick update:

* Update installation chapter to note that plugins need to be installed separately with Cargo
* Add a one-liner in the Plugins chapter to install all the default plugins at once