### PR TITLE
Turn back on line-numbers

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -172,7 +172,7 @@ export default defineUserConfig({
     }),
     shikiPlugin({
       theme: 'dark-plus',
-      lineNumbers: false,
+      lineNumbers: true,
       langs: [
         'nushell',
         'rust',


### PR DESCRIPTION
While I would certainly love to turn line-numbers off (or at least only use them when there's a certain number of lines in the code-block), as mentioned in #1573 this just doesn't seem to work in Vuepress at the moment when using Shiki.  Attempting to turn them off makes the problem *worse* by only removing the line-number from the last line, while keeping the rest:

![image](https://github.com/user-attachments/assets/1a5a74c5-f690-4321-a3e3-70143b060b1a)

This PR turns them back on to at least fix that bug.  I don't yet know what the long-term solution should be.

It seems odd to me that this is broken at the Vuepress/Shiki upstream, but as mentioned in #1573, I reproduced it in a clean environment.