### PR TITLE
Attempt to fix Android table issues

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ commands/docs/*.md
 .vuepress/.temp
 .vuepress/.cache
 .vuepress/dist/
+.vuepress/styles/

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ commands/docs/*.md
 .vuepress/.cache
 .vuepress/dist/
 .vuepress/styles/
+**/*.scss
+**/*.css

--- a/.vuepress/styles/index.scss
+++ b/.vuepress/styles/index.scss
@@ -29,8 +29,7 @@ div[class*='language-'].line-numbers-mode .line-numbers {
  */
 :root {
   --code-line-height: 1.1;
-  --font-family-code: Consolas, Monaco, 'Andale Mono', 'DejaVu Sans Mono',
-    'Ubuntu Mono', monospace;
+  --font-family-code: Consolas, Monaco, 'Andale Mono', 'DejaVu Sans Mono', 'Ubuntu Mono', monospace;
 }
 
 @media screen and (min-width: 720px) and (max-width: 815px) {


### PR DESCRIPTION
As @132ikl [mentioned in Discord today](https://discord.com/channels/601130461678272522/729071784321876040/1292515291279921205), the latest update breaks formatting on tables in code-blocks on Android browsers.  This looks like it is due to a change where the `--font-family-codes` got split across multiple lines, which should be invalid.  This puts them back on one line and will hopefully fix the issue.