### PR TITLE
Added changes to release notes for version 0.99.0 due to nushell/#14020

### DIFF
--- a/blog/2024-10-15-nushell_0_99_0.md
+++ b/blog/2024-10-15-nushell_0_99_0.md
@@ -27,6 +27,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
 - [_Changes_](#changes-toc)
   - [_Additions_](#additions-toc)
+    - [_`enhanced keybinding configuration`_](#enhanced-keybinding-configuration-toc)
   - [_Breaking changes_](#breaking-changes-toc)
   - [_Deprecations_](#deprecations-toc)
   - [_Removals_](#removals-toc)
@@ -69,6 +70,40 @@ As part of this release, we also publish a set of optional plugins you can insta
 # Changes [[toc](#table-of-content)]
 
 ## Additions [[toc](#table-of-content)]
+
+### `enhanced keybinding configuration` [[toc](#table-of-content)]
+
+**Support for Unicode Code Points in Keycodes.**
+
+Starting from [#14020](https://github.com/nushell/nushell/pull/14020), users can now specify characters in the keycode field using their Unicode code points, in the format `char_uXXXX`, where `XXXX` is the hexadecimal Unicode code point. This provides greater flexibility when configuring keybindings in Nushell.
+
+Specifying Unicode code points can help eliminate confusion when characters from different Unicode blocks look identical but have different code points. For example, by using `char_u0041` for the Latin `A`, `char_u0391` for the Greek `Α`, or `char_u0410` for the Cyrillic `А`, users can accurately define keybindings and avoid ambiguity in configurations.
+
+**Key Feature:**
+
+The current implementation does not restrict the number of leading zeroes when specifying Unicode code points. For example, the character `A` can be represented as `char_u41,` `char_u0041`, or even `char_u000041`. However, it is recommended to use four hexadecimal digits (e.g., `char_u0041`) to improve readability and maintain a consistent format across different configurations. This recommendation follows the standard Unicode representation and helps prevent ambiguity.
+
+**Example usage:**
+
+```nushell
+$env.config = {
+    ...
+
+    keybindings: [
+        {
+            name: <command_name>, # name of the command
+            modifier: none,       # key modifier
+            keycode: char_u0391,  # Unicode code for Greek 'Α'
+            mode: vi_normal,      # mode in which this binding should work
+            event: {
+                send: <action>    # action to be performed
+            }
+        }
+    ]
+
+    ...
+}
+```
 
 ## Breaking changes [[toc](#table-of-content)]
 


### PR DESCRIPTION
This PR includes details about Unicode code points in keybindings, as requested in [the comment](https://github.com/nushell/nushell/pull/14020#issuecomment-2399909753). The changes are based on the improvements introduced in [#14020](https://github.com/nushell/nushell/pull/14020).