### PR TITLE
str_replace: add link to rust doc

### DIFF
--- a/commands/docs/str_replace.md
+++ b/commands/docs/str_replace.md
@@ -22,7 +22,7 @@ usage: |
 
  -  `--all, -a`: replace all occurrences of the pattern
  -  `--no-expand, -n`: do not expand capture groups (like $name) in the replacement string
- -  `--regex, -r`: match the pattern as a regular expression in the input, instead of a substring
+ -  `--regex, -r`: match the pattern as a regular expression in the input, instead of a substring, following [rust specification](https://docs.rs/regex/latest/regex/struct.Regex.html#method.replace)
  -  `--multiline, -m`: multi-line regex mode (implies --regex): ^ and $ match begin/end of line; equivalent to (?m)
 
 ## Parameters


### PR DESCRIPTION
Trying to escape a capture group name, I had to discover and read rust doc.
Finding it should be easy for people who wants to know the specification of the regex mode.

Adding a link to it will bring knowledge to users.

:+1: Knowledge!
:thinking: Should we copy rust doc here in order to not be coupled with it? I have the feeling Nushell<>rust coupling is intentional, this is why I am opening the PR this way