### PR TITLE
wrapped script in "def main [] {...}"

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -175,7 +175,9 @@ For script to have access to standard input, `nu` should be invoked with `--stdi
 
 ```nu
 #!/usr/bin/env -S nu --stdin
-echo $"stdin: ($in)"
+def main [] {
+  echo $"stdin: ($in)"
+}
 ```
 
 ```nu


### PR DESCRIPTION
The example was not running correctly, without `main []`
It resulted in the following error:

```
 1 │ ╭─▶ #!/usr/bin/env -S nu --stdin
 2 │ │   
 3 │ │   echo $"stdin: ($in)"
 4 │ │     
 5 │ ├─▶ 
   · ╰──── block is missing compiled representation
```
