### PR TITLE
Updates to "Working with Tables" - Adds info on "index renaming" and the table command

### DIFF
--- a/book/working_with_tables.md
+++ b/book/working_with_tables.md
@@ -404,7 +404,7 @@ You've noticed that every table, by default, starts with a column with the headi
    - The default mode
    - Nushell provides a 0-based, consecutive index
    - Always corresponds to the cell-path row-number, where `select 0` will return the first item in the list, and `select <n-1>` returns the nth item
-   - Is a display of an internal representation only. In other words, it is not addressible by column name. For example, `get index` will not work, nor `get #`
+   - Is a display of an internal representation only. In other words, it is not accessible by column name. For example, `get index` will not work, nor `get #`
 
 1. "Index"-Renamed #
 
@@ -576,7 +576,7 @@ This can be useful when you need to store the rendered view of structured data a
 ls | table | ansi strip
 ```
 
-The `table` command also has multipe options for _changing_ the rendering of a table, such as:
+The `table` command also has multiple options for _changing_ the rendering of a table, such as:
 
 - `-e` to expand data that would normally be collapsed when rendering. Compare `scope modules | table` to `scope modules | table -e`.
 - `-i false` to hide the `index`/`#` column

--- a/book/working_with_tables.md
+++ b/book/working_with_tables.md
@@ -512,10 +512,10 @@ The `sort-by modified` now _also_ sorts the `index` along with the rest of the c
 
 ```nu
 let table = [
-[additions | deletions | delta ];
-[       10 |        20 |   -10 ]
-[       15 |         5 |    10 ]
-[        8 |         6 |     2 ]]
+[additions   deletions   delta ];
+[       10          20     -10 ]
+[       15           5      10 ]
+[        8           6       2 ]]
 
 let totals_row = ($table | math sum | insert index {"Totals"})
 $table | append $totals_row


### PR DESCRIPTION
Implements #1574 

Also, while there, I noticed that the chapter on Tables doesn't have any info on the `table` command, which seemed a bit odd - Added some detail regarding it, since it sometimes causes confusion.