### PR TITLE
Added candidate naming convention to the style guide

### DIFF
--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -267,10 +267,11 @@ It's common practice in Nushell to separate the words of the command with `-` fo
 ::: tip
 Because `def` is a parser keyword, the command name must be known at parse time. This means that command names may not be a variable or constant. For example, the following is _not allowed_:
 
-````nu
+```nu
 let name = "foo"
 def $name [] { foo }
 :::
+```
 
 ### Subcommands
 
@@ -280,7 +281,7 @@ You can also define subcommands of commands using a space. For example, if we wa
 def "str mycommand" [] {
   "hello"
 }
-````
+```
 
 Now we can call our custom command as if it were a built-in subcommand of [`str`](/commands/docs/str.md):
 

--- a/book/style_guide.md
+++ b/book/style_guide.md
@@ -180,6 +180,141 @@ let selectedProfile = (
 })
 ```
 
+## Naming Convention
+
+### Abbreviations and Acronyms
+
+**It's recommended** to use full concise words over abbreviations and acronyms, unless they are well-known and/or
+commonly used.
+
+Correct:
+
+```nu
+query-user --id 123
+
+$user.name | str downcase
+```
+
+Incorrect:
+
+```nu
+qry-usr --id 123
+
+$user.name | string downcase
+```
+
+### Case
+
+#### Commands
+
+**It's recommended to** use kebab-case for command names with multiple words.
+
+Correct:
+
+```nu
+fetch-user --id 123
+```
+
+Incorrect:
+
+```nu
+fetch_user --id 123
+fetchUser --id 123
+```
+
+See also [Naming Commands](custom_commands.md#naming-commands).
+
+#### Sub-Commands
+
+Sub commands are commands that are logically grouped under a parent command and separated by a space.
+**It's recommended to** use kebab-case for the sub-command name.
+
+Correct:
+
+```nu
+date now
+
+date list-timezone
+
+def "login basic-auth" [username: string password: string] {
+    # ...
+}
+```
+
+See also [Naming Sub-Commands](custom_commands.md#subcommands).
+
+#### Flags
+
+**It's recommended to** use kebab-case for flag names.
+
+Correct:
+
+```nu
+def greet [name: string, --all-caps] {
+    # ...
+}
+```
+
+Incorrect:
+
+```nu
+def greet [name: string, --all_caps] {
+    # ...
+}
+```
+
+::: tip
+Notice that the name used to access the flag is accessed by replacing the dash with an underscore in the resulting
+variable name.
+
+See [Flags](custom_commands.md#flags).
+:::
+
+#### Variables and Command Parameters
+
+**It's recommended to** use snake_case for variable names, including command parameters.
+
+Correct:
+
+```nu
+let user_id = 123
+
+def fetch-user [user_id: int] {
+  # ...
+}
+```
+
+Incorrect:
+
+```nu
+let user-id = 123
+let userId = 123
+
+def fetch-user [user-id: int] {
+  # ...
+}
+```
+
+#### Environment Variables
+
+**It's recommended to** use SCREAMING_SNAKE_CASE for environment variable names.
+
+Correct:
+
+```nu
+$env.ENVIRONMENT_CODE = "prod"
+
+$env.APP_VERSION = "1.0.0"
+```
+
+Incorrect:
+
+```nu
+$env.ENVIRONMENT-CODE = "prod"
+
+$env.app_version = "1.0.0"
+```
+
 ## Options and Parameters of Custom Commands
 
 - **It's recommended to** keep count of all positional parameters less than or equal to 2, for remaining inputs use options. Assume that command can expect source and destination parameter, like `mv`: source and target file or directory.


### PR DESCRIPTION
As per Discord, raised to help document the commonly used naming and make it easier for newbies to see normal usage and help staying consistent with standard library usage. Hopefully all standard practice and nothing controversial here. The foundations were taken from [this comment in Discord](https://discord.com/channels/601130461678272522/615329862395101194/941324199748853760)

This does feel a little verbose but I couldn't think of reducing it without removing the examples.

There was also a question about restructuring this page. Not sure I'm best placed to do that, but happy to give that a shot with more guidance.