### PR TITLE
Update forwarded cmd.exe commands docs

### DIFF
--- a/book/coming_from_cmd.md
+++ b/book/coming_from_cmd.md
@@ -57,4 +57,14 @@ This table was last updated for Nu 0.67.0.
 | `VERIFY`                             |                                                                                     | Verify that file writes happen                                        |
 | `VOL`                                |                                                                                     | Show drive information                                                |
 
-Before Nu version 0.67, Nu [used to](https://www.nushell.sh/blog/2022-08-16-nushell-0_67.html#windows-cmd-exe-changes-rgwood) use CMD.EXE to launch external commands, which meant that the above builtins could be run as an `^external` command. As of version 0.67, however, Nu no longer uses CMD.EXE to launch externals, meaning the above builtins cannot be run from within Nu, except for `ASSOC`, `CLS`, `ECHO`, `FTYPE`, `MKLINK`, `PAUSE`, `START`, `VER`, and `VOL`, which are explicitly allowed to be interpreted by CMD if no executable by that name exists.
+## Forwarded CMD.EXE commands
+
+Nu accepts and runs *some* CMD.EXE commands through `cmd.exe`.
+
+The forwarded commands are: `ASSOC`, `CLS`, `ECHO`, `FTYPE`, `MKLINK`, `PAUSE`, `START`, `VER`, `VOL`
+
+These forwarded commands take precedence over external commands.
+
+For example, with a `ver.bat` file in the current working directory, executing `^ver` leads to the CMD.EXE `VER` being executed, *NOT* the `ver.bat` file.
+
+Executing `./ver` or `ver.bat` *will* execute the local bat file though.

--- a/book/coming_from_cmd.md
+++ b/book/coming_from_cmd.md
@@ -59,12 +59,12 @@ This table was last updated for Nu 0.67.0.
 
 ## Forwarded CMD.EXE commands
 
-Nu accepts and runs *some* CMD.EXE commands through `cmd.exe`.
+Nu accepts and runs *some* of CMD.EXE's internal commands through `cmd.exe`.
 
-The forwarded commands are: `ASSOC`, `CLS`, `ECHO`, `FTYPE`, `MKLINK`, `PAUSE`, `START`, `VER`, `VOL`
+The internal commands are: `ASSOC`, `CLS`, `ECHO`, `FTYPE`, `MKLINK`, `PAUSE`, `START`, `VER`, `VOL`
 
-These forwarded commands take precedence over external commands.
+These internal commands take precedence over external commands.
 
-For example, with a `ver.bat` file in the current working directory, executing `^ver` leads to the CMD.EXE `VER` being executed, *NOT* the `ver.bat` file.
+For example, with a `ver.bat` file in the current working directory, executing `^ver` executes CMD.EXE's internal `VER` command, *NOT* the `ver.bat` file.
 
 Executing `./ver` or `ver.bat` *will* execute the local bat file though.


### PR DESCRIPTION
Replaces #1605 (which documented behavior across versions).

The "if no executable by that name exists" has been wrong since 0.94.0 (not disclosed in release notes, but consequence of 6c649809d38a687cd63b59ab028b7f30207e5663 [PR 12921](12921)).

The "used to" (prior version 0.67 2022-08-16) is very old, and no longer worth it to keep.

Add information about forwarded commands overshadowing external files.