### PR TITLE
Release notes for `0.100.0`

### DIFF
--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -1,0 +1,121 @@
+---
+title: Nushell 0.100.0
+author: The Nu Authors
+author_site: https://twitter.com/nu_shell
+author_image: https://www.nushell.sh/blog/images/nu_logo.png
+excerpt: Today, we're releasing version 0.100.0 of Nu. This release adds...
+---
+<!-- TODO: complete the excerpt above -->
+
+# Nushell 0.100.0
+
+Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your command line. It works seamlessly with the data from your filesystem, operating system, and a growing number of file formats to make it easy to build powerful command line pipelines.
+
+<!-- TODO: write this excerpt -->
+Today, we're releasing version 0.100.0 of Nu. This release adds...
+
+# Where to get it
+
+Nu 0.100.0 is available as [pre-built binaries](https://github.com/nushell/nushell/releases/tag/0.100.0) or from [crates.io](https://crates.io/crates/nu). If you have Rust installed you can install it using `cargo install nu`.
+
+As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
+
+# Table of contents
+- [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
+- [_Changes_](#changes-toc)
+  - [_Additions_](#additions-toc)
+  - [_Breaking changes_](#breaking-changes-toc)
+  - [_Deprecations_](#deprecations-toc)
+  - [_Removals_](#removals-toc)
+  - [_Bug fixes and other changes_](#bug-fixes-and-other-changes-toc)
+- [_Notes for plugin developers_](#notes-for-plugin-developers-toc)
+- [_Hall of fame_](#hall-of-fame-toc)
+- [_Full changelog_](#full-changelog-toc)
+<!-- TODO: please add links to the other sections here
+
+    the following command should help pre-generate a great deal of the table of content.
+    be careful with the format and false-positives :wink:
+    ```nushell
+    rg '^#+ ' blog/...
+        | lines
+        | each {
+            str replace '# ' '- '
+                | str replace --all '#' '    '
+                | str replace --regex '- (.*)' '- [_$1_](#$1-toc)'
+        }
+        | to text
+    ```
+-->
+
+# Highlights and themes of this release [[toc](#table-of-content)]
+<!-- NOTE: if you wanna write a section about a breaking change, when it's a very important one,
+    please add the following snippet to have a "warning" banner :)
+    > see [an example](https://www.nushell.sh/blog/2023-09-19-nushell_0_85_0.html#pythonesque-operators-removal)
+
+    ```md
+    ::: warning Breaking change
+    See a full overview of the [breaking changes](#breaking-changes)
+    :::
+    ```
+-->
+<!-- NOTE: see https://vuepress.github.io/reference/default-theme/markdown.html#custom-containers
+    for the list of available *containers*
+-->
+
+# Changes [[toc](#table-of-content)]
+
+## Additions [[toc](#table-of-content)]
+
+## Breaking changes [[toc](#table-of-content)]
+
+## Deprecations [[toc](#table-of-content)]
+
+## Removals [[toc](#table-of-content)]
+
+## Bug fixes and other changes [[toc](#table-of-content)]
+
+<!-- NOTE: to start investigating the contributions of last release, i like to list them all in a raw table.
+    to achieve this, one can use the [`list-merged-prs` script from `nu_scripts`](https://github.com/nushell/nu_scripts/blob/main/make_release/release-note/list-merged-prs)
+    as follows:
+
+    ```nushell
+    use ./make_release/release-note/list-merged-prs
+    use std clip
+
+    let last_release_date = ^gh api /repos/nushell/nushell/releases
+        | from json
+        | into datetime published_at
+        | get published_at
+        | sort
+        | last
+
+    let prs = list-merged-prs nushell/nushell $last_release_date
+        | sort-by mergedAt
+        | update url {|it| $"[#($it.number)]\(($it.url)\)" }
+        | update author { $"[@($in)]\(https://github.com/($in)\)" }
+        | select author title url
+        | rename -c {url: pr}
+        | to md --pretty
+
+    $prs | to md --pretty | clip
+    ```
+-->
+
+# Notes for plugin developers [[toc](#table-of-content)]
+
+# Hall of fame [[toc](#table-of-content)]
+
+Thanks to all the contributors below for helping us solve issues and improve documentation :pray:
+
+| author                               | title       | url                                                     |
+| ------------------------------------ | ----------- | ------------------------------------------------------- |
+| [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
+
+# Full changelog [[toc](#table-of-content)]
+<!-- TODO:
+    paste the output of
+    ```nu
+    ./make_release/release-note/get-full-changelog
+    ```
+    here
+-->

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -25,16 +25,37 @@ As part of this release, we also publish a set of optional plugins you can insta
 # Table of contents
 
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
-  - [_Cheers to a century!_][#cheers-to-a-century-toc]
+  - [_Cheers to a century!_](#cheers-to-a-century-toc)
 - [_Changes_](#changes-toc)
   - [_Additions_](#additions-toc)
-    - []
+    - [_`like` and `not-like` operators_](#like-and-not-like-operators-toc)
+    - [_`catch` error record_](#catch-error-record-toc)
+    - [_`help commands` and `scope commands`_](#help-commands-and-scope-commands-toc)
+    - [_`ps -l`_](#ps-l-toc)
+    - [_`url build-query`_](#url-build-query-toc)
+    - [_`stor`_](#stor-toc)
+    - [_`to text --no-newline`_](#to-text-no-newline)
+    - [_`open --raw`_](#open-raw-toc)
+    - [_`help`_](#help-toc)
+    - [_`$env.config.table.footer_inheritance`_](#env-config-table-footer-inheritance-toc)
   - [_Breaking changes_](#breaking-changes-toc)
+    - [_Lone, leading pipe in closures_](#lone-leading-pipe-in-closures-toc)
     - [_`plugin list`_](#plugin-list-toc)
   - [_Deprecations_](#deprecations-toc)
+    - [_AST evaluation engine_](#ast-evaluation-engine-toc)
   - [_Removals_](#removals-toc)
   - [_Bug fixes and other changes_](#bug-fixes-and-other-changes-toc)
-- [_Notes for plugin developers_](#notes-for-plugin-developers-toc)
+    - [_`return`_](#return-toc)
+    - [_`to text`_](#to-text-toc)
+    - [_`to nuon`_](#to-nuon-toc)
+    - [_`use`_](#use-toc)
+    - [_`transpose`_](#transpose-toc)
+    - [_Constants with type signatures_](#constants-with-type-signatures-toc)
+    - [_Short flag type checking_](#short-flag-type-checking-toc)
+    - [_Cell path pretty printing_](#cell-path-pretty-printing-toc)
+    - [_`in $range`_](#in-range-toc)
+    - [_`clear`_](#clear-toc)
+    - [_Panic fixes_](#panic-fixes-toc)
 - [_Hall of fame_](#hall-of-fame-toc)
 - [_Full changelog_](#full-changelog-toc)
 <!-- TODO: please add links to the other sections here
@@ -77,11 +98,11 @@ We wish to express our heartfelt gratitude and congratulations to all of our con
 
 ## Additions [[toc](#table-of-content)]
 
-### `like` and `not-like` operators
+### `like` and `not-like` operators [[toc](#table-of-content)]
 
 With [#14072](https://github.com/nushell/nushell/pull/14072), this release adds two "new" operators: `like` and `not-like`. These operators are alternative forms of the preexisting `=~` and `!~` operators, respectively. The only reason to use one form over the other is preference. For example, people familiar with SQL may prefer using `like` and `not-like`. In the future, there is a chance that the shorter forms may be removed, but there are no plans to do so yet, if at all.
 
-### `history import`
+### `history import` [[toc](#table-of-content)]
 
 Thanks to [@qfel](https://github.com/qfel) in [#13450](https://github.com/nushell/nushell/pull/13450), this release adds the `history import` command. Running this command takes the history from the alternate history file format and imports it into the currently configured history file format. For example, to migrate from plain text to sqlite:
 
@@ -98,7 +119,7 @@ history import
 
 You can also pipe new history entries into `history import`, and they will be added to your history file. See `help history import` for some examples.
 
-### `catch` error record
+### `catch` error record [[toc](#table-of-content)]
 
 In [#14082](https://github.com/nushell/nushell/pull/14082), two additional columns were added to the error record passed to catch blocks/closures:
 
@@ -109,7 +130,15 @@ In [#14082](https://github.com/nushell/nushell/pull/14082), two additional colum
 
 This release adds a new `url split-query` command in [#14211](https://github.com/nushell/nushell/pull/14211) thanks to [@Bahex](https://github.com/Bahex). It is the counterpart to `url build-query` and splits a url query string into its different parameters. It returns a table with two columns: `key` and `value`.
 
-### `url build-query`
+### `help commands` and `scope commands` [[toc](#table-of-content)]
+
+The `help commands` and `scope commands` now output an `is_const` column indicating whether a command can be used in a parse-time constant context ([#14125](https://github.com/nushell/nushell/pull/14125)).
+
+### `ps -l` [[toc](#table-of-content)]
+
+On macOS, `ps -l` now lists the `start_time` of the processes. Windows and Linux already listed a `start_time` column ([#14127](https://github.com/nushell/nushell/pull/14127)).
+
+### `url build-query` [[toc](#table-of-content)]
 
 Thanks to [@adaschma](https://github.com/adaschma) in [#14073](https://github.com/nushell/nushell/pull/14073), `url build-query` now allows list values in the parameter record. For example:
 
@@ -118,7 +147,7 @@ Thanks to [@adaschma](https://github.com/adaschma) in [#14073](https://github.co
 # a=1&a=2&b=3
 ```
 
-### `touch --no-deref`
+### `touch --no-deref` [[toc](#table-of-content)]
 
 Thanks to [@Dorumin](https://github.com/Dorumin) in [#14214](https://github.com/nushell/nushell/pull/14214), a new `--no-deref` flag was added to `touch`. Providing this flag will make `touch` not follow symlinks.
 
@@ -134,11 +163,11 @@ On macOS, `ps -l` now lists the `start_time` of the processes. Windows and Linux
 
 Thanks to [@sgvictorino](https://github.com/sgvictorino) in [#14224](https://github.com/nushell/nushell/pull/14224), the `length` command now supports binary values as input and returns the number of bytes.
 
-### `stor`
+### `stor` [[toc](#table-of-content)]
 
 `stor` now supports list and table inputs thanks to [@friaes](https://github.com/friaes) in [#14175](https://github.com/nushell/nushell/pull/14175).
 
-### `to text --no-newline`
+### `to text --no-newline` [[toc](#table-of-content)]
 
 In [#14158](https://github.com/nushell/nushell/pull/14158), the `--no-newline`/`-n` flag was added to `to text`. Providing this flag disables the trailing new line added to the output.
 
@@ -150,15 +179,15 @@ In [#14158](https://github.com/nushell/nushell/pull/14158), the `--no-newline`/`
 [a b] | to text -n # "a\nb"
 ```
 
-### `open --raw`
+### `open --raw` [[toc](#table-of-content)]
 
 After [#14141](https://github.com/nushell/nushell/pull/14141), `open --raw` now sets the appropriate `content-type` in the pipeline metadata for `nu`, `nuon`, and `json` files.
 
-### `help`
+### `help` [[toc](#table-of-content)]
 
 The `help` output for commands now shows the command type in parenthesis after the command name (i.e., `plugin`, `alias`, or `custom`). Currently, the command type is not displayed for `built-in`, `keyword`, or known `external` commands ([#14165](https://github.com/nushell/nushell/pull/14165)).
 
-### `$env.config.table.footer_inheritance`
+### `$env.config.table.footer_inheritance` [[toc](#table-of-content)]
 
 A new option has been introduced for table rendering by [@zhiburt](https://github.com/zhiburt) in [#14070](https://github.com/nushell/nushell/pull/14070). With `$env.config.table.footer_inheritance = true`, if one of the inner rendered tables trips the footer mode setting to show a footer at the bottom of the table, all of the outer tables will also have footers rendered.
 
@@ -168,11 +197,11 @@ Thanks to [@hacker-DOM](https://github.com/hacker-DOM) in [#14201](https://githu
 
 ## Breaking changes [[toc](#table-of-content)]
 
-### Division, floor division, and `mod`
+### Division, floor division, and `mod` [[toc](#table-of-content)]
 
 In [#14157](https://github.com/nushell/nushell/pull/14157), several changes were made to the division related operators to make them more consistent.
 
-### Division
+#### Division
 
 First, division between two integers used to be able to return either an int or a float value even though the type signature claimed the result would always be a float.
 
@@ -241,7 +270,7 @@ This matches the behavior of Python's `//` and `%` operators which were the orig
 
 Otherwise, the implementation of all the division related operators has been improved to account for overflow. Rather than silently clamping or overflowing, the operators will now create an error in these cases.
 
-### Lone, leading pipe in closures
+### Lone, leading pipe in closures [[toc](#table-of-content)]
 
 Currently, a leading pipe character is allowed for pipelines in Nushell:
 
@@ -324,6 +353,10 @@ The method used for case insensitive comparisons and sorting has been updated/im
 
 In [#14184](https://github.com/nushell/nushell/pull/14184), `ansi clear_entire_screen_plus_buffer` now returns an ansi code that clears both the screen and scrollback buffer. Previously, it would only clear the scrollback buffer. In addition, a new `clear_scrollback_buffer` entry has been added to the `ansi` command. This will clear only the scrollback buffer.
 
+### AST evaluation engine [[toc](#table-of-content)]
+
+The `NU_DISABLE_IR` environment variable as well as the AST evaluation engine itself is planned to be removed in the next release, and is now deprecated. We consider the IR evaluator to now be mature enough that it's time to stop maintaining the old evaluator.
+
 ## Removals [[toc](#table-of-content)]
 
 ### `std/dirs`
@@ -336,41 +369,45 @@ The `std/dirs` module is no longer loaded by default on startup after [#14242](h
 
 In [#14120](https://github.com/nushell/nushell/pull/14120), a bug was fixed were `return`, `break`, and `continue` would set the last exit code to 1.
 
-### External command bareword arguments
+### External command bareword arguments [[toc](#table-of-content)]
 
 There was a bug where "expressions" inside barewords created using backticks would be evaluated if provided as arguments to external commands. This has been fixed with [#14210](https://github.com/nushell/nushell/pull/14210).
 
-### `to text`
+### `return` [[toc](#table-of-content)]
+
+In [#14120](https://github.com/nushell/nushell/pull/14120), a bug was fixed were `return`, `break`, and `continue` would set the last exit code to 1.
+
+### `to text` [[toc](#table-of-content)]
 
 `to text` previously had different behavior for list values and streaming list input. This has been fixed with [#14158](https://github.com/nushell/nushell/pull/14158), and the behavior for list streams is now used for list values.
 
-### `to nuon`
+### `to nuon` [[toc](#table-of-content)]
 
 `to nuon` previously did not escape column names containing quotes. This has been fixed by [@aionescu](https://github.com/aionescu) in [#14180](https://github.com/nushell/nushell/pull/14180).
 
-### `use`
+### `use` [[toc](#table-of-content)]
 
 When importing a module that defines no constants, an empty record variable is no longer created ([#14051](https://github.com/nushell/nushell/pull/14051)).
 
-### `transpose`
+### `transpose` [[toc](#table-of-content)]
 
 With [#14096](https://github.com/nushell/nushell/pull/14096), `transpose` now bubbles up any top-level errors it encounters in its input thanks to [@PhotonBursted](https://github.com/PhotonBursted).
 
-### Constants with type signatures
+### Constants with type signatures [[toc](#table-of-content)]
 
 Thanks to [@sgvictorino](https://github.com/sgvictorino) in [#14118](https://github.com/nushell/nushell/pull/14118), a compiler bug preventing imports of constants with type signatures has been fixed.
 
-### Short flag type checking
+### Short flag type checking [[toc](#table-of-content)]
 
 Short flags for commands were previously not being typed checked. This has been fixed in [#14074](https://github.com/nushell/nushell/pull/14074) thanks to [@sgvictorino](https://github.com/sgvictorino).
 
-### Cell path pretty printing
+### Cell path pretty printing [[toc](#table-of-content)]
 
 The pretty printing for optional cell paths has been fixed by [@aionescu](https://github.com/aionescu) in [#14042](https://github.com/nushell/nushell/pull/14042) to show a `?` after each optional path component. This is particularly helpful for the `view ir` command. Thanks!
 
 The formatting has also been changed in [#14197](https://github.com/nushell/nushell/pull/14197) to start with `$`, reflecting the literal syntax. This means that the cell path literal `$.foo.bar` will now be printed as `$.foo.bar` instead of `foo.bar`.
 
-### `in $range`
+### `in $range` [[toc](#table-of-content)]
 
 The step value for ranges was previously not taken into account when checking if a value was `in` a range. Thanks to [@JoaquinTrinanes](https://github.com/JoaquinTrinanes), this has been fixed with [#14011](https://github.com/nushell/nushell/pull/14011).
 
@@ -390,15 +427,13 @@ An issue where table literal arguments to `join` were not parsed correctly has b
 
 An issue where table literals were incorrectly parsed when used as arguments to commands has been fixed in [#14190](https://github.com/nushell/nushell/pull/14190) and [#14226](https://github.com/nushell/nushell/pull/14226) thanks to [@sgvictorino](https://github.com/sgvictorino).
 
-### `clear`
+### `clear` [[toc](#table-of-content)]
 
 On some terminals, `clear` would behave weirdly if used in a series of commands. Thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds), this has been fixed in [#14181](https://github.com/nushell/nushell/pull/14181).
 
-### Panic fixes
+### Panic fixes [[toc](#table-of-content)]
 
 A parser panic regarding redirections was fixed in [#14035](https://github.com/nushell/nushell/pull/14035) thanks to [@Kither12](https://github.com/Kither12).
-
-# Notes for plugin developers [[toc](#table-of-content)]
 
 # Hall of fame [[toc](#table-of-content)]
 

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -73,41 +73,14 @@ As part of this release, we also publish a set of optional plugins you can insta
 - [_Hall of fame_](#hall-of-fame-toc)
 - [_All breaking changes_](#all-breaking-changes-toc)
 - [_Full changelog_](#full-changelog-toc)
-<!-- TODO: please add links to the other sections here
-
-    the following command should help pre-generate a great deal of the table of content.
-    be careful with the format and false-positives :wink:
-    ```nushell
-    rg '^#+ ' blog/...
-        | lines
-        | each {
-            str replace '# ' '- '
-                | str replace --all '#' '    '
-                | str replace --regex '- (.*)' '- [_$1_](#$1-toc)'
-        }
-        | to text
-    ```
--->
 
 # Highlights and themes of this release [[toc](#table-of-content)]
-
-<!-- NOTE: if you wanna write a section about a breaking change, when it's a very important one,
-    please add the following snippet to have a "warning" banner :)
-    > see [an example](https://www.nushell.sh/blog/2023-09-19-nushell_0_85_0.html#pythonesque-operators-removal)
-
-    ```md
-    ::: warning Breaking change
-    See a full overview of the [breaking changes](#breaking-changes)
-    :::
-    ```
--->
-<!-- NOTE: see https://vuepress.github.io/reference/default-theme/markdown.html#custom-containers
-    for the list of available *containers*
--->
 
 ## Cheers to a century! [[toc](#table-of-content)]
 
 We wish to express our heartfelt gratitude and congratulations to all of our contributors and users on releasing version 0.100.0! Thanks for sticking with us and making Nushell great. Here's to a hundred more! 🎉
+
+After this release, we will be switching to a 6-week release schedule instead of our current 4-week one. This will allow us to focus more on making and merging changes, and giving major changes room to breathe.
 
 ## `like` and `not-like` operators [[toc](#table-of-content)]
 

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -3,18 +3,14 @@ title: Nushell 0.100.0
 author: The Nu Authors
 author_site: https://twitter.com/nu_shell
 author_image: https://www.nushell.sh/blog/images/nu_logo.png
-excerpt: Today, we're releasing version 0.100.0 of Nu. This release adds...
+excerpt: Today, we're releasing version 0.100.0 of Nu. In addition to being a major milestone, this release adds two new operators for working with strings, improves plugin management, and includes a very large number of other minor improvements and fixes.
 ---
-
-<!-- TODO: complete the excerpt above -->
 
 # Nushell 0.100.0
 
 Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your command line. It works seamlessly with the data from your filesystem, operating system, and a growing number of file formats to make it easy to build powerful command line pipelines.
 
-<!-- TODO: write this excerpt -->
-
-Today, we're releasing version 0.100.0 of Nu. This release adds...
+Today, we're releasing version 0.100.0 of Nu. In addition to being a major milestone, this release adds two new operators for working with strings, improves plugin management, and includes a very large number of other minor improvements and fixes.
 
 # Where to get it
 
@@ -26,9 +22,10 @@ As part of this release, we also publish a set of optional plugins you can insta
 
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
   - [_Cheers to a century!_](#cheers-to-a-century-toc)
+  - [_`like` and `not-like` operators_](#like-and-not-like-operators-toc)
+  - [_`plugin list`_](#plugin-list-toc)
 - [_Changes_](#changes-toc)
   - [_Additions_](#additions-toc)
-    - [_`like` and `not-like` operators_](#like-and-not-like-operators-toc)
     - [_`catch` error record_](#catch-error-record-toc)
     - [_`help commands` and `scope commands`_](#help-commands-and-scope-commands-toc)
     - [_`ps -l`_](#ps-l-toc)
@@ -40,7 +37,6 @@ As part of this release, we also publish a set of optional plugins you can insta
     - [_`$env.config.table.footer_inheritance`_](#env-config-table-footer-inheritance-toc)
   - [_Breaking changes_](#breaking-changes-toc)
     - [_Lone, leading pipe in closures_](#lone-leading-pipe-in-closures-toc)
-    - [_`plugin list`_](#plugin-list-toc)
   - [_Deprecations_](#deprecations-toc)
     - [_AST evaluation engine_](#ast-evaluation-engine-toc)
   - [_Removals_](#removals-toc)
@@ -95,6 +91,43 @@ As part of this release, we also publish a set of optional plugins you can insta
 ## Cheers to a century! [[toc](#table-of-content)]
 
 We wish to express our heartfelt gratitude and congratulations to all of our contributors and users on releasing version 0.100.0! Thanks for sticking with us and making Nushell great. Here's to a hundred more! 🎉
+
+## `like` and `not-like` operators [[toc](#table-of-content)]
+
+With [#14072](https://github.com/nushell/nushell/pull/14072), this release adds two "new" operators: `like` and `not-like`. These operators are alternative forms of the preexisting `=~` and `!~` operators, respectively. The only reason to use one form over the other is preference. For example, people familiar with SQL may prefer using `like` and `not-like`. In the future, there is a chance that the shorter forms may be removed, but there are no plans to do so yet, if at all.
+
+## `plugin list` [[toc](#table-of-content)]
+
+::: warning Breaking change
+See a full overview of the [breaking changes](#breaking-changes-toc)
+:::
+
+The `plugin list` command has been changed in [#14085](https://github.com/nushell/nushell/pull/14085) to consider both the plugins currently present in the engine state as well as the plugins stored in the registry file. Changes made by `plugin add` and `plugin rm` should now be more obvious.
+
+As part of this change, the `is_running` column has been replaced by a `status` column, which now displays many possible states a plugin can be in:
+
+- `added`: The plugin is present in the plugin registry file, but not in the engine.
+- `loaded`: The plugin is present both in the plugin registry file and in the engine, but is not running.
+- `running`: The plugin is currently running, and the `pid` column should contain its process ID.
+- `modified`: The plugin state present in the plugin registry file is different from the state in the engine.
+- `removed`: The plugin is still loaded in the engine, but is not present in the plugin registry file.
+- `invalid`: The data in the plugin registry file couldn't be deserialized, and the plugin most likely needs to be added again.
+
+`running` always has high priority as a state, so other statuses won't be visible if a plugin is currently running. This means that
+
+```nushell
+# 0.99.0
+plugin list | where is_running
+```
+
+can now always be replaced by:
+
+```nushell
+# 0.100.0
+plugin list | where status == running
+```
+
+In case you want to avoid loading the plugin registry file (e.g. for performance reasons), you can now use the `--engine` flag to do so. Similarly, the `--registry` flag will only display the contents of the registry, without comparing them against the state of the engine (but all plugins will appear as `added`). The `--plugin-config` flag is now supported to allow use of a separate plugin registry file, identically to the other `plugin` commands.
 
 # Changes [[toc](#table-of-content)]
 
@@ -297,6 +330,10 @@ Otherwise, the implementation of all the division related operators has been imp
 
 ### Lone, leading pipe in closures [[toc](#table-of-content)]
 
+::: warning Breaking change
+See a full overview of the [breaking changes](#breaking-changes-toc)
+:::
+
 Currently, a leading pipe character is allowed for pipelines in Nushell:
 
 ```nu
@@ -377,6 +414,8 @@ The method used for case insensitive comparisons and sorting has been updated/im
 ### `ansi clear_entire_screen_plus_buffer`
 
 In [#14184](https://github.com/nushell/nushell/pull/14184), `ansi clear_entire_screen_plus_buffer` now returns an ansi code that clears both the screen and scrollback buffer. Previously, it would only clear the scrollback buffer. In addition, a new `clear_scrollback_buffer` entry has been added to the `ansi` command. This will clear only the scrollback buffer.
+
+## Deprecations [[toc](#table-of-content)]
 
 ### AST evaluation engine [[toc](#table-of-content)]
 

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -81,6 +81,23 @@ We wish to express our heartfelt gratitude and congratulations to all of our con
 
 With [#14072](https://github.com/nushell/nushell/pull/14072), this release adds two "new" operators: `like` and `not-like`. These operators are alternative forms of the preexisting `=~` and `!~` operators, respectively. The only reason to use one form over the other is preference. For example, people familiar with SQL may prefer using `like` and `not-like`. In the future, there is a chance that the shorter forms may be removed, but there are no plans to do so yet, if at all.
 
+### `history import`
+
+Thanks to [@qfel](https://github.com/qfel) in [#13450](https://github.com/nushell/nushell/pull/13450), this release adds the `history import` command. Running this command takes the history from the alternate history file format and imports it into the currently configured history file format. For example, to migrate from plain text to sqlite:
+
+```nu
+# Current format is plain text
+# $env.config.history.file_format == plaintext
+
+# Change the file format. Make sure to set this in your config if you want to persist this change.
+$env.config.history.file_format = 'sqlite'
+
+# Import the old history to the new format. It will create a backup if necessary.
+history import
+```
+
+You can also pipe new history entries into `history import`, and they will be added to your history file. See `help history import` for some examples.
+
 ### `catch` error record
 
 In [#14082](https://github.com/nushell/nushell/pull/14082), two additional columns were added to the error record passed to catch blocks/closures:
@@ -88,13 +105,9 @@ In [#14082](https://github.com/nushell/nushell/pull/14082), two additional colum
 - `json`: a string containing the error data as JSON.
 - `rendered`: a string containing the pretty formatted error message, roughly the same as you would see in your terminal.
 
-### `help commands` and `scope commands`
+### `url split-query` [[toc](#table-of-content)]
 
-The `help commands` and `scope commands` now output an `is_const` column indicating whether a command can be used in a parse-time constant context ([#14125](https://github.com/nushell/nushell/pull/14125)).
-
-### `ps -l`
-
-On macOS, `ps -l` now lists the `start_time` of the processes. Windows and Linux already listed a `start_time` column ([#14127](https://github.com/nushell/nushell/pull/14127)).
+This release adds a new `url split-query` command in [#14211](https://github.com/nushell/nushell/pull/14211) thanks to [@Bahex](https://github.com/Bahex). It is the counterpart to `url build-query` and splits a url query string into its different parameters. It returns a table with two columns: `key` and `value`.
 
 ### `url build-query`
 
@@ -104,6 +117,22 @@ Thanks to [@adaschma](https://github.com/adaschma) in [#14073](https://github.co
 { a: [1 2], b: 3 } | url build-query
 # a=1&a=2&b=3
 ```
+
+### `touch --no-deref`
+
+Thanks to [@Dorumin](https://github.com/Dorumin) in [#14214](https://github.com/nushell/nushell/pull/14214), a new `--no-deref` flag was added to `touch`. Providing this flag will make `touch` not follow symlinks.
+
+### `help commands` and `scope commands`
+
+The `help commands` and `scope commands` now output an `is_const` column indicating whether a command can be used in a parse-time constant context ([#14125](https://github.com/nushell/nushell/pull/14125)).
+
+### `ps -l`
+
+On macOS, `ps -l` now lists the `start_time` of the processes. Windows and Linux already listed a `start_time` column ([#14127](https://github.com/nushell/nushell/pull/14127)).
+
+### `length`
+
+Thanks to [@sgvictorino](https://github.com/sgvictorino) in [#14224](https://github.com/nushell/nushell/pull/14224), the `length` command now supports binary values as input and returns the number of bytes.
 
 ### `stor`
 
@@ -123,7 +152,7 @@ In [#14158](https://github.com/nushell/nushell/pull/14158), the `--no-newline`/`
 
 ### `open --raw`
 
-After [#14141](https://github.com/nushell/nushell/pull/14141), `open --raw` now sets the `content-type` in the pipeline metadata for `nu`, `nuon`, and `json` files.
+After [#14141](https://github.com/nushell/nushell/pull/14141), `open --raw` now sets the appropriate `content-type` in the pipeline metadata for `nu`, `nuon`, and `json` files.
 
 ### `help`
 
@@ -133,7 +162,84 @@ The `help` output for commands now shows the command type in parenthesis after t
 
 A new option has been introduced for table rendering by [@zhiburt](https://github.com/zhiburt) in [#14070](https://github.com/nushell/nushell/pull/14070). With `$env.config.table.footer_inheritance = true`, if one of the inner rendered tables trips the footer mode setting to show a footer at the bottom of the table, all of the outer tables will also have footers rendered.
 
+### Function key keybindings
+
+Thanks to [@hacker-DOM](https://github.com/hacker-DOM) in [#14201](https://github.com/nushell/nushell/pull/14201), the function keys from F21 to F35 are now allowed in key bindings. Note that for the keys to work, support for the kitty keyboard protocol needs to be enabled in your config (`$env.config.use_kitty_protocol`) and your terminal also needs to support the protocol.
+
 ## Breaking changes [[toc](#table-of-content)]
+
+### Division, floor division, and `mod`
+
+In [#14157](https://github.com/nushell/nushell/pull/14157), several changes were made to the division related operators to make them more consistent.
+
+### Division
+
+First, division between two integers used to be able to return either an int or a float value even though the type signature claimed the result would always be a float.
+
+```nu
+(1 / 2 | describe) == float
+(2 / 2 | describe) == int
+```
+
+This release changes division between any two types to always return a float **except** if the left hand side is a filesize or duration and the right hand side is an int or float.
+
+```nu
+(1 / 2 | describe) == float
+(2 / 2 | describe) == float
+(1KB / 1KB | describe) == float
+(2sec / 2sec | describe) == float
+
+# There is no floating point representation for filesizes and durations,
+# so truncating division is used in this case.
+(5B / 2) == 2B
+(2sec / 2.0) == 1sec
+```
+
+#### Floor division
+
+Second, floor division now does automatic float promotion. That is, if one of the operands is a float, and the other is an int or float, then the result will be a float. This matches the behavior of other operators like addition and multiplication which do float promotion as well. It also avoids potential overflows when trying to convert a large magnitude float into an int.
+
+```nu
+# Before
+(1 // 1 | describe) == int
+(1 // 1.0 | describe) == int
+(1.0 // 1.0 | describe) == int
+
+# After
+(1 // 1 | describe) == int
+(1 // 1.0 | describe) == float
+(1.0 // 1.0 | describe) == float
+```
+
+Additionally, the previous implementation of floor division performed unnecessary clamping which has been fixed with this release. So, results should now be more accurate.
+
+#### `mod`
+
+In previous releases, the implementation of `mod` was based off of truncating division even though Nushell does not have a truncating division operator. This release changes `mod` to be based off of floor division so that `mod` and floor division in combination can satisfy the division rule:
+
+```nu
+let quotient = $n // $d
+let remainder = $n mod $d
+$n == $quotient * $d + $remainder
+```
+
+If the signs of the divisor and dividend are the same, then the result of `mod` will be the same as before. However, if the signs are not the same, then the result of `mod` will be different compared to before to satisfy the division rule.
+
+```nu
+# Before
+let q = 8 // -3   # -3
+let r = 8 mod -3  # 2
+8 == $q * -3 + $r # false
+
+# After
+let q = 8 // -3   # -3
+let r = 8 mod -3  # -1
+8 == $q * -3 + $r # true
+```
+
+This matches the behavior of Python's `//` and `%` operators which were the original inspiration.
+
+Otherwise, the implementation of all the division related operators has been improved to account for overflow. Rather than silently clamping or overflowing, the operators will now create an error in these cases.
 
 ### Lone, leading pipe in closures
 
@@ -186,19 +292,57 @@ plugin list | where status == running
 
 In case you want to avoid loading the plugin registry file (e.g. for performance reasons), you can now use the `--engine` flag to do so. Similarly, the `--registry` flag will only display the contents of the registry, without comparing them against the state of the engine (but all plugins will appear as `added`). The `--plugin-config` flag is now supported to allow use of a separate plugin registry file, identically to the other `plugin` commands.
 
-## Deprecations [[toc](#table-of-content)]
+### `url parse`
+
+Thanks to [@Bahex](https://github.com/Bahex) in [#14211](https://github.com/nushell/nushell/pull/14211), the `params` field output for `url parse` is now a table with a `key` and `value` column instead of a record to match the new `url split-query` command ([see above](#url-split-query-toc)).
+
+### `http` `--max-time`
+
+With [#14237](https://github.com/nushell/nushell/pull/14237), the `--max-time` flag for the `http` family of commands now takes a duration value instead of a integer number of seconds. Thanks to [@alex-kattathra-johnson](https://github.com/alex-kattathra-johnson) for making this change!
+
+### Empty rest matches
+
+If a list rest pattern match ended up being empty, the match variable would previously be `null`. In [#14246](https://github.com/nushell/nushell/pull/14246) thanks to [@CharlesTaylor7](https://github.com/CharlesTaylor7), the match variable will instead be an empty list if no matches are found.
+
+```nu
+# Before
+match [] {
+    [..$rest] => ($rest == null) # true
+}
+
+# After
+match [] {
+    [..$rest] => ($rest == []) # true
+}
+```
+
+### Case insensitive sorting
+
+The method used for case insensitive comparisons and sorting has been updated/improved this release in [#14255](https://github.com/nushell/nushell/pull/14255) thanks to [@132ikl](https://github.com/132ikl). This will affect the output of `sort -i`, `uniq -i`, `get -s`, `find -i`, `str contains -i`, `str starts-with -i`, `str ends-with -i`, tab completions, and probably a few other commands (this list is not exhaustive).
+
+### `ansi clear_entire_screen_plus_buffer`
+
+In [#14184](https://github.com/nushell/nushell/pull/14184), `ansi clear_entire_screen_plus_buffer` now returns an ansi code that clears both the screen and scrollback buffer. Previously, it would only clear the scrollback buffer. In addition, a new `clear_scrollback_buffer` entry has been added to the `ansi` command. This will clear only the scrollback buffer.
 
 ## Removals [[toc](#table-of-content)]
 
+### `std/dirs`
+
+The `std/dirs` module is no longer loaded by default on startup after [#14242](https://github.com/nushell/nushell/pull/14242). See the [previous release notes](https://www.nushell.sh/blog/2024-10-15-nushell_0_99_0.html#standard-library-std-dirs-toc) for more information.
+
 ## Bug fixes and other changes [[toc](#table-of-content)]
 
-### `return`
+### `return`, `break`, and `continue`
 
 In [#14120](https://github.com/nushell/nushell/pull/14120), a bug was fixed were `return`, `break`, and `continue` would set the last exit code to 1.
 
+### External command bareword arguments
+
+There was a bug where "expressions" inside barewords created using backticks would be evaluated if provided as arguments to external commands. This has been fixed with [#14210](https://github.com/nushell/nushell/pull/14210).
+
 ### `to text`
 
-`to text` would previously have different behavior for list values and streaming list input. This has been fixed with [#14158](https://github.com/nushell/nushell/pull/14158), and the behavior for list streams is now used for list values.
+`to text` previously had different behavior for list values and streaming list input. This has been fixed with [#14158](https://github.com/nushell/nushell/pull/14158), and the behavior for list streams is now used for list values.
 
 ### `to nuon`
 
@@ -230,6 +374,22 @@ The formatting has also been changed in [#14197](https://github.com/nushell/nush
 
 The step value for ranges was previously not taken into account when checking if a value was `in` a range. Thanks to [@JoaquinTrinanes](https://github.com/JoaquinTrinanes), this has been fixed with [#14011](https://github.com/nushell/nushell/pull/14011).
 
+### `into datetime`
+
+After [#14266](https://github.com/nushell/nushell/pull/14266), times are kept intact when performing conversion to the local time zone for parsed human date strings.
+
+### `ansi -l`
+
+The preview column from `ansi -l` now also shows bold, dimmed, blink, and other effects thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds) in [#14196](https://github.com/nushell/nushell/pull/14196).
+
+### `join`
+
+An issue where table literal arguments to `join` were not parsed correctly has been fixed in
+
+### Table literals as arguments
+
+An issue where table literals were incorrectly parsed when used as arguments to commands has been fixed in [#14190](https://github.com/nushell/nushell/pull/14190) and [#14226](https://github.com/nushell/nushell/pull/14226) thanks to [@sgvictorino](https://github.com/sgvictorino).
+
 ### `clear`
 
 On some terminals, `clear` would behave weirdly if used in a series of commands. Thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds), this has been fixed in [#14181](https://github.com/nushell/nushell/pull/14181).
@@ -256,6 +416,8 @@ https://github.com/nushell/nushell/pull/14128
 https://github.com/nushell/nushell/pull/14229
 https://github.com/nushell/nushell/pull/14230
 https://github.com/nushell/nushell/pull/14291
+https://github.com/nushell/nushell/pull/14307
+https://github.com/nushell/nushell/pull/14002
 -->
 
 # Full changelog [[toc](#table-of-content)]

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -25,8 +25,10 @@ As part of this release, we also publish a set of optional plugins you can insta
 # Table of contents
 
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
+  - [_Cheers to a century!_][#cheers-to-a-century-toc]
 - [_Changes_](#changes-toc)
   - [_Additions_](#additions-toc)
+    - []
   - [_Breaking changes_](#breaking-changes-toc)
     - [_`plugin list`_](#plugin-list-toc)
   - [_Deprecations_](#deprecations-toc)
@@ -66,6 +68,10 @@ As part of this release, we also publish a set of optional plugins you can insta
 <!-- NOTE: see https://vuepress.github.io/reference/default-theme/markdown.html#custom-containers
     for the list of available *containers*
 -->
+
+## Cheers to a century! [[toc](#table-of-content)]
+
+We wish to express our heartfelt gratitude and congratulations to all of our contributors and users on releasing version 0.100.0! Thanks for sticking with us and making Nushell great. Here's to a hundred more! 🎉
 
 # Changes [[toc](#table-of-content)]
 
@@ -122,6 +128,10 @@ After [#14141](https://github.com/nushell/nushell/pull/14141), `open --raw` now 
 ### `help`
 
 The `help` output for commands now shows the command type in parenthesis after the command name (i.e., `plugin`, `alias`, or `custom`). Currently, the command type is not displayed for `built-in`, `keyword`, or known `external` commands ([#14165](https://github.com/nushell/nushell/pull/14165)).
+
+### `$env.config.table.footer_inheritance`
+
+A new option has been introduced for table rendering by [@zhiburt](https://github.com/zhiburt) in [#14070](https://github.com/nushell/nushell/pull/14070). With `$env.config.table.footer_inheritance = true`, if one of the inner rendered tables trips the footer mode setting to show a footer at the bottom of the table, all of the outer tables will also have footers rendered.
 
 ## Breaking changes [[toc](#table-of-content)]
 

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -5,6 +5,7 @@ author_site: https://twitter.com/nu_shell
 author_image: https://www.nushell.sh/blog/images/nu_logo.png
 excerpt: Today, we're releasing version 0.100.0 of Nu. This release adds...
 ---
+
 <!-- TODO: complete the excerpt above -->
 
 # Nushell 0.100.0
@@ -12,6 +13,7 @@ excerpt: Today, we're releasing version 0.100.0 of Nu. This release adds...
 Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your command line. It works seamlessly with the data from your filesystem, operating system, and a growing number of file formats to make it easy to build powerful command line pipelines.
 
 <!-- TODO: write this excerpt -->
+
 Today, we're releasing version 0.100.0 of Nu. This release adds...
 
 # Where to get it
@@ -21,6 +23,7 @@ Nu 0.100.0 is available as [pre-built binaries](https://github.com/nushell/nushe
 As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
 
 # Table of contents
+
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
 - [_Changes_](#changes-toc)
   - [_Additions_](#additions-toc)
@@ -48,6 +51,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 -->
 
 # Highlights and themes of this release [[toc](#table-of-content)]
+
 <!-- NOTE: if you wanna write a section about a breaking change, when it's a very important one,
     please add the following snippet to have a "warning" banner :)
     > see [an example](https://www.nushell.sh/blog/2023-09-19-nushell_0_85_0.html#pythonesque-operators-removal)
@@ -66,7 +70,81 @@ As part of this release, we also publish a set of optional plugins you can insta
 
 ## Additions [[toc](#table-of-content)]
 
+### `like` and `not-like` operators
+
+With [#14072](https://github.com/nushell/nushell/pull/14072), this release adds two "new" operators: `like` and `not-like`. These operators are alternative forms of the preexisting `=~` and `!~` operators, respectively. The only reason to use one form over the other is preference. For example, people familiar with SQL may prefer using `like` and `not-like`. In the future, there is a chance that the shorter forms may be removed, but there are no plans to do so yet, if at all.
+
+### `catch` error record
+
+In [#14082](https://github.com/nushell/nushell/pull/14082), two additional columns were added to the error record passed to catch blocks/closures:
+
+- `json`: a string containing the error data as JSON.
+- `rendered`: a string containing the pretty formatted error message, roughly the same as you would see in your terminal.
+
+### `help commands` and `scope commands`
+
+The `help commands` and `scope commands` now output an `is_const` column indicating whether a command can be used in a parse-time constant context ([#14125](https://github.com/nushell/nushell/pull/14125)).
+
+### `ps -l`
+
+On macOS, `ps -l` now lists the `start_time` of the processes. Windows and Linux already listed a `start_time` column ([#14127](https://github.com/nushell/nushell/pull/14127)).
+
+### `url build-query`
+
+Thanks to [@adaschma](https://github.com/adaschma) in [#14073](https://github.com/nushell/nushell/pull/14073), `url build-query` now allows list values in the parameter record. For example:
+
+```nu
+{ a: [1 2], b: 3 } | url build-query
+# a=1&a=2&b=3
+```
+
+### `stor`
+
+`stor` now supports list and table inputs thanks to [@friaes](https://github.com/friaes) in [#14175](https://github.com/nushell/nushell/pull/14175).
+
+### `to text --no-newline`
+
+In [#14158](https://github.com/nushell/nushell/pull/14158), the `--no-newline`/`-n` flag was added to `to text`. Providing this flag disables the trailing new line added to the output.
+
+```nu
+[a] | to text    # "a\n"
+[a] | to text -n # "a"
+
+[a b] | to text    # "a\nb\n"
+[a b] | to text -n # "a\nb"
+```
+
+### `open --raw`
+
+After [#14141](https://github.com/nushell/nushell/pull/14141), `open --raw` now sets the `content-type` in the pipeline metadata for `nu`, `nuon`, and `json` files.
+
+### `help`
+
+The `help` output for commands now shows the command type in parenthesis after the command name (i.e., `plugin`, `alias`, or `custom`). Currently, the command type is not displayed for `built-in`, `keyword`, or known `external` commands ([#14165](https://github.com/nushell/nushell/pull/14165)).
+
 ## Breaking changes [[toc](#table-of-content)]
+
+### Lone, leading pipe in closures
+
+Currently, a leading pipe character is allowed for pipelines in Nushell:
+
+```nu
+| ls
+```
+
+The closure syntax also uses pipe characters, so the parser previously allowed some cursed code:
+
+```nu
+{ |a $a }
+{ |a, b $a $b }
+```
+
+Thanks to [@sgvictorino](https://github.com/sgvictorino) in [#14095](https://github.com/nushell/nushell/pull/14095), unmatched leading pipe characters in closures are no longer allowed to prevent this potential ambiguity.
+
+```nu
+{ |a| $a } # ok
+{ |a $a }  # now errors
+```
 
 ## Deprecations [[toc](#table-of-content)]
 
@@ -74,32 +152,41 @@ As part of this release, we also publish a set of optional plugins you can insta
 
 ## Bug fixes and other changes [[toc](#table-of-content)]
 
-<!-- NOTE: to start investigating the contributions of last release, i like to list them all in a raw table.
-    to achieve this, one can use the [`list-merged-prs` script from `nu_scripts`](https://github.com/nushell/nu_scripts/blob/main/make_release/release-note/list-merged-prs)
-    as follows:
+### `return`
 
-    ```nushell
-    use ./make_release/release-note/list-merged-prs
-    use std clip
+In [#14120](https://github.com/nushell/nushell/pull/14120), a bug was fixed were `return`, `break`, and `continue` would set the last exit code to 1.
 
-    let last_release_date = ^gh api /repos/nushell/nushell/releases
-        | from json
-        | into datetime published_at
-        | get published_at
-        | sort
-        | last
+### `to text`
 
-    let prs = list-merged-prs nushell/nushell $last_release_date
-        | sort-by mergedAt
-        | update url {|it| $"[#($it.number)]\(($it.url)\)" }
-        | update author { $"[@($in)]\(https://github.com/($in)\)" }
-        | select author title url
-        | rename -c {url: pr}
-        | to md --pretty
+`to text` would previously have different behavior for list values and streaming list input. This has been fixed with [#14158](https://github.com/nushell/nushell/pull/14158), and the behavior for list streams is now used for list values.
 
-    $prs | to md --pretty | clip
-    ```
--->
+### `use`
+
+When importing a module that defines no constants, an empty record variable is no longer created ([#14051](https://github.com/nushell/nushell/pull/14051)).
+
+### `transpose`
+
+With [#14096](https://github.com/nushell/nushell/pull/14096), `transpose` now bubbles up any top-level errors it encounters in its input thanks to [@PhotonBursted](https://github.com/PhotonBursted).
+
+### Constants with type signatures
+
+Thanks to [@sgvictorino](https://github.com/sgvictorino) in [#14118](https://github.com/nushell/nushell/pull/14118), a compiler bug preventing imports of constants with type signatures has been fixed.
+
+### Short flag type checking
+
+Short flags for commands were previously not being typed checked. This has been fixed in [#14074](https://github.com/nushell/nushell/pull/14074) thanks to [@sgvictorino](https://github.com/sgvictorino).
+
+### `in $range`
+
+The step value for ranges was previously not taken into account when checking if a value was `in` a range. Thanks to [@JoaquinTrinanes](https://github.com/JoaquinTrinanes), this has been fixed with [#14011](https://github.com/nushell/nushell/pull/14011).
+
+### `clear`
+
+On some terminals, `clear` would behave weirdly if used in a series of commands. Thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds), this has been fixed in [#14181](https://github.com/nushell/nushell/pull/14181).
+
+### Panic fixes
+
+A parser panic regarding redirections was fixed in [#14035](https://github.com/nushell/nushell/pull/14035) thanks to [@Kither12](https://github.com/Kither12).
 
 # Notes for plugin developers [[toc](#table-of-content)]
 
@@ -107,11 +194,22 @@ As part of this release, we also publish a set of optional plugins you can insta
 
 Thanks to all the contributors below for helping us solve issues and improve documentation :pray:
 
-| author                               | title       | url                                                     |
-| ------------------------------------ | ----------- | ------------------------------------------------------- |
-| [@author](https://github.com/author) | ...         | [#12345](https://github.com/nushell/nushell/pull/12345) |
+| author                               | title | url                                                     |
+| ------------------------------------ | ----- | ------------------------------------------------------- |
+| [@author](https://github.com/author) | ...   | [#12345](https://github.com/nushell/nushell/pull/12345) |
+
+<!--
+TODO
+
+https://github.com/nushell/nushell/pull/14108
+https://github.com/nushell/nushell/pull/14128
+https://github.com/nushell/nushell/pull/14229
+https://github.com/nushell/nushell/pull/14230
+https://github.com/nushell/nushell/pull/14291
+-->
 
 # Full changelog [[toc](#table-of-content)]
+
 <!-- TODO:
     paste the output of
     ```nu

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -420,12 +420,145 @@ https://github.com/nushell/nushell/pull/14307
 https://github.com/nushell/nushell/pull/14002
 -->
 
+# All breaking changes
+
+- [#14275](https://github.com/nushell/nushell/pull/14275) Fix the order of preference for `VISUAL` and `EDITOR`
+- [#14211](https://github.com/nushell/nushell/pull/14211) Url split query
+- [#14242](https://github.com/nushell/nushell/pull/14242) No longer autoload deprecated-dirs
+- [#14255](https://github.com/nushell/nushell/pull/14255) Switch to unicase's to_folded_case
+- [#14157](https://github.com/nushell/nushell/pull/14157) Div, mod, and floor div overhaul
+- [#14246](https://github.com/nushell/nushell/pull/14246) Empty rest args match should be an empty list
+- [#14237](https://github.com/nushell/nushell/pull/14237) Change --max-time arg for http commands to use `Duration` type
+- [#14085](https://github.com/nushell/nushell/pull/14085) Make `plugin list` read state from plugin registry file as well
+
 # Full changelog [[toc](#table-of-content)]
 
-<!-- TODO:
-    paste the output of
-    ```nu
-    ./make_release/release-note/get-full-changelog
-    ```
-    here
--->
+- [hustcer](https://github.com/hustcer) created
+  - [Downgrade softprops/action-gh-release to 2.0.5](https://github.com/nushell/nushell/pull/14327)
+  - [Bump version to `0.100.0`](https://github.com/nushell/nushell/pull/14312)
+  - [Add RELEASE_QUERY_API build arg for Dockerfiles](https://github.com/nushell/nushell/pull/14209)
+  - [Update the dockerfile for alpine image](https://github.com/nushell/nushell/pull/14191)
+  - [Add milestone to a closed issue that has a merged PR fix automatically](https://github.com/nushell/nushell/pull/14131)
+  - [Add a workflow to set milestone for a merged PR automatically](https://github.com/nushell/nushell/pull/14084)
+- [sholderbach](https://github.com/sholderbach) created
+  - [Pin reedline to `0.37.0` release](https://github.com/nushell/nushell/pull/14317)
+  - [Consolidate uses of `test-case` to `rstest`](https://github.com/nushell/nushell/pull/14250)
+  - [Bump `brotli` to 6.0.0](https://github.com/nushell/nushell/pull/14161)
+  - [Make contributor image wider](https://github.com/nushell/nushell/pull/14138)
+  - [Add slice as a search term on `range`](https://github.com/nushell/nushell/pull/14128)
+  - [Bump to 0.99.2](https://github.com/nushell/nushell/pull/14136)
+- [NotTheDr01ds](https://github.com/NotTheDr01ds) created
+  - [Fix binary example and add one for text uploads](https://github.com/nushell/nushell/pull/14307)
+  - [Fix ignored `into datetime` test](https://github.com/nushell/nushell/pull/14302)
+  - [Fix multipart/form-data post example](https://github.com/nushell/nushell/pull/14291)
+  - [No longer autoload deprecated-dirs](https://github.com/nushell/nushell/pull/14242)
+  - [`ansi -l` includes previews of attributes (e.g., bold, dimmed, blink, etc.)](https://github.com/nushell/nushell/pull/14196)
+  - [ansi name for clear-scrollback code](https://github.com/nushell/nushell/pull/14184)
+  - [Send both 2J and 3J on clear](https://github.com/nushell/nushell/pull/14181)
+- [fdncred](https://github.com/fdncred) created
+  - [ignore without_timezone test for now](https://github.com/nushell/nushell/pull/14297)
+  - [update reedline to the latest commit](https://github.com/nushell/nushell/pull/14281)
+  - [allow != for polars](https://github.com/nushell/nushell/pull/14263)
+  - [update human-date-parser conversion to use local timezone](https://github.com/nushell/nushell/pull/14266)
+  - [allow oem code pages to be used to decode text](https://github.com/nushell/nushell/pull/14187)
+  - [add command_type to help](https://github.com/nushell/nushell/pull/14165)
+  - [Add metadata on `open --raw` with bytestreams](https://github.com/nushell/nushell/pull/14141)
+  - [make adding newlines with `to text` more consistent and opt-out-able](https://github.com/nushell/nushell/pull/14158)
+  - [add `name` to `$env.config.keybindings`](https://github.com/nushell/nushell/pull/14159)
+  - [update to reedline commit 9cb1128](https://github.com/nushell/nushell/pull/14146)
+  - [try and fix osc633 escaping yet again](https://github.com/nushell/nushell/pull/14140)
+  - [add `start_time` to `ps -l` on macos](https://github.com/nushell/nushell/pull/14127)
+  - [add is_const to `help commands` and `scope commands`](https://github.com/nushell/nushell/pull/14125)
+  - [add rendered and json error messages in try/catch](https://github.com/nushell/nushell/pull/14082)
+  - [allow `group-by` and `split-by` to work with other values](https://github.com/nushell/nushell/pull/14086)
+  - [add `like` and `not-like` operators as synonyms for the regex operators `=~` and `!~`](https://github.com/nushell/nushell/pull/14072)
+- [atahabaki](https://github.com/atahabaki) created
+  - [upgrade bracoxide to v0.1.4 (fixes #14290)](https://github.com/nushell/nushell/pull/14296)
+- [aionescu](https://github.com/aionescu) created
+  - [Remove unneeded clones in `select`](https://github.com/nushell/nushell/pull/14283)
+  - [Improve `CellPath` display output](https://github.com/nushell/nushell/pull/14197)
+  - [Drop `once_cell` dependency](https://github.com/nushell/nushell/pull/14198)
+  - [Show `?` for optional entries when displaying `CellPath`s](https://github.com/nushell/nushell/pull/14042)
+  - [Fix quoting in `to nuon` and refactor quoting functions](https://github.com/nushell/nushell/pull/14180)
+- [WindSoilder](https://github.com/WindSoilder) created
+  - [IR: Don't generate instructions for `def` and `export def`.](https://github.com/nushell/nushell/pull/14114)
+  - [fix $env.FILE_PWD and $env.CURRENT_FILE inside use](https://github.com/nushell/nushell/pull/14101)
+  - [don't run subcommand if it's surrounded with backtick quote](https://github.com/nushell/nushell/pull/14210)
+  - [`use` command: Don't create a variable with empty record if it doesn't define any constants](https://github.com/nushell/nushell/pull/14051)
+- [weirdan](https://github.com/weirdan) created
+  - [Fix the order of preference for `VISUAL` and `EDITOR`](https://github.com/nushell/nushell/pull/14275)
+- [Bahex](https://github.com/Bahex) created
+  - [add table params support to `url join` and `url build-query`](https://github.com/nushell/nushell/pull/14239)
+  - [Url split query](https://github.com/nushell/nushell/pull/14211)
+  - [provide a common implementation for query string conversions in `url join` and `url build-query`](https://github.com/nushell/nushell/pull/14173)
+- [sgvictorino](https://github.com/sgvictorino) created
+  - [don't include import path in args to aliased external commands](https://github.com/nushell/nushell/pull/14231)
+  - [correctly parse table literals as lists](https://github.com/nushell/nushell/pull/14226)
+  - [support binary input in `length`](https://github.com/nushell/nushell/pull/14224)
+  - [support table literal syntax in `join` right-table argument](https://github.com/nushell/nushell/pull/14190)
+  - [error when closure param lists aren't terminated by `|`](https://github.com/nushell/nushell/pull/14095)
+  - [fix error when exporting constants with type signatures in modules](https://github.com/nushell/nushell/pull/14118)
+  - [run ensure_flag_arg_type for short flag values](https://github.com/nushell/nushell/pull/14074)
+- [app/dependabot](https://github.com/app/dependabot) created
+  - [Bump crate-ci/typos from 1.26.8 to 1.27.0](https://github.com/nushell/nushell/pull/14272)
+  - [Bump notify-debouncer-full from 0.3.1 to 0.3.2](https://github.com/nushell/nushell/pull/14271)
+  - [Bump scraper from 0.20.0 to 0.21.0](https://github.com/nushell/nushell/pull/14270)
+  - [Bump softprops/action-gh-release from 2.0.8 to 2.0.9](https://github.com/nushell/nushell/pull/14273)
+  - [Bump chrono-tz from 0.8.6 to 0.10.0](https://github.com/nushell/nushell/pull/14205)
+  - [Bump trash from 5.1.1 to 5.2.0](https://github.com/nushell/nushell/pull/14206)
+  - [Bump fancy-regex from 0.13.0 to 0.14.0](https://github.com/nushell/nushell/pull/14207)
+  - [Bump unicase from 2.7.0 to 2.8.0](https://github.com/nushell/nushell/pull/14208)
+  - [Bump crate-ci/typos from 1.26.0 to 1.26.8](https://github.com/nushell/nushell/pull/14203)
+  - [Bump uuid from 1.10.0 to 1.11.0](https://github.com/nushell/nushell/pull/14155)
+  - [Bump bytes from 1.7.1 to 1.8.0](https://github.com/nushell/nushell/pull/14156)
+- [132ikl](https://github.com/132ikl) created
+  - [Switch to unicase's to_folded_case](https://github.com/nushell/nushell/pull/14255)
+  - [Add count to uniq search terms](https://github.com/nushell/nushell/pull/14108)
+- [IanManske](https://github.com/IanManske) created
+  - [Make `to text` line endings consistent for list (streams)](https://github.com/nushell/nushell/pull/14166)
+  - [Remove `as_i64` and `as_f64`](https://github.com/nushell/nushell/pull/14258)
+  - [Div, mod, and floor div overhaul](https://github.com/nushell/nushell/pull/14157)
+  - [Fix return setting last exit code](https://github.com/nushell/nushell/pull/14120)
+  - [Revert PRs for 0.99.1 patch](https://github.com/nushell/nushell/pull/14119)
+- [CharlesTaylor7](https://github.com/CharlesTaylor7) created
+  - [Empty rest args match should be an empty list](https://github.com/nushell/nushell/pull/14246)
+- [alex-kattathra-johnson](https://github.com/alex-kattathra-johnson) created
+  - [Add tests to test the `--max-age` arg in http commands](https://github.com/nushell/nushell/pull/14245)
+  - [Change --max-time arg for http commands to use `Duration` type](https://github.com/nushell/nushell/pull/14237)
+- [Dorumin](https://github.com/Dorumin) created
+  - [no deref in touch](https://github.com/nushell/nushell/pull/14214)
+- [Kissaki](https://github.com/Kissaki) created
+  - [Improve comment wording in run_external.rs](https://github.com/nushell/nushell/pull/14230)
+  - [Fix comment typos in run_external.rs](https://github.com/nushell/nushell/pull/14229)
+- [vyadh](https://github.com/vyadh) created
+  - [Tests for new Alpine and Debian image builds](https://github.com/nushell/nushell/pull/14225)
+  - [Add Debian Dockerfile](https://github.com/nushell/nushell/pull/14193)
+- [hacker-DOM](https://github.com/hacker-DOM) created
+  - [Allow using function keys F21-F35 for keybindings](https://github.com/nushell/nushell/pull/14201)
+- [blindFS](https://github.com/blindFS) created
+  - [Fix LSP non-ascii characters offset issues.](https://github.com/nushell/nushell/pull/14002)
+- [qfel](https://github.com/qfel) created
+  - [Add the history import command (again)](https://github.com/nushell/nushell/pull/14083)
+- [friaes](https://github.com/friaes) created
+  - [feat: stor insert accepts lists](https://github.com/nushell/nushell/pull/14175)
+- [ofek](https://github.com/ofek) created
+  - [Ensure default config files end with a new line](https://github.com/nushell/nushell/pull/14192)
+- [zhiburt](https://github.com/zhiburt) created
+  - [Introduce footer_inheritance option](https://github.com/nushell/nushell/pull/14070)
+- [ayax79](https://github.com/ayax79) created
+  - [Upgrade to polars 0.43](https://github.com/nushell/nushell/pull/14148)
+  - [Update to rust 1.80.1](https://github.com/nushell/nushell/pull/14106)
+  - [Implemented `polars unnest`](https://github.com/nushell/nushell/pull/14104)
+- [PhotonBursted](https://github.com/PhotonBursted) created
+  - [Defensive handling of errors when transposing](https://github.com/nushell/nushell/pull/14096)
+- [adaschma](https://github.com/adaschma) created
+  - [Feature `url build_query` accepts records with lists of strings](https://github.com/nushell/nushell/pull/14073)
+- [Kither12](https://github.com/Kither12) created
+  - [Fix panic if tokens are placed after a redirection](https://github.com/nushell/nushell/pull/14035)
+- [JoaquinTrinanes](https://github.com/JoaquinTrinanes) created
+  - [Fix range contains](https://github.com/nushell/nushell/pull/14011)
+- [YizhePKU](https://github.com/YizhePKU) created
+  - [Reduce duplicate dependencies on the `windows` crate](https://github.com/nushell/nushell/pull/14105)
+- [devyn](https://github.com/devyn) created
+  - [Make `plugin list` read state from plugin registry file as well](https://github.com/nushell/nushell/pull/14085)
+  - [Bump to version `0.99.1`](https://github.com/nushell/nushell/pull/14100)

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -3,14 +3,14 @@ title: Nushell 0.100.0
 author: The Nu Authors
 author_site: https://twitter.com/nu_shell
 author_image: https://www.nushell.sh/blog/images/nu_logo.png
-excerpt: Today, we're releasing version 0.100.0 of Nu. In addition to being a major milestone, this release adds two new operators for working with strings, improves plugin management, and includes a very large number of other minor improvements and fixes.
+excerpt: Today, we're releasing version 0.100.0 of Nu. In addition to being a major milestone, this release adds two new operators for working with strings, fixes division and modulo quirks, improves plugin management, and includes a very large number of other minor improvements and fixes.
 ---
 
 # Nushell 0.100.0
 
 Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your command line. It works seamlessly with the data from your filesystem, operating system, and a growing number of file formats to make it easy to build powerful command line pipelines.
 
-Today, we're releasing version 0.100.0 of Nu. In addition to being a major milestone, this release adds two new operators for working with strings, improves plugin management, and includes a very large number of other minor improvements and fixes.
+Today, we're releasing version 0.100.0 of Nu. In addition to being a major milestone, this release adds two new operators for working with strings, fixes division and modulo quirks, improves plugin management, and includes a very large number of other minor improvements and fixes.
 
 # Where to get it
 
@@ -23,25 +23,37 @@ As part of this release, we also publish a set of optional plugins you can insta
 - [_Highlights and themes of this release_](#highlights-and-themes-of-this-release-toc)
   - [_Cheers to a century!_](#cheers-to-a-century-toc)
   - [_`like` and `not-like` operators_](#like-and-not-like-operators-toc)
-  - [_`plugin list`_](#plugin-list-toc)
+  - [_Division, floor division, and `mod`_](#division-floor-division-and-mod-toc)
+  - [_`plugin list` improvements_](#plugin-list-improvements-toc)
 - [_Changes_](#changes-toc)
   - [_Additions_](#additions-toc)
+    - [_`history import`_](#history-import-toc)
     - [_`catch` error record_](#catch-error-record-toc)
+    - [_`url join` and `url build-query`_](#url-join-and-url-build-query-toc)
+    - [_`touch --no-deref`_](#touch-no-deref-toc)
     - [_`help commands` and `scope commands`_](#help-commands-and-scope-commands-toc)
     - [_`ps -l`_](#ps-l-toc)
-    - [_`url join` and `url build-query`_](#url-join-and-url-build-query-toc)
+    - [_`length`_](#length-toc)
     - [_`stor`_](#stor-toc)
-    - [_`to text --no-newline`_](#to-text-no-newline)
+    - [_`to text --no-newline`_](#to-text-no-newline-toc)
     - [_`open --raw`_](#open-raw-toc)
     - [_`help`_](#help-toc)
     - [_`$env.config.table.footer_inheritance`_](#env-config-table-footer-inheritance-toc)
+    - [_Function key keybindings_](#function-key-keybindings-toc)
   - [_Breaking changes_](#breaking-changes-toc)
     - [_Lone, leading pipe in closures_](#lone-leading-pipe-in-closures-toc)
+    - [_`url parse`_](#url-parse-toc)
+    - [_`http --max-time`_](#http-max-time-toc)
+    - [_Empty rest matches_](#empty-rest-matches-toc)
+    - [_Case insensitive sorting_](#case-insensitive-sorting-toc)
+    - [_`ansi clear_entire_screen_plus_buffer`_](#ansi-clear-entire-screen-plus-buffer-toc)
   - [_Deprecations_](#deprecations-toc)
     - [_AST evaluation engine_](#ast-evaluation-engine-toc)
   - [_Removals_](#removals-toc)
+    - [_`std/dirs`_](#std-dirs-toc)
   - [_Bug fixes and other changes_](#bug-fixes-and-other-changes-toc)
-    - [_`return`_](#return-toc)
+    - [_`return`, `break`, and `continue`_](#return-break-and-continue-toc)
+    - [_External command bareword arguments_](#external-command-bareword-arguments-toc)
     - [_`to text`_](#to-text-toc)
     - [_`to nuon`_](#to-nuon-toc)
     - [_`use`_](#use-toc)
@@ -50,11 +62,16 @@ As part of this release, we also publish a set of optional plugins you can insta
     - [_Short flag type checking_](#short-flag-type-checking-toc)
     - [_Cell path pretty printing_](#cell-path-pretty-printing-toc)
     - [_`in $range`_](#in-range-toc)
+    - [_`into datetime`_](#into-datetime-toc)
+    - [_`ansi -l`_](#ansi-l-toc)
+    - [_`join`_](#join-toc)
+    - [_Table literals as arguments_](#table-literals-as-arguments-toc)
     - [_`clear`_](#clear-toc)
     - [_Prefer `$env.VISUAL` over `$env.EDITOR`_](#prefer-env-visual-over-env-editor-toc)
     - [_Fix handling of exported external aliases_](#fix-handling-of-exported-external-aliases-toc)
     - [_Panic fixes_](#panic-fixes-toc)
 - [_Hall of fame_](#hall-of-fame-toc)
+- [_All breaking changes_](#all-breaking-changes-toc)
 - [_Full changelog_](#full-changelog-toc)
 <!-- TODO: please add links to the other sections here
 
@@ -96,10 +113,87 @@ We wish to express our heartfelt gratitude and congratulations to all of our con
 
 With [#14072](https://github.com/nushell/nushell/pull/14072), this release adds two "new" operators: `like` and `not-like`. These operators are alternative forms of the preexisting `=~` and `!~` operators, respectively. The only reason to use one form over the other is preference. For example, people familiar with SQL may prefer using `like` and `not-like`. In the future, there is a chance that the shorter forms may be removed, but there are no plans to do so yet, if at all.
 
-## `plugin list` [[toc](#table-of-content)]
+## Division, floor division, and `mod` [[toc](#table-of-content)]
 
 ::: warning Breaking change
-See a full overview of the [breaking changes](#breaking-changes-toc)
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
+:::
+
+In [#14157](https://github.com/nushell/nushell/pull/14157), several changes were made to the division related operators to make them more consistent.
+
+### Division
+
+First, division between two integers used to be able to return either an int or a float value even though the type signature claimed the result would always be a float.
+
+```nu
+(1 / 2 | describe) == float
+(2 / 2 | describe) == int
+```
+
+This release changes division between any two types to always return a float **except** if the left hand side is a filesize or duration and the right hand side is an int or float.
+
+```nu
+(1 / 2 | describe) == float
+(2 / 2 | describe) == float
+(1KB / 1KB | describe) == float
+(2sec / 2sec | describe) == float
+
+# There is no floating point representation for filesizes and durations,
+# so truncating division is used in this case.
+(5B / 2) == 2B
+(2sec / 2.0) == 1sec
+```
+
+### Floor division
+
+Second, floor division now does automatic float promotion. That is, if one of the operands is a float, and the other is an int or float, then the result will be a float. This matches the behavior of other operators like addition and multiplication which do float promotion as well. It also avoids potential overflows when trying to convert a large magnitude float into an int.
+
+```nu
+# Before
+(1 // 1 | describe) == int
+(1 // 1.0 | describe) == int
+(1.0 // 1.0 | describe) == int
+
+# After
+(1 // 1 | describe) == int
+(1 // 1.0 | describe) == float
+(1.0 // 1.0 | describe) == float
+```
+
+Additionally, the previous implementation of floor division performed unnecessary clamping which has been fixed with this release. So, results should now be more accurate.
+
+### `mod`
+
+In previous releases, the implementation of `mod` was based off of truncating division even though Nushell does not have a truncating division operator. This release changes `mod` to be based off of floor division so that `mod` and floor division in combination can satisfy the division rule:
+
+```nu
+let quotient = $n // $d
+let remainder = $n mod $d
+$n == $quotient * $d + $remainder
+```
+
+If the signs of the divisor and dividend are the same, then the result of `mod` will be the same as before. However, if the signs are not the same, then the result of `mod` will be different compared to before to satisfy the division rule.
+
+```nu
+# Before
+let q = 8 // -3   # -3
+let r = 8 mod -3  # 2
+8 == $q * -3 + $r # false
+
+# After
+let q = 8 // -3   # -3
+let r = 8 mod -3  # -1
+8 == $q * -3 + $r # true
+```
+
+This matches the behavior of Python's `//` and `%` operators which were the original inspiration.
+
+Otherwise, the implementation of all the division related operators has been improved to account for overflow. Rather than silently clamping or overflowing, the operators will now create an error in these cases.
+
+## `plugin list` improvements [[toc](#table-of-content)]
+
+::: warning Breaking change
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
 :::
 
 The `plugin list` command has been changed in [#14085](https://github.com/nushell/nushell/pull/14085) to consider both the plugins currently present in the engine state as well as the plugins stored in the registry file. Changes made by `plugin add` and `plugin rm` should now be more obvious.
@@ -132,10 +226,6 @@ In case you want to avoid loading the plugin registry file (e.g. for performance
 # Changes [[toc](#table-of-content)]
 
 ## Additions [[toc](#table-of-content)]
-
-### `like` and `not-like` operators [[toc](#table-of-content)]
-
-With [#14072](https://github.com/nushell/nushell/pull/14072), this release adds two "new" operators: `like` and `not-like`. These operators are alternative forms of the preexisting `=~` and `!~` operators, respectively. The only reason to use one form over the other is preference. For example, people familiar with SQL may prefer using `like` and `not-like`. In the future, there is a chance that the shorter forms may be removed, but there are no plans to do so yet, if at all.
 
 ### `history import` [[toc](#table-of-content)]
 
@@ -213,10 +303,6 @@ Thanks to [@Dorumin](https://github.com/Dorumin) in [#14214](https://github.com/
 
 The `help commands` and `scope commands` now output an `is_const` column indicating whether a command can be used in a parse-time constant context ([#14125](https://github.com/nushell/nushell/pull/14125)).
 
-### `ps -l`
-
-On macOS, `ps -l` now lists the `start_time` of the processes. Windows and Linux already listed a `start_time` column ([#14127](https://github.com/nushell/nushell/pull/14127)).
-
 ### `length`
 
 Thanks to [@sgvictorino](https://github.com/sgvictorino) in [#14224](https://github.com/nushell/nushell/pull/14224), the `length` command now supports binary values as input and returns the number of bytes.
@@ -249,89 +335,16 @@ The `help` output for commands now shows the command type in parenthesis after t
 
 A new option has been introduced for table rendering by [@zhiburt](https://github.com/zhiburt) in [#14070](https://github.com/nushell/nushell/pull/14070). With `$env.config.table.footer_inheritance = true`, if one of the inner rendered tables trips the footer mode setting to show a footer at the bottom of the table, all of the outer tables will also have footers rendered.
 
-### Function key keybindings
+### Function key keybindings [[toc](#table-of-content)]
 
 Thanks to [@hacker-DOM](https://github.com/hacker-DOM) in [#14201](https://github.com/nushell/nushell/pull/14201), the function keys from F21 to F35 are now allowed in key bindings. Note that for the keys to work, support for the kitty keyboard protocol needs to be enabled in your config (`$env.config.use_kitty_protocol`) and your terminal also needs to support the protocol.
 
 ## Breaking changes [[toc](#table-of-content)]
 
-### Division, floor division, and `mod` [[toc](#table-of-content)]
-
-In [#14157](https://github.com/nushell/nushell/pull/14157), several changes were made to the division related operators to make them more consistent.
-
-#### Division
-
-First, division between two integers used to be able to return either an int or a float value even though the type signature claimed the result would always be a float.
-
-```nu
-(1 / 2 | describe) == float
-(2 / 2 | describe) == int
-```
-
-This release changes division between any two types to always return a float **except** if the left hand side is a filesize or duration and the right hand side is an int or float.
-
-```nu
-(1 / 2 | describe) == float
-(2 / 2 | describe) == float
-(1KB / 1KB | describe) == float
-(2sec / 2sec | describe) == float
-
-# There is no floating point representation for filesizes and durations,
-# so truncating division is used in this case.
-(5B / 2) == 2B
-(2sec / 2.0) == 1sec
-```
-
-#### Floor division
-
-Second, floor division now does automatic float promotion. That is, if one of the operands is a float, and the other is an int or float, then the result will be a float. This matches the behavior of other operators like addition and multiplication which do float promotion as well. It also avoids potential overflows when trying to convert a large magnitude float into an int.
-
-```nu
-# Before
-(1 // 1 | describe) == int
-(1 // 1.0 | describe) == int
-(1.0 // 1.0 | describe) == int
-
-# After
-(1 // 1 | describe) == int
-(1 // 1.0 | describe) == float
-(1.0 // 1.0 | describe) == float
-```
-
-Additionally, the previous implementation of floor division performed unnecessary clamping which has been fixed with this release. So, results should now be more accurate.
-
-#### `mod`
-
-In previous releases, the implementation of `mod` was based off of truncating division even though Nushell does not have a truncating division operator. This release changes `mod` to be based off of floor division so that `mod` and floor division in combination can satisfy the division rule:
-
-```nu
-let quotient = $n // $d
-let remainder = $n mod $d
-$n == $quotient * $d + $remainder
-```
-
-If the signs of the divisor and dividend are the same, then the result of `mod` will be the same as before. However, if the signs are not the same, then the result of `mod` will be different compared to before to satisfy the division rule.
-
-```nu
-# Before
-let q = 8 // -3   # -3
-let r = 8 mod -3  # 2
-8 == $q * -3 + $r # false
-
-# After
-let q = 8 // -3   # -3
-let r = 8 mod -3  # -1
-8 == $q * -3 + $r # true
-```
-
-This matches the behavior of Python's `//` and `%` operators which were the original inspiration.
-
-Otherwise, the implementation of all the division related operators has been improved to account for overflow. Rather than silently clamping or overflowing, the operators will now create an error in these cases.
-
 ### Lone, leading pipe in closures [[toc](#table-of-content)]
 
 ::: warning Breaking change
-See a full overview of the [breaking changes](#breaking-changes-toc)
+See a full overview of the [breaking changes](#all-breaking-changes-toc)
 :::
 
 Currently, a leading pipe character is allowed for pipelines in Nushell:
@@ -354,44 +367,15 @@ Thanks to [@sgvictorino](https://github.com/sgvictorino) in [#14095](https://git
 { |a $a }  # now errors
 ```
 
-### `plugin list` [[toc](#table-of-content)]
-
-The `plugin list` command has been changed in [#14085](https://github.com/nushell/nushell/pull/14085) to consider both the plugins currently present in the engine state as well as the plugins stored in the registry file. Changes made by `plugin add` and `plugin rm` should now be more obvious.
-
-As part of this change, the `is_running` column has been replaced by a `status` column, which now displays many possible states a plugin can be in:
-
-- `added`: The plugin is present in the plugin registry file, but not in the engine.
-- `loaded`: The plugin is present both in the plugin registry file and in the engine, but is not running.
-- `running`: The plugin is currently running, and the `pid` column should contain its process ID.
-- `modified`: The plugin state present in the plugin registry file is different from the state in the engine.
-- `removed`: The plugin is still loaded in the engine, but is not present in the plugin registry file.
-- `invalid`: The data in the plugin registry file couldn't be deserialized, and the plugin most likely needs to be added again.
-
-`running` always has high priority as a state, so other statuses won't be visible if a plugin is currently running. This means that
-
-```nushell
-# 0.99.0
-plugin list | where is_running
-```
-
-can now always be replaced by:
-
-```nushell
-# 0.100.0
-plugin list | where status == running
-```
-
-In case you want to avoid loading the plugin registry file (e.g. for performance reasons), you can now use the `--engine` flag to do so. Similarly, the `--registry` flag will only display the contents of the registry, without comparing them against the state of the engine (but all plugins will appear as `added`). The `--plugin-config` flag is now supported to allow use of a separate plugin registry file, identically to the other `plugin` commands.
-
-### `url parse`
+### `url parse` [[toc](#table-of-content)]
 
 Thanks to [@Bahex](https://github.com/Bahex) in [#14211](https://github.com/nushell/nushell/pull/14211), the `params` field output for `url parse` is now a table with a `key` and `value` column instead of a record to match the new `url split-query` command ([see above](#url-split-query-toc)).
 
-### `http` `--max-time`
+### `http` `--max-time` [[toc](#table-of-content)]
 
 With [#14237](https://github.com/nushell/nushell/pull/14237), the `--max-time` flag for the `http` family of commands now takes a duration value instead of a integer number of seconds. Thanks to [@alex-kattathra-johnson](https://github.com/alex-kattathra-johnson) for making this change!
 
-### Empty rest matches
+### Empty rest matches [[toc](#table-of-content)]
 
 If a list rest pattern match ended up being empty, the match variable would previously be `null`. In [#14246](https://github.com/nushell/nushell/pull/14246) thanks to [@CharlesTaylor7](https://github.com/CharlesTaylor7), the match variable will instead be an empty list if no matches are found.
 
@@ -407,11 +391,11 @@ match [] {
 }
 ```
 
-### Case insensitive sorting
+### Case insensitive sorting [[toc](#table-of-content)]
 
 The method used for case insensitive comparisons and sorting has been updated/improved this release in [#14255](https://github.com/nushell/nushell/pull/14255) thanks to [@132ikl](https://github.com/132ikl). This will affect the output of `sort -i`, `uniq -i`, `get -s`, `find -i`, `str contains -i`, `str starts-with -i`, `str ends-with -i`, tab completions, and probably a few other commands (this list is not exhaustive).
 
-### `ansi clear_entire_screen_plus_buffer`
+### `ansi clear_entire_screen_plus_buffer` [[toc](#table-of-content)]
 
 In [#14184](https://github.com/nushell/nushell/pull/14184), `ansi clear_entire_screen_plus_buffer` now returns an ansi code that clears both the screen and scrollback buffer. Previously, it would only clear the scrollback buffer. In addition, a new `clear_scrollback_buffer` entry has been added to the `ansi` command. This will clear only the scrollback buffer.
 
@@ -423,23 +407,19 @@ The `NU_DISABLE_IR` environment variable as well as the AST evaluation engine it
 
 ## Removals [[toc](#table-of-content)]
 
-### `std/dirs`
+### `std/dirs` [[toc](#table-of-content)]
 
 The `std/dirs` module is no longer loaded by default on startup after [#14242](https://github.com/nushell/nushell/pull/14242). See the [previous release notes](https://www.nushell.sh/blog/2024-10-15-nushell_0_99_0.html#standard-library-std-dirs-toc) for more information.
 
 ## Bug fixes and other changes [[toc](#table-of-content)]
 
-### `return`, `break`, and `continue`
+### `return`, `break`, and `continue` [[toc](#table-of-content)]
 
 In [#14120](https://github.com/nushell/nushell/pull/14120), a bug was fixed were `return`, `break`, and `continue` would set the last exit code to 1.
 
 ### External command bareword arguments [[toc](#table-of-content)]
 
 There was a bug where "expressions" inside barewords created using backticks would be evaluated if provided as arguments to external commands. This has been fixed with [#14210](https://github.com/nushell/nushell/pull/14210).
-
-### `return` [[toc](#table-of-content)]
-
-In [#14120](https://github.com/nushell/nushell/pull/14120), a bug was fixed were `return`, `break`, and `continue` would set the last exit code to 1.
 
 ### `to text` [[toc](#table-of-content)]
 
@@ -475,19 +455,19 @@ The formatting has also been changed in [#14197](https://github.com/nushell/nush
 
 The step value for ranges was previously not taken into account when checking if a value was `in` a range. Thanks to [@JoaquinTrinanes](https://github.com/JoaquinTrinanes), this has been fixed with [#14011](https://github.com/nushell/nushell/pull/14011).
 
-### `into datetime`
+### `into datetime` [[toc](#table-of-content)]
 
 After [#14266](https://github.com/nushell/nushell/pull/14266), times are kept intact when performing conversion to the local time zone for parsed human date strings.
 
-### `ansi -l`
+### `ansi -l` [[toc](#table-of-content)]
 
 The preview column from `ansi -l` now also shows bold, dimmed, blink, and other effects thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds) in [#14196](https://github.com/nushell/nushell/pull/14196).
 
-### `join`
+### `join` [[toc](#table-of-content)]
 
 An issue where table literal arguments to `join` were not parsed correctly has been fixed in
 
-### Table literals as arguments
+### Table literals as arguments [[toc](#table-of-content)]
 
 An issue where table literals were incorrectly parsed when used as arguments to commands has been fixed in [#14190](https://github.com/nushell/nushell/pull/14190) and [#14226](https://github.com/nushell/nushell/pull/14226) thanks to [@sgvictorino](https://github.com/sgvictorino).
 
@@ -521,23 +501,23 @@ A parser panic regarding redirections was fixed in [#14035](https://github.com/n
 
 Thanks to all the contributors below for helping us solve issues and improve documentation :pray:
 
-| author                               | title | url                                                     |
-| ------------------------------------ | ----- | ------------------------------------------------------- |
-| [@author](https://github.com/author) | ...   | [#12345](https://github.com/nushell/nushell/pull/12345) |
+| author                                             | title                                                                                       | PR                                                      |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------- |
+| [@atahabaki](https://github.com/atahabaki)         | upgrade bracoxide to v0.1.4 (fixes #14290)                                                  | [#14296](https://github.com/nushell/nushell/pull/14296) |
+| [@fdncred](https://github.com/fdncred)             | allow != for polars                                                                         | [#14263](https://github.com/nushell/nushell/pull/14263) |
+| [@sgvictorino](https://github.com/sgvictorino)     | don't include import path in args to aliased external commands                              | [#14231](https://github.com/nushell/nushell/pull/14231) |
+| [@sgvictorino](https://github.com/sgvictorino)     | correctly parse table literals as lists                                                     | [#14226](https://github.com/nushell/nushell/pull/14226) |
+| [@WindSoilder](https://github.com/WindSoilder)     | fix $env.FILE_PWD and $env.CURRENT_FILE inside use                                          | [#14101](https://github.com/nushell/nushell/pull/14101) |
+| [@fdncred](https://github.com/fdncred)             | make adding newlines with `to text` more consistent and opt-out-able                        | [#14158](https://github.com/nushell/nushell/pull/14158) |
+| [@PhotonBursted](https://github.com/PhotonBursted) | Defensive handling of errors when transposing                                               | [#14096](https://github.com/nushell/nushell/pull/14096) |
+| [@sgvictorino](https://github.com/sgvictorino)     | error when closure param lists aren't terminated by `                                       | `                                                       | [#14095](https://github.com/nushell/nushell/pull/14095) |
+| [@sgvictorino](https://github.com/sgvictorino)     | fix error when exporting constants with type signatures in modules                          | [#14118](https://github.com/nushell/nushell/pull/14118) |
+| [@fdncred](https://github.com/fdncred)             | try and fix osc633 escaping yet again                                                       | [#14140](https://github.com/nushell/nushell/pull/14140) |
+| [@IanManske](https://github.com/IanManske)         | Fix return setting last exit code                                                           | [#14120](https://github.com/nushell/nushell/pull/14120) |
+| [@WindSoilder](https://github.com/WindSoilder)     | `use` command: Don't create a variable with empty record if it doesn't define any constants | [#14051](https://github.com/nushell/nushell/pull/14051) |
+| [@sgvictorino](https://github.com/sgvictorino)     | run ensure_flag_arg_type for short flag values                                              | [#14074](https://github.com/nushell/nushell/pull/14074) |
 
-<!--
-TODO
-
-https://github.com/nushell/nushell/pull/14108
-https://github.com/nushell/nushell/pull/14128
-https://github.com/nushell/nushell/pull/14229
-https://github.com/nushell/nushell/pull/14230
-https://github.com/nushell/nushell/pull/14291
-https://github.com/nushell/nushell/pull/14307
-https://github.com/nushell/nushell/pull/14002
--->
-
-# All breaking changes
+# All breaking changes [[toc](#table-of-content)]
 
 - [#14275](https://github.com/nushell/nushell/pull/14275) Fix the order of preference for `VISUAL` and `EDITOR`
 - [#14211](https://github.com/nushell/nushell/pull/14211) Url split query

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -32,7 +32,7 @@ As part of this release, we also publish a set of optional plugins you can insta
     - [_`catch` error record_](#catch-error-record-toc)
     - [_`help commands` and `scope commands`_](#help-commands-and-scope-commands-toc)
     - [_`ps -l`_](#ps-l-toc)
-    - [_`url build-query`_](#url-build-query-toc)
+    - [_`url join` and `url build-query`_](#url-join-and-url-build-query-toc)
     - [_`stor`_](#stor-toc)
     - [_`to text --no-newline`_](#to-text-no-newline)
     - [_`open --raw`_](#open-raw-toc)
@@ -55,6 +55,8 @@ As part of this release, we also publish a set of optional plugins you can insta
     - [_Cell path pretty printing_](#cell-path-pretty-printing-toc)
     - [_`in $range`_](#in-range-toc)
     - [_`clear`_](#clear-toc)
+    - [_Prefer `$env.VISUAL` over `$env.EDITOR`_](#prefer-env-visual-over-env-editor-toc)
+    - [_Fix handling of exported external aliases_](#fix-handling-of-exported-external-aliases-toc)
     - [_Panic fixes_](#panic-fixes-toc)
 - [_Hall of fame_](#hall-of-fame-toc)
 - [_Full changelog_](#full-changelog-toc)
@@ -138,13 +140,36 @@ The `help commands` and `scope commands` now output an `is_const` column indicat
 
 On macOS, `ps -l` now lists the `start_time` of the processes. Windows and Linux already listed a `start_time` column ([#14127](https://github.com/nushell/nushell/pull/14127)).
 
-### `url build-query` [[toc](#table-of-content)]
+### `url join` and `url build-query` [[toc](#table-of-content)]
 
 Thanks to [@adaschma](https://github.com/adaschma) in [#14073](https://github.com/nushell/nushell/pull/14073), `url build-query` now allows list values in the parameter record. For example:
 
 ```nu
 { a: [1 2], b: 3 } | url build-query
 # a=1&a=2&b=3
+```
+
+Also, thanks to [@Bahex](https://github.com/Bahex) in [#14239](https://github.com/nushell/nushell/pull/14239), `url join` and `url build-query` now support table values for `params`:
+
+```nushell
+{
+    "scheme": "http",
+    "username": "usr",
+    "password": "pwd",
+    "host": "localhost",
+    "params": [
+        ["key", "value"];
+        ["par_1", "aaa"],
+        ["par_2", "bbb"],
+        ["par_1", "ccc"],
+        ["par_2", "ddd"],
+    ],
+    "port": "1234",
+} | url join
+```
+
+```
+http://usr:pwd@localhost:1234?par_1=aaa&par_2=bbb&par_1=ccc&par_2=ddd
 ```
 
 ### `touch --no-deref` [[toc](#table-of-content)]
@@ -430,6 +455,24 @@ An issue where table literals were incorrectly parsed when used as arguments to 
 ### `clear` [[toc](#table-of-content)]
 
 On some terminals, `clear` would behave weirdly if used in a series of commands. Thanks to [@NotTheDr01ds](https://github.com/NotTheDr01ds), this has been fixed in [#14181](https://github.com/nushell/nushell/pull/14181).
+
+### Prefer `$env.VISUAL` over `$env.EDITOR` [[toc](#table-of-content)]
+
+[@weirdan](https://github.com/weirdan) fixed our preference of environment variable to find an editor to be more like other Unix commands in [#14275](https://github.com/nushell/nushell/pull/14275). We now prefer to use `VISUAL` first, if it's set.
+
+### Fix handling of exported external aliases [[toc](#table-of-content)]
+
+In [#14231](https://github.com/nushell/nushell/pull/14231), [@sgvictorino](https://github.com/sgvictorino) fixed the way aliases to external commands are handled when exported from modules. Previously, they would mistakenly be passed arguments corresponding to the module path.
+
+```nushell
+> module foo { export alias bar = ^echo }
+> use foo
+> foo bar baz
+# 0.99.0:
+bar baz
+# 0.100.0:
+baz
+```
 
 ### Panic fixes [[toc](#table-of-content)]
 

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -200,6 +200,10 @@ In [#14120](https://github.com/nushell/nushell/pull/14120), a bug was fixed were
 
 `to text` would previously have different behavior for list values and streaming list input. This has been fixed with [#14158](https://github.com/nushell/nushell/pull/14158), and the behavior for list streams is now used for list values.
 
+### `to nuon`
+
+`to nuon` previously did not escape column names containing quotes. This has been fixed by [@aionescu](https://github.com/aionescu) in [#14180](https://github.com/nushell/nushell/pull/14180).
+
 ### `use`
 
 When importing a module that defines no constants, an empty record variable is no longer created ([#14051](https://github.com/nushell/nushell/pull/14051)).
@@ -215,6 +219,12 @@ Thanks to [@sgvictorino](https://github.com/sgvictorino) in [#14118](https://git
 ### Short flag type checking
 
 Short flags for commands were previously not being typed checked. This has been fixed in [#14074](https://github.com/nushell/nushell/pull/14074) thanks to [@sgvictorino](https://github.com/sgvictorino).
+
+### Cell path pretty printing
+
+The pretty printing for optional cell paths has been fixed by [@aionescu](https://github.com/aionescu) in [#14042](https://github.com/nushell/nushell/pull/14042) to show a `?` after each optional path component. This is particularly helpful for the `view ir` command. Thanks!
+
+The formatting has also been changed in [#14197](https://github.com/nushell/nushell/pull/14197) to start with `$`, reflecting the literal syntax. This means that the cell path literal `$.foo.bar` will now be printed as `$.foo.bar` instead of `foo.bar`.
 
 ### `in $range`
 

--- a/blog/2024-11-12-nushell_0_100_0.md
+++ b/blog/2024-11-12-nushell_0_100_0.md
@@ -28,6 +28,7 @@ As part of this release, we also publish a set of optional plugins you can insta
 - [_Changes_](#changes-toc)
   - [_Additions_](#additions-toc)
   - [_Breaking changes_](#breaking-changes-toc)
+    - [_`plugin list`_](#plugin-list-toc)
   - [_Deprecations_](#deprecations-toc)
   - [_Removals_](#removals-toc)
   - [_Bug fixes and other changes_](#bug-fixes-and-other-changes-toc)
@@ -145,6 +146,35 @@ Thanks to [@sgvictorino](https://github.com/sgvictorino) in [#14095](https://git
 { |a| $a } # ok
 { |a $a }  # now errors
 ```
+
+### `plugin list` [[toc](#table-of-content)]
+
+The `plugin list` command has been changed in [#14085](https://github.com/nushell/nushell/pull/14085) to consider both the plugins currently present in the engine state as well as the plugins stored in the registry file. Changes made by `plugin add` and `plugin rm` should now be more obvious.
+
+As part of this change, the `is_running` column has been replaced by a `status` column, which now displays many possible states a plugin can be in:
+
+- `added`: The plugin is present in the plugin registry file, but not in the engine.
+- `loaded`: The plugin is present both in the plugin registry file and in the engine, but is not running.
+- `running`: The plugin is currently running, and the `pid` column should contain its process ID.
+- `modified`: The plugin state present in the plugin registry file is different from the state in the engine.
+- `removed`: The plugin is still loaded in the engine, but is not present in the plugin registry file.
+- `invalid`: The data in the plugin registry file couldn't be deserialized, and the plugin most likely needs to be added again.
+
+`running` always has high priority as a state, so other statuses won't be visible if a plugin is currently running. This means that
+
+```nushell
+# 0.99.0
+plugin list | where is_running
+```
+
+can now always be replaced by:
+
+```nushell
+# 0.100.0
+plugin list | where status == running
+```
+
+In case you want to avoid loading the plugin registry file (e.g. for performance reasons), you can now use the `--engine` flag to do so. Similarly, the `--registry` flag will only display the contents of the registry, without comparing them against the state of the engine (but all plugins will appear as `added`). The `--plugin-config` flag is now supported to allow use of a separate plugin registry file, identically to the other `plugin` commands.
 
 ## Deprecations [[toc](#table-of-content)]
 


### PR DESCRIPTION
Please add your new features and breaking changes to the release notes
by opening PRs against the `release-notes-0.100.0` branch.

## TODO
- [x] look at interesting contributions
- [x] write all the sections
  - [x] special note for version 0.100.0!
  - [x] switching to a 6-week long release cycle. Next release is on Christmas (Dec 24)!
- [x] order the sections by interest
- [x] add the breaking changes
- [x] detail the breaking changes
- [x] add the full changelog
- [x] complete all the `TODO`s inside the release note
- [x] ... (PRs that need to land before the release, e.g. [deprecations](https://github.com/nushell/nushell/labels/deprecation) or [removals](https://github.com/nushell/nushell/pulls?q=is%3Apr+is%3Aopen+label%3Aremoval-after-deprecation))