### PR TITLE
Fix code-block line numbering

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -172,6 +172,11 @@ export default defineUserConfig({
         sidebar: sidebarZhCN,
       },
     },
+    themePlugins: {
+      prismjs: {
+        lineNumbers: 10,
+      },
+    },
   }),
   plugins: [
     gitPlugin(),
@@ -186,7 +191,7 @@ export default defineUserConfig({
     }),
     shikiPlugin({
       theme: 'dark-plus',
-      lineNumbers: true,
+      lineNumbers: 10,
       langs: [
         'nushell',
         'rust',


### PR DESCRIPTION
Fixes #1573 on my local system (as well as my test VuePress repo).  Had to look at the VuePress Ecosystem doc repo to see what they were doing.  Turns out we need both PrismJS line-numbering config in addition to Shiki config.

I've set both to start numbering code-blocks when they have 10 or more lines.  This seems to work fairly well.