### PR TITLE
Update direnv.md - use ENV_CONVERSIONS

### DIFF
--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -22,7 +22,9 @@ $env.config = {
       }
 
       direnv export json | from json | default {} | load-env
-      $env.PATH = do $env.ENV_CONVERSIONS.PATH.from_string $env.PATH
+      if 'ENV_CONVERSIONS' in ($env | columns) and 'PATH' in ($env.ENV_CONVERSIONS | columns) {
+        $env.PATH = do $env.ENV_CONVERSIONS.PATH.from_string $env.PATH
+      }
     }]
   }
 }

--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -22,6 +22,7 @@ $env.config = {
       }
 
       direnv export json | from json | default {} | load-env
+      $env.PATH = do $env.ENV_CONVERSIONS.PATH.from_string $env.PATH
     }]
   }
 }

--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -22,7 +22,7 @@ $env.config = {
       }
 
       direnv export json | from json | default {} | load-env
-      if 'ENV_CONVERSIONS' in ($env | columns) and 'PATH' in ($env.ENV_CONVERSIONS | columns) {
+      if 'ENV_CONVERSIONS' in $env and 'PATH' in $env.ENV_CONVERSIONS {
         $env.PATH = do $env.ENV_CONVERSIONS.PATH.from_string $env.PATH
       }
     }]


### PR DESCRIPTION
This PR updates the nushell cookbook's direnv integration recommendation so that `$env.PATH` will be stored as a nushell list rather than as a colon-separated string.

Before this change, my `$env.PATH` looks like this:
```
> $env.PATH
/Users/jasha/bin:/Users/jasha/.cargo/bin:/Users/jasha/.local/bin:/Users/jasha/.nvm/versions/node/v18.19.0/bin:/Users/jasha/.pyenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Applications/iTerm.app/Contents/Resources/utilities
```

After the change, `$env.PATH looks like this:
```
> $env.PATH
╭────┬───────────────────────────────────────────────────────────────────────────────────╮
│  0 │ /Users/jasha/bin                                                                  │
│  1 │ /Users/jasha/.cargo/bin                                                           │
│  2 │ /Users/jasha/.local/bin                                                           │
│  3 │ /Users/jasha/.nvm/versions/node/v18.19.0/bin                                      │
│  4 │ /Users/jasha/.pyenv/shims                                                         │
│  5 │ /opt/homebrew/bin                                                                 │
│  6 │ /opt/homebrew/sbin                                                                │
│  7 │ /bin                                                                              │
│  8 │ /sbin                                                                             │
│  9 │ /usr/bin                                                                          │
│ 10 │ /usr/sbin                                                                         │
│ 11 │ /usr/local/bin                                                                    │
│ 12 │ /System/Cryptexes/App/usr/bin                                                     │
│ 13 │ /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin         │
│ 14 │ /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin               │
│ 15 │ /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin │
│ 16 │ /Applications/iTerm.app/Contents/Resources/utilities                              │
╰────┴───────────────────────────────────────────────────────────────────────────────────╯
```

I have verified that the direnv integration still works as expected, with `$env.PATH` being modified when I `cd` into or out of a direnv-managed directory.