### PR TITLE
Be more specific about std/log use in modules

### DIFF
--- a/book/modules/creating_modules.md
+++ b/book/modules/creating_modules.md
@@ -346,6 +346,10 @@ Running this command changes the directory _locally_ in the module, but the chan
 
 ### `export-env` runs only when the `use` call is _evaluated_
 
+::: note
+This scenario is commonly encountered when creating a module that uses `std/log`.
+:::
+
 Attempting to import a module's environment within another environment may not work as expected. Let's create a new module `go.nu` that creates "shortcuts" to common directories. One of these will be the `$env.NU_MODULES_DIR` defined above in `my-utils`.
 
 We might try:

--- a/book/standard_library.md
+++ b/book/standard_library.md
@@ -146,6 +146,13 @@ nu -n -c "$nu.startup-time"
 
 You will not be able to import the library, any of its submodules, nor use any of its commands, when it is disabled in this way.
 
+## Using `std/log` in Modules
+
+::: warning Important!
+`std/log` exports environment variables. To use the `std/log` module in your own module, please see [this caveat](./modules/creating_modules.md#export-env-runs-only-when-the-use-call-is-evaluated) in the "Creating Modules" Chapter.
+
+:::
+
 ## Optimal Startup
 
 If Nushell's startup time is important to your workflow, review your [startup configuration]([./configuration.md]) in `config.nu`, `env.nu`, and potentially others for inefficient use of the standard library. The following command should identify any problem areas:


### PR DESCRIPTION
Importing `std/log` into another module requires some special-care due to its environment variables. Previously, this caveat was discussed as a more general use-case, but `std/log` is so common that it should be explicitly documented.