### PR TITLE
Update and simplify Escaping to the System Windows Note

### DIFF
--- a/book/escaping.md
+++ b/book/escaping.md
@@ -16,4 +16,6 @@ Escape to external command:
 
 ## Windows Note
 
-When running an external command on Windows, nushell [used to](https://www.nushell.sh/blog/2022-08-16-nushell-0_67.html#windows-cmd-exe-changes-rgwood) use [Cmd.exe](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd) to run the command, as a number of common commands on Windows are actually shell builtins and not available as separate executables. [Coming from CMD.EXE](coming_from_cmd.md) contains a list of these commands and how to map them to nushell native concepts.
+When running an external command on Windows,
+Nushell forwards some CMD.EXE internal commands to cmd instead of attempting to run external commands.
+[Coming from CMD.EXE](coming_from_cmd.md) contains a list of these commands and describes the behavior in more detail.


### PR DESCRIPTION
The history note (historic behavior, in the past) is very old. It has little value in the current docs.

The "shell built-ins" wording and description may not be obvious to readers.

The Coming from CMD.EXE documents the internal command forwarding as well as other relations between the two shells. Here, in 'Escaping the System', we should focus on the aspect of escaping to the system, only give a general description and note, and reference to the more definitive and exhaustive documentation.