### PR TITLE
Fix absolute path example item text

### DIFF
--- a/book/modules/using_modules.md
+++ b/book/modules/using_modules.md
@@ -42,7 +42,7 @@ The module's documentation will usually tell you the recommended way to import i
 
 The path to the module can be:
 
-- An absolute or relative path to a directory containing a `mod.nu` file:
+- An absolute path to a directory containing a `mod.nu` file:
 
   ::: details Example
 


### PR DESCRIPTION
The relative example follows afterwards. This block only contains docs on absolute paths.

Split from #1608 so the fix can be merged without further discussion. The other splittable fixup 9eea190c86573d0354ae169bdb9b82bc436f7bb4 has apparently been resolved through another PR #1620.