### PR TITLE
Add `--locked` flag to Cargo install

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -107,7 +107,7 @@ Using [Homebrew](https://brew.sh/), you will need to install "openssl" and "cmak
 Nushell releases are published as source to the popular Rust package registry [crates.io](https://crates.io/). This makes it easy to build and install the latest Nu release with `cargo`:
 
 ```nu
-cargo install nu
+cargo install nu --locked
 ```
 
 The `cargo` tool will do the work of downloading Nu and its source dependencies, building it, and installing it into the cargo bin path.

--- a/book/plugins.md
+++ b/book/plugins.md
@@ -27,7 +27,7 @@ Nushell also ships with several plugins that serve as examples or tools for plug
 Core plugins are typically distributed with the Nushell release and should already be installed in the same directory as the Nushell executable. If this is the case on your system, core plugins should be using correct `nu-plugin` protocol version. If your package management system installs them separately, please make sure to update the core plugins whenever Nushell itself is updated.
 
 ::: tip Installing using Cargo
-For example, when installing or upgrading Nushell directly from crates.io using `cargo install nu`, the corresponding core plugins for that version may also be installed or updated using `cargo install nu_plugin_<plugin_name>`.
+For example, when installing or upgrading Nushell directly from crates.io using `cargo install nu --locked`, the corresponding core plugins for that version may also be installed or updated using `cargo install nu_plugin_<plugin_name> --locked`.
 
 To install all of the default plugins, from within Nushell run:
 
@@ -37,7 +37,7 @@ To install all of the default plugins, from within Nushell run:
   nu_plugin_gstat
   nu_plugin_formats
   nu_plugin_query
-] | each { cargo install $in } | ignore
+] | each { cargo install $in --locked } | ignore
 ```
 
 :::
@@ -54,13 +54,13 @@ To install a third-party plugin on your system, you first need to make sure the 
 To install a plugin by name from crates.io, run:
 
 ```nu
-cargo install nu_plugin_<plugin_name>
+cargo install nu_plugin_<plugin_name> --locked
 ```
 
 When installing from a repository (e.g., GitHub), run the following from inside the cloned repository:
 
 ```nu
-cargo install --path .
+cargo install --path . --locked
 ```
 
 This will create a binary file that can be used to add the plugin.

--- a/contributor-book/plugins.md
+++ b/contributor-book/plugins.md
@@ -254,7 +254,7 @@ Here we import everything we need -- types and functions -- to be able to create
 Once we have finished our plugin, to use it all we need to do is install it.
 
 ```nu
-> cargo install --path .
+> cargo install --path . --locked
 # nushell only (run with `nu -c` if not in nushell)
 > plugin add ~/.cargo/bin/nu_plugin_len # add .exe on Windows
 ```

--- a/es/book/instalacion.md
+++ b/es/book/instalacion.md
@@ -113,7 +113,7 @@ brew install openssl cmake
 Una vez instaladas las depependencias que Nu necesita, podemos instalarla usando el comando `cargo` que viene con el compilador Rust.
 
 ```
-> cargo install nu
+> cargo install nu --locked
 ```
 
 ¡Eso es todo! Cargo hará el trabajo de descarga Nu junto con sus dependencias, construirla e instalarla en el bin path de cargo para que podamos arrancarlo.
@@ -121,7 +121,7 @@ Una vez instaladas las depependencias que Nu necesita, podemos instalarla usando
 Si deseas instalar con más funcionalidades, puedes hacer:
 
 ```
-> cargo install nu --features=stable
+> cargo install nu --locked --features=stable
 ```
 
 Para todas las funcionalidades disponibles, la manera más fácil es descargar la fuente de Nu y construírlo usted mismo usando las herramientas de Rust:
@@ -129,7 +129,7 @@ Para todas las funcionalidades disponibles, la manera más fácil es descargar l
 ```
 > git clone https://github.com/nushell/nushell.git
 > cd nushell
-nushell> cargo install --path . --force --features=stable
+nushell> cargo install --path . --locked --force --features=stable
 
 Para que esto funcione, asegúrate de tener todas las dependencias instaladas (que se muestran arriba) en el sistema.
 

--- a/pt-BR/README.md
+++ b/pt-BR/README.md
@@ -24,7 +24,7 @@ Instale a última versão a partir da [página de _releases_](https://github.com
 Alternativamente, você pode instalar a partir do código fonte com o [crates.io](https://crates.io):
 
 ```sh
-$ cargo install nu
+$ cargo install nu --locked
 ```
 
 #### Instale com Gerenciador de Pacotes

--- a/pt-BR/book/instalacao.md
+++ b/pt-BR/book/instalacao.md
@@ -95,7 +95,7 @@ brew install openssl cmake
 Quando tivermos todas as dependências de que o Nu precisa, podemos instalá-lo usando o comando `cargo`, que vem junto com o compilador Rust.
 
 ```nu
-> cargo install nu
+> cargo install nu --locked
 ```
 
 Pronto! A ferramenta cargo fará o download do Nu e das dependências do fonte, o build e a instalação no caminho bin do cargo, de forma que possamos rodá-lo.
@@ -103,7 +103,7 @@ Pronto! A ferramenta cargo fará o download do Nu e das dependências do fonte, 
 Se quiser instalar todas as funcionalidades, inclusive algumas opcionais divertidas, você pode usar:
 
 ```nu
-> cargo install nu --features=stable
+> cargo install nu --locked --features=stable
 ```
 
 Para esse comando funcionar, certifique-se de ter todas as dependências (mostradas acima) instaladas no seu sistema.

--- a/snippets/installation/build_nu_yourself.sh
+++ b/snippets/installation/build_nu_yourself.sh
@@ -1,3 +1,3 @@
 > git clone https://github.com/nushell/nushell.git
 > cd nushell
-nushell> cargo install --path .
+nushell> cargo install --path . --locked

--- a/snippets/installation/cargo_install_nu.sh
+++ b/snippets/installation/cargo_install_nu.sh
@@ -1,1 +1,1 @@
-> cargo install nu
+> cargo install nu --locked


### PR DESCRIPTION
Using the `--locked` flag prevents installation failures when dependencies have broken updates.

All references are replaced. Closes #1641.

An accompanying PR will be opened for nushell/nushell.