### PR TITLE
Drop experimental label from display_output hook

### DIFF
--- a/book/hooks.md
+++ b/book/hooks.md
@@ -8,8 +8,8 @@ Currently, we support these types of hooks:
 - `pre_prompt` : Triggered before the prompt is drawn
 - `pre_execution` : Triggered before the line input starts executing
 - `env_change` : Triggered when an environment variable changes
-- `display_output` : A block that the output is passed to (experimental).
-- `command_not_found` : Triggered when a command is not found.
+- `display_output` : A block that the output is passed to
+- `command_not_found` : Triggered when a command is not found
 
 To make it clearer, we can break down Nushell's execution cycle.
 The steps to evaluate one line in the REPL mode are as follows:


### PR DESCRIPTION
The hook was introduced two years ago and has been stable since. In #14361 there is a discussion about the hook's behavior but no indication that it could be dropped.

Dropping the experimental label makes it more obvious that the hook is here to stay. If its behavior changes, it can be documented like usual in release breaking change notes which would make sense anyway.

As a drive-by text form fixup, drop the period from the last two list items. None of the other list items end in a period, which matches the common English form for [simple] lists.