### PR TITLE
plugins.md - fix typo in python example code

### DIFF
--- a/contributor-book/plugins.md
+++ b/contributor-book/plugins.md
@@ -1112,7 +1112,7 @@ if __name__ == "__main__":
             break
         elif "Call" in input:
             [id, call] = input["Call"]
-            if plugin_call == "Metadata":
+            if call == "Metadata":
                 send_response(id, {
                     "Metadata": {
                         "version": "0.1.0",
@@ -1145,7 +1145,7 @@ if __name__ == "__main__":
             break
         elif "Call" in input:
             [id, call] = input["Call"]
-            if plugin_call == "Metadata":
+            if call == "Metadata":
                 send_response(id, {
                     "Metadata": {
                         "version": "0.1.0",


### PR DESCRIPTION
This PR fixes a typo in the python plugin example (occurs twice) that prevents the code from working if a reader tries to run the code as given.
