### PR TITLE
Update the Fish completer to leverage nushell/nushell#14399

### DIFF
--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -21,15 +21,15 @@ This completer will use [the fish shell](https://fishshell.com/) to handle compl
 ```nu
 let fish_completer = {|spans|
     fish --command $'complete "--do-complete=($spans | str join " ")"'
-    | $"value(char tab)description(char newline)" + $in
-    | from tsv --flexible --no-infer
+    | from tsv --flexible --noheaders --no-infer
+    | rename value description
 }
 ```
 
 A couple of things to note on this command:
 
 - The fish completer will return lines of text, each one holding the `value` and `description` separated by a tab. The `description` can be missing, and in that case there won't be a tab after the `value`. If that happens, `from tsv` will fail, so we add the `--flexible` flag.
-- `$"value(char tab)description(char newline)" + $in` exists to fix another edge case. Even with the `--flexible` flag, if the first line of the input doesn't have a second column the parser will skip that column for **all** the input. This is fixed adding a header to the input before-hand.
+- The output of the fish completer does not contain a header (name of the columns), so we add `--noheaders` to prevent `from tsv` from treating the first row as headers and later give the columns their names using `rename`.
 - `--no-infer` is optional. `from tsv` will infer the data type of the result, so a numeric value like some git hashes will be inferred as a number. `--no-infer` will keep everything as a string. It doesn't make a difference in practice but it will print a more consistent output if the completer is ran on it's own.
 
 ### Zoxide completer


### PR DESCRIPTION
- nushell/nushell#14398
- nushell/nushell#14399

We no longer need to prepend the header row to make sure about the number of columns.
Updated the fish completer to a more clean & performant version.
Also updated the descriptions below accordingly.