### PR TITLE
types at a glance: the block should have a semicolon instead of a comma

### DIFF
--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -31,7 +31,7 @@ int
 | [Tables](#tables)                     | `[{x:12, y:15}, {x:8, y:9}]`, `[[x, y]; [12, 15], [8, 9]]`            |
 | [Closures](#closures)                 | `{\|e\| $e + 1 \| into string }`, `{ $in.name.0 \| path exists }`     |
 | [Cell-paths](#cell-paths)             | `$.name.0`                                                            |
-| [Blocks](#blocks)                     | `if true { print "hello!" }`, `loop { print "press ctrl-c to exit" }` |
+| [Blocks](#blocks)                     | `if true { print "hello!" }`; `loop { print "press ctrl-c to exit" }` |
 | [Null (Nothing)](#nothing-null)       | `null`                                                                |
 | [Any](#any)                           | `let p: any = 5`                                                      |
 


### PR DESCRIPTION

I was going through the examples and noticed that this one appears to be syntactically not correct

```rust
if true { print "hello!" }, loop { print "press ctrl-c to exit" }
```

it should be a semi-colon instead of a comma

```rust
if true { print "hello!" }; loop { print "press ctrl-c to exit" }
```

Also when I fire up this example in the repl 
the comma does not complete
whereas the semi-colon does