### PR TITLE
Add `cd` to title of Changing Directories in a Custom Command section for searchability

### DIFF
--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -899,7 +899,7 @@ $env.FOO
 # => After
 ```
 
-### Changing Directories in a Custom Command
+### Changing Directories (cd) in a Custom Command
 
 Likewise, changing the directory using the `cd` command results in a change of the `$env.PWD` environment variable. This means that directory changes (the `$env.PWD` variable) will also be reset when a custom command ends. The solution, as above, is to use `def --env` or `export def --env`.
 


### PR DESCRIPTION
A good number of people seem to get caught up on needing to use `def --env` for custom commands with `cd`. There is already a note in the help page for `cd` about this, but it would help if the dedicated section on this topic came up with you searched `cd` also. It seems most people don't think to type "changing directories" causing them to miss this section. This is a bit of a hack, ideally we would change something in the Docsearch/Algolia config to add some sort of an "alias" but I'm not sure if that's possible so this should be a sufficient workaround for now.