### PR TITLE
Removed duplicate 'get' in list.md

### DIFF
--- a/lang-guide/chapters/types/basic_types/list.md
+++ b/lang-guide/chapters/types/basic_types/list.md
@@ -65,7 +65,6 @@ there are too many commands to list here. Here are a few:
 - `all`
 - `get`
 - `select`
-- `get`
 - `each`, `par-each`, `filter`, `reduce`
 - `skip`, `skip until`, `skip while`, `take`, `take until`, `take while`
 - `first`, `last`, `length`


### PR DESCRIPTION
'get' was listed twice as a command that can be used with lists