### PR TITLE
Update creating_errors.md to use $span variable directly in example

### DIFF
--- a/book/creating_errors.md
+++ b/book/creating_errors.md
@@ -28,7 +28,7 @@ def my-command [x] {
         msg: "this is fishy",
         label: {
             text: "fish right here",
-            span: (metadata $x).span
+            span: $span
         }
     }
 }


### PR DESCRIPTION
Use `$span` variable in `my-command` function definition from code example.