### PR TITLE
internal nushell commands use structured data

### DIFF
--- a/book/stdout_stderr_exit_codes.md
+++ b/book/stdout_stderr_exit_codes.md
@@ -121,7 +121,7 @@ Unlike file redirections, pipe redirections do not apply to all commands inside 
 
 ## Raw Streams
 
-Both stdout and stderr are represented as "raw streams" inside of Nushell. These are streams of bytes rather than structured data, which are what internal Nushell commands use.
+Both stdout and stderr are represented as "raw streams" inside of Nushell. These are streams of bytes rather than the structured data used by internal Nushell commands.
 
 Because streams of bytes can be difficult to work with, especially given how common it is to use output as if it was text data, Nushell attempts to convert raw streams into text data. This allows other commands to pull on the output of external commands and receive strings they can further process.
 


### PR DESCRIPTION
The "which" in the original sentence sounds like it is referring to the raw bytes.