### PR TITLE
Try to get the command doc comment bot working

### DIFF
--- a/.github/workflows/command-block.yml
+++ b/.github/workflows/command-block.yml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
     paths:
       - 'commands/docs/**'
+      - 'commands/categories/**'
 
 jobs:
   comment:

--- a/.github/workflows/command-block.yml
+++ b/.github/workflows/command-block.yml
@@ -1,6 +1,8 @@
 name: Comment on manual command changes
 on:
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
     paths:
       - 'commands/docs/**'
 

--- a/.github/workflows/command-block.yml
+++ b/.github/workflows/command-block.yml
@@ -1,8 +1,6 @@
 name: Comment on manual command changes
 on:
   pull_request_target:
-    types:
-      - opened
     paths:
       - 'commands/docs/**'
 

--- a/commands/docs/ansi.md
+++ b/commands/docs/ansi.md
@@ -12,6 +12,7 @@ usage: |
 
 # `ansi` for [platform](/commands/categories/platform.md)
 
+JUST MESSING
 <div class='command-title'>Output ANSI codes to change color and style of text.</div>
 
 ## Signature


### PR DESCRIPTION
Trying to use the `pull_request_target` triggeer instead, as that has
apparently different permissions according to:
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
