### PR TITLE
Disable PrismJS

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -103,11 +103,15 @@ export default defineUserConfig({
       handleImportPath: (str) =>
         str.replace(/^@snippets/, path.resolve(__dirname, '../snippets')),
     },
+    highlighter: 'shiki',
   },
   // without this, we attempt to prefetch the whole site 😬
   shouldPrefetch: false,
   colorMode: 'auto',
   theme: defaultTheme({
+    markdown: {
+      highlighter: 'shiki',
+    },
     repo: 'nushell/nushell',
     repoLabel: 'GitHub',
     editLinks: true,
@@ -173,9 +177,7 @@ export default defineUserConfig({
       },
     },
     themePlugins: {
-      prismjs: {
-        lineNumbers: 10,
-      },
+      prismjs: false,
     },
   }),
   plugins: [
@@ -190,9 +192,10 @@ export default defineUserConfig({
       },
     }),
     shikiPlugin({
-      theme: 'dark-plus',
+      theme: 'vitesse-dark',
       lineNumbers: 10,
       langs: [
+        'csv',
         'nushell',
         'rust',
         'bash',


### PR DESCRIPTION
* Disables the PrismJS highlighter entirely (I hope), setting Shiki as the highlighter for both VuePress and the theme.

* CSV was apparently getting parsed through Prism previously, so this also adds the `csv` language to the Shiki config

* And this changes the Shiki code-block theme from `dark-plus` to `vitesse-dark`.  This does not appear to change any `nu`/`nushell` syntax highlighting, but it does enable proper `ansi` coloring.

This might finally explain why line-numbers were being applied by both Shiki and PrismJS previously.