### PR TITLE
Revert codeblock theme

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -192,7 +192,7 @@ export default defineUserConfig({
       },
     }),
     shikiPlugin({
-      theme: 'vitesse-dark',
+      theme: 'dark-plus',
       lineNumbers: 10,
       langs: [
         'csv',


### PR DESCRIPTION
The color choices in the theme added in #1714 don't work well for Nushell codeblocks.  Reverting to the original while we either look for a theme that works well (and supports `ansi`) or add the ANSI CSS styles in manually.