### PR TITLE
Shiki nord theme

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -192,7 +192,7 @@ export default defineUserConfig({
       },
     }),
     shikiPlugin({
-      theme: 'dark-plus',
+      theme: 'nord',
       lineNumbers: 10,
       langs: [
         'csv',


### PR DESCRIPTION
Updates Shiki theme to `nord`, which appears to have a nice colorset that both:

* Works with `nu`/`nushell` language blocks
* Works with `ansi` language blocks