### PR TITLE
Apply theme change only for ansi highlights

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -192,8 +192,26 @@ export default defineUserConfig({
       },
     }),
     shikiPlugin({
-      theme: 'dark-plus',
+      themes: {
+        dark: 'dark-plus',
+        vitessedark: 'vitesse-dark', // pre-load vitesse-dark for ansi code blocks
+      },
       lineNumbers: 10,
+      transformers: [
+        {
+          preprocess(code, options) {
+            if (options.lang == 'ansi') {
+              this.options.defaultColor = 'vitessedark';
+              // this doesn't work at the top-level for some reason
+              this.options.colorReplacements = {
+                // make vitesse-dark background color the same as dark-plus
+                '#121212': '#1e1e1e',
+              };
+            }
+            return code;
+          },
+        },
+      ],
       langs: [
         'csv',
         'nushell',

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -194,18 +194,21 @@ export default defineUserConfig({
     shikiPlugin({
       themes: {
         dark: 'dark-plus',
-        vitessedark: 'vitesse-dark', // pre-load vitesse-dark for ansi code blocks
+        onedarkpro: 'one-dark-pro', // pre-load one-dark-pro for ansi code blocks
       },
       lineNumbers: 10,
       transformers: [
+        // use one-dark-pro theme for ansi code blocks
         {
           preprocess(code, options) {
             if (options.lang == 'ansi') {
-              this.options.defaultColor = 'vitessedark';
+              this.options.defaultColor = 'onedarkpro';
               // this doesn't work at the top-level for some reason
               this.options.colorReplacements = {
-                // make vitesse-dark background color the same as dark-plus
-                '#121212': '#1e1e1e',
+                // make one-dark-pro background color the same as dark-plus
+                '#282c34': '#1e1e1e',
+                // HACK: change color of comments, since nu-highlight can't highlight them
+                '#abb2bf': '#80858f',
               };
             }
             return code;


### PR DESCRIPTION
Use the one-dark-pro theme only for `ansi` code blocks. Additionally, override the background color to be the same as `dark-plus`.

I can switch the theme if others would prefer, but I think the `one-dark-pro` theme looks decent along with the other code blocks, and is very readable. Here's an error using `ansi`, highlighted with `one-dark-pro`:

![image](https://github.com/user-attachments/assets/17368633-337d-4989-aa29-8ea5a4ca34c5)
