### PR TITLE
Use `nu-highlight` for code blocks

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -192,8 +192,26 @@ export default defineUserConfig({
       },
     }),
     shikiPlugin({
-      theme: 'dark-plus',
+      themes: {
+        dark: 'dark-plus',
+        vitessedark: 'vitesse-dark', // pre-load vitesse-dark for ansi code blocks
+      },
       lineNumbers: 10,
+      transformers: [
+        {
+          preprocess(code, options) {
+            if (options.lang == 'ansi') {
+              this.options.defaultColor = 'vitessedark';
+              // this doesn't work at the top-level for some reason
+              this.options.colorReplacements = {
+                // make vitesse-dark background color the same as dark-plus
+                '#121212': '#1e1e1e',
+              };
+            }
+            return code;
+          },
+        },
+      ],
       langs: [
         'csv',
         'nushell',

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -287,6 +287,10 @@ def "str mycommand" [] {
 Now we can call our custom command as if it were a built-in subcommand of [`str`](/commands/docs/str.md):
 
 ```nu
+def "str mycommand" [] {
+  "hello"
+}
+# BEGIN EXAMPLE
 str mycommand
 ```
 
@@ -444,12 +448,16 @@ greet World
 
 If we try to run the above, Nushell will tell us that the types don't match:
 
-```nu
-error: Type Error
-  ┌─ shell:6:7
-  │
-5 │ greet world
-  │       ^^^^^ Expected int
+```ansi
+Error: [31mnu::parser::parse_mismatch
+
+[39m  [31m×[39m Parse mismatch during operation.
+   ╭─[[22;1;36;4mentry #1:5:7[22;39;24m]
+ [22;2m4[22m │
+ [22;2m5[22m │ greet World
+   · [22;1;35m      ──┬──
+[22;39m   ·         [22;1;35m╰── expected int
+[22;39m   ╰────[m
 ```
 
 ::: tip Cool!

--- a/book/operators.md
+++ b/book/operators.md
@@ -167,6 +167,9 @@ let cats = ["Mr. Humphrey Montgomery", Kitten]
 
 The below code is an equivalent version using `append`:
 ```nushell
+let dogs = [Spot, Teddy, Tommy]
+let cats = ["Mr. Humphrey Montgomery", Kitten]
+# BEGIN EXAMPLE
 $dogs |
   append Polly |
   append ($cats | each { |elt| $"($elt) \(cat\)" }) |
@@ -209,6 +212,8 @@ You can make a new record with all the fields of `$config` and some new addition
 operator. You can use the spread multiple records inside a single record literal.
 
 ```nushell
+let config = { path: /tmp, limit: 5 }
+# BEGIN EXAMPLE
 {
   ...$config,
   users: [alice bob],

--- a/tools/highlight.nu
+++ b/tools/highlight.nu
@@ -1,0 +1,15 @@
+const DELIMITER = "BEGIN EXAMPLE"
+
+def main [] {
+  let source = $in
+  let highlighted = $source | nu-highlight
+  if $DELIMITER in $source {
+    $highlighted
+    | lines
+    | skip while {|line| "BEGIN EXAMPLE" not-in $line}
+    | skip 1 # skip example line itself
+    | to text
+  } else {
+    $highlighted
+  }
+}

--- a/tools/highlight.nu
+++ b/tools/highlight.nu
@@ -1,7 +1,11 @@
 const DELIMITER = "BEGIN EXAMPLE"
 
 def main [] {
-  let source = $in
+  let source = (
+    $in
+    # prune leading caret
+    | str replace -r '^[>>]\s+' ''
+  )
   let highlighted = $source | nu-highlight
   if $DELIMITER in $source {
     $highlighted


### PR DESCRIPTION
Work in progress. Adds a Shiki transformer which uses the `highlight.nu` script to highlight nushell code blocks using `nu-highlight`.

Also adds the ability to add code before the true code block, for examples which require extra code to work:
```nushell
def "str mycommand" [] {
  "hello"
}
# BEGIN EXAMPLE
str mycommand
```

Only the `str mycommand` line will show up in the final code block, but it will not be error highlighted since the `str mycommand` definition exists.

The output of `nu-highlight` heavily depends on bold fonts for readability, so we should make sure all of the fonts listed in `--code-font-family` support bold. Notably, on my machine the font fell back to Andale Mono, which did not have a bold face. I was able to get bold `ansi` highlighting working install consolas, which is a higher priority font in `--code-font-family` and does have a bold face.

Need to rebase this on #1718 assuming that gets merged.