### PR TITLE
Use dark-plus in code blocks for light mode also

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -193,6 +193,7 @@ export default defineUserConfig({
     }),
     shikiPlugin({
       themes: {
+        light: 'dark-plus',
         dark: 'dark-plus',
         onedarkpro: 'one-dark-pro', // pre-load one-dark-pro for ansi code blocks
       },


### PR DESCRIPTION
Currently, in light mode, there's no code highlighting:
![image](https://github.com/user-attachments/assets/90f7e729-a4a1-4c21-85bf-c9f31697acdb)

This is a quick fix so that light mode also uses the dark-plus theme for code blocks.
![image](https://github.com/user-attachments/assets/4a44c338-fb9c-4013-b0f7-c7bcea51302f)

I think this happened because previously, we just had `theme: 'dark-plus'`, whereas now have a `themes` object where the light theme needs to be specified.