### PR TITLE
Update plugins.md

### DIFF
--- a/contributor-book/plugins.md
+++ b/contributor-book/plugins.md
@@ -90,7 +90,7 @@ impl SimplePluginCommand for Len {
         "len"
     }
 
-    fn usage(&self) -> &str {
+    fn description(&self) -> &str {
         "calculates the length of its input"
     }
 
@@ -173,7 +173,7 @@ impl SimplePluginCommand for Len {
 }
 ```
 
-There are a few methods required for this implementation. We first define the `name` of the command, which is what the user will type at the prompt or in their script to run the command. The `usage` is also required, which is a short documentation string for users to know what the command does, and is displayed along with completions and in `help`. Finally, we define the `signature`, which specifies arguments and types for the command.
+There are a few methods required for this implementation. We first define the `name` of the command, which is what the user will type at the prompt or in their script to run the command. The `description` is also required, which is a short documentation string for users to know what the command does, and is displayed along with completions and in `help`. Finally, we define the `signature`, which specifies arguments and types for the command.
 
 We tell Nu that the name is "len", give it a basic description for `help` to display and declare that we expect to be passed a string and will return an integer.
 
@@ -432,7 +432,7 @@ impl SimplePluginCommand for Motd {
         "motd"
     }
 
-    fn usage(&self) -> &str {
+    fn description(&self) -> &str {
         "Message of the day"
     }
 
@@ -505,7 +505,7 @@ impl PluginCommand for MyEach {
         "my-each"
     }
 
-    fn usage(&self) -> &str {
+    fn description(&self) -> &str {
         "Run closure on each element of a list"
     }
 


### PR DESCRIPTION
Traits PluginCommand + SimplePluginCommand:
usage was renamed description in v. 0.98

https://www.nushell.sh/blog/2024-09-17-nushell_0_98_0.html#breaking-plugin-changes-toc