### PR TITLE
Fix broken link + typo

### DIFF
--- a/blog/2024-06-25-nushell_0_95_0.md
+++ b/blog/2024-06-25-nushell_0_95_0.md
@@ -147,7 +147,7 @@ New constants for system-level items such as `$nu.vendor-autoload-dir` will be i
 | -------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | [@NotTheDr01ds](https://github.com/NotTheDr01ds)   | Suppress column index for default `cal` output                                                     | [#13188](https://github.com/nushell/nushell/pull/13188) |
 | [@NotTheDr01ds](https://github.com/NotTheDr01ds)   | Fixed `generate` command signature                                                                 | [#13200](https://github.com/nushell/nushell/pull/13200) |
-| [@ayax79](https://github.com/ayax79)               | Use polars default infer schema amount of 100 rows instead of scanning entire CVS/json lines files | [#13193](https://github.com/nushell/nushell/pull/13193) |
+| [@ayax79](https://github.com/ayax79)               | Use polars default infer schema amount of 100 rows instead of scanning entire CSV/json lines files | [#13193](https://github.com/nushell/nushell/pull/13193) |
 | [@zhiburt](https://github.com/zhiburt)             | nu-explore: Add vertical lines && fix index/transpose issue                                        | [#13147](https://github.com/nushell/nushell/pull/13147) |
 | [@devyn](https://github.com/devyn)                 | fix nu-system build on arm64 FreeBSD                                                               | [#13196](https://github.com/nushell/nushell/pull/13196) |
 | [@NotTheDr01ds](https://github.com/NotTheDr01ds)   | Do example                                                                                         | [#13190](https://github.com/nushell/nushell/pull/13190) |
@@ -344,7 +344,7 @@ Thanks to all the contributors below for helping us solve issues and improve doc
 
 | author                                           | title                                                                                              | PR                                                      |
 | ------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| [@ayax79](https://github.com/ayax79)             | Use polars default infer schema amount of 100 rows instead of scanning entire CVS/json lines files | [#13193](https://github.com/nushell/nushell/pull/13193) |
+| [@ayax79](https://github.com/ayax79)             | Use polars default infer schema amount of 100 rows instead of scanning entire CSV/json lines files | [#13193](https://github.com/nushell/nushell/pull/13193) |
 | [@weirdan](https://github.com/weirdan)           | Update `sys users` signature                                                                       | [#13172](https://github.com/nushell/nushell/pull/13172) |
 | [@WindSoilder](https://github.com/WindSoilder)   | Improves commands that support range input                                                         | [#13113](https://github.com/nushell/nushell/pull/13113) |
 | [@devyn](https://github.com/devyn)               | Fix compilation for `nu_protocol::value::from_value` on 32-bit targets                             | [#13169](https://github.com/nushell/nushell/pull/13169) |
@@ -372,7 +372,7 @@ Thanks to all the contributors below for helping us solve issues and improve doc
 
 | author                               | title                                                                                              | PR                                                      |
 | ------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| [@ayax79](https://github.com/ayax79) | Use polars default infer schema amount of 100 rows instead of scanning entire CVS/json lines files | [#13193](https://github.com/nushell/nushell/pull/13193) |
+| [@ayax79](https://github.com/ayax79) | Use polars default infer schema amount of 100 rows instead of scanning entire CSV/json lines files | [#13193](https://github.com/nushell/nushell/pull/13193) |
 | [@ayax79](https://github.com/ayax79) | Added the ability to turn on performance debugging through and env var for the polars plugin       | [#13191](https://github.com/nushell/nushell/pull/13191) |
 | [@ayax79](https://github.com/ayax79) | Added the ability to open json lines dataframes with polars lazy json lines reader.                | [#13167](https://github.com/nushell/nushell/pull/13167) |
 | [@ayax79](https://github.com/ayax79) | Allow the addition of an index column to be optional                                               | [#13097](https://github.com/nushell/nushell/pull/13097) |
@@ -418,7 +418,7 @@ Thanks to all the contributors below for helping us solve issues and improve doc
   - [Fixes #13093 - Erroneous example in 'touch' help](https://github.com/nushell/nushell/pull/13095)
   - [`cd`/`def --env` examples](https://github.com/nushell/nushell/pull/13068)
 - [ayax79](https://github.com/ayax79) created
-  - [Use polars default infer schema amount of 100 rows instead of scanning entire CVS/json lines files](https://github.com/nushell/nushell/pull/13193)
+  - [Use polars default infer schema amount of 100 rows instead of scanning entire CSV/json lines files](https://github.com/nushell/nushell/pull/13193)
   - [Added the ability to turn on performance debugging through and env var for the polars plugin](https://github.com/nushell/nushell/pull/13191)
   - [Added the ability to open json lines dataframes with polars lazy json lines reader.](https://github.com/nushell/nushell/pull/13167)
   - [Allow the addition of an index column to be optional](https://github.com/nushell/nushell/pull/13097)

--- a/book/moving_around.md
+++ b/book/moving_around.md
@@ -184,7 +184,7 @@ cd ....
 ```
 
 ::: tip
-Multi-dot shortcuts are available to both internal Nushell [filesystem commands](//commands/categories/filesystem.html) as well as to external commands. For example, running `^stat ....` on a Linux/Unix system will show that the path is expanded to `../../../..`
+Multi-dot shortcuts are available to both internal Nushell [filesystem commands](/commands/categories/filesystem.html) as well as to external commands. For example, running `^stat ....` on a Linux/Unix system will show that the path is expanded to `../../../..`
 :::
 
 You can combine relative directory levels with directory names as well:

--- a/book/quick_tour.md
+++ b/book/quick_tour.md
@@ -237,7 +237,7 @@ Pressing <kbd>Esc</kbd> one time returns from Scroll-mode to the View; Pressing 
 :::
 
 ::: tip
-You can, of course, use the `explore` command on _any_ structured data in Nushell. This might include JSON data coming from a Web API, a spreadsheet or CVS file, YAML, or anything that can be represented as structured data in Nushell.
+You can, of course, use the `explore` command on _any_ structured data in Nushell. This might include JSON data coming from a Web API, a spreadsheet or CSV file, YAML, or anything that can be represented as structured data in Nushell.
 
 Try `$env.config | explore` for fun!
 :::

--- a/fr/book/moving_around.md
+++ b/fr/book/moving_around.md
@@ -128,7 +128,7 @@ Vous pouvez ajouter des points supplémentaires pour remonter de niveaux supplé
 @[code](@snippets/book/moving_around/multiple_cd_levels.nu)
 
 ::: tip
-Les raccourcis multi-points sont disponibles à la fois pour les commandes Nushelles, [les commandes du système de fichier](//commands/categories/filesystem.html) et les commandes externes. Par exemple, executer `^stat ....` sur un système Linux/Unix affichera que le chemin est étendu à `../../../..`
+Les raccourcis multi-points sont disponibles à la fois pour les commandes Nushelles, [les commandes du système de fichier](/commands/categories/filesystem.html) et les commandes externes. Par exemple, executer `^stat ....` sur un système Linux/Unix affichera que le chemin est étendu à `../../../..`
 :::
 
 Vous pouvez aussi combiner des niveaux de répertoires relatifs avec des noms de répertoires :


### PR DESCRIPTION
Just a little PR to fix a broken link (markdown typo) and fix a `CVS/CSV` typo.