### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--
+# Important
+
+Nushell command documentation (under https://nushell.sh/commands) is automatically generated from the
+built-in Help system (e.g., `help <command>`). Command doc cannot be updated in this repository, but
+instead should be changed in the command source itself in https://github.com/nushell/nushell
+-->
+
+<!--
+if this PR closes one or more issues, you can automatically link the PR with
+them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
+- this PR should close #xxxx
+- fixes #xxxx
+
+you can also mention related issues, PRs or discussions!
+-->
+
+# Description
+
+<!--
+Thank you for improving the Nushell documentation!
+
+Description of your pull request goes here
+-->


### PR DESCRIPTION
Adds a PR template as recommended in #1722.  This probably doesn't save much time, since the user will have already pushed the changes by the time they see this.

I'll look at suppressing the GitHub plugin on the `/commands` route next.