### PR TITLE
Remove "Edit this page" and contributors list from Command docs

### DIFF
--- a/make_docs.nu
+++ b/make_docs.nu
@@ -75,6 +75,8 @@ def make_docs [
 #   Various commands for working with bits.
 # usage: |
 #   Various commands for working with bits.
+# editLink: false      # turns off the "Edit this page in GitHub for commands"
+# contributors: false  # turns off the contributors list since it is not accurate for commands
 # ---
 # ```
 # - the `dfr min` command in `commands/docs/dfr_min.md`
@@ -92,6 +94,8 @@ def make_docs [
 # usage: |
 #   Creates a min expression
 #   Aggregates columns to their min value
+# editLink: false
+# contributors: false
 # ---
 # ```
 def command-frontmatter [commands_group, command_name] {
@@ -130,6 +134,8 @@ version: ($nu_version)
 ($category_matter)
 usage: |
 ($indented_usage)
+editLink: false
+contributors: false
 ---"
 }
 
@@ -375,7 +381,12 @@ def generate-category [category] {
     let safe_name = ($category | safe-path)
     let doc_path = (['.', 'commands', 'categories', $'($safe_name).md'] | path join)
 
-$"# ($category | str title-case)
+$"---
+editLink: false
+contributors: false
+---
+
+# ($category | str title-case)
 
 <script>
   import pages from '@temp/pages'

--- a/make_docs.nu
+++ b/make_docs.nu
@@ -403,14 +403,18 @@ contributors: false
 </script>
 
 <table>
-  <tr>
-    <th>Command</th>
-    <th>Description</th>
-  </tr>
-  <tr v-for=\"command in commands\">
-   <td><a :href=\"$withBase\(command.path\)\">{{ command.title }}</a></td>
-   <td style=\"white-space: pre-wrap;\">{{ command.frontmatter.usage }}</td>
-  </tr>
+  <thead>
+    <tr>
+      <th>Command</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr v-for=\"command in commands\">
+       <td><a :href=\"$withBase\(command.path\)\">{{ command.title }}</a></td>
+       <td style=\"white-space: pre-wrap;\">{{ command.frontmatter.usage }}</td>
+    </tr>
+  </tbody>
 </table>
 "
     | save --raw --force $doc_path


### PR DESCRIPTION
* Completes #1722 by adding frontmatter to Nushell Commands and Categories pages to remove the *"Edit this page in GitHub"* link.

* Also removes the *"Contributors"* list since it is not accurate for these pages.

* And implements a workaround for https://github.com/vuejs/core/issues/12088 by placing table heading rows inside a `<thead>` and table body rows inside a `<tbody>`.  This shouldn't be necessary, but without it VuePress will now generate ugly warnings for each of the Category pages.