### PR TITLE
Use white foreground for copy code button

### DIFF
--- a/.vuepress/styles/index.scss
+++ b/.vuepress/styles/index.scss
@@ -85,3 +85,12 @@ html[data-theme='dark'] {
     text-decoration: underline;
   }
 }
+
+:root,
+html[data-theme='light'] {
+  .vp-copy-code-button {
+    // Make the copy code button white for good contrast with the
+    // dark background in code blocks
+    color: white !important;
+  }
+}


### PR DESCRIPTION
This should make the color of the copy code button in code blocks (including the "Copied" notification) white in light mode, to make it stand out better against the dark background. The button is already white in dark mode.

Fixes https://github.com/nushell/nushell.github.io/issues/1727