### PR TITLE
Update hooks.md

### DIFF
--- a/book/hooks.md
+++ b/book/hooks.md
@@ -226,7 +226,7 @@ $env.config = ($env.config | upsert hooks.env_change.PWD {
         {
             condition: {|before, after|
                 ('/path/to/target/dir' not-in $after
-                    and '/path/to/target/dir' in $before
+                    and '/path/to/target/dir' in ($before | default "")
                     and 'test-env' in (overlay list))
             }
             code: "overlay hide test-env --keep-env [ PWD ]"


### PR DESCRIPTION
Running the example for environment activation as-is gave the following type mismatch error:

```
Error: nu::shell::type_mismatch

  × Type mismatch during operation.
    ╭─[/Users/foo/Library/Application Support/nushell/config.nu:27:33]
 26 │                         ('/Users/foo/dir' not-in $after
 27 │                             and '/Users/foo/dir' in $before
    ·                                 ─────────────────────┬──────────────────── ─┬ ───┬───
    ·                                                      │                      │    ╰── nothing
    ·                                                      │                      ╰── type mismatch for operator
    ·                                                      ╰── string
 28 │                             and 'activate' in (overlay list))
    ╰────


~ 
❯ 𝒾: 
process finished with exit code = -1
```