### PR TITLE
Fixing shell aliases module name mismatch

### DIFF
--- a/book/directory_stack.md
+++ b/book/directory_stack.md
@@ -120,7 +120,7 @@ The Standard Library provides a set of aliases that can be used in place of the 
 Import them using:
 
 ```nu
-use std/dirs shell-aliases *
+use std/dirs shells-aliases *
 ```
 
 The built-in aliases are:


### PR DESCRIPTION
The Nushell book says:

> Some users may prefer to think of this feature as multiple "shells within shells", where each has its own directory.
> 
> The Standard Library provides a set of aliases that can be used in place of the dirs commands above.
> 
> Import them using:
> 
> use std/dirs **shell-aliases** *
> 
> The built-in aliases are: ...

But the Nushell source code says

> crates/nu-std/std/dirs/mod.nu
> 
> export module **shells-aliases** {
>     export alias shells = main
>     export alias enter = add
>     export alias dexit = drop 

This PR aims to fix this mismatch.