### PR TITLE
Added $? equivalent to $env.LAST_EXIT_CODE

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -56,6 +56,7 @@ $env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 | `echo /tmp/$RANDOM`                  | `$"/tmp/(random int)"`                                        | Use command output in a string                                    |
 | `cargo b --jobs=$(nproc)`            | `cargo b $"--jobs=(sys cpu \| length)"`                       | Use command output in an option                                   |
 | `echo $PATH`                         | `$env.PATH` (Non-Windows) or `$env.Path` (Windows)            | See the current path                                              |
+| `echo $?`                            | `$env.LAST_EXIT_CODE`                                         | See the exit status of the last executed command                  |
 | `<update ~/.bashrc>`                 | `vim $nu.config-path`                                         | Update PATH permanently                                           |
 | `export PATH = $PATH:/usr/other/bin` | `$env.PATH = ($env.PATH \| append /usr/other/bin)`            | Update PATH temporarily                                           |
 | `export`                             | `$env`                                                        | List the current environment variables                            |


### PR DESCRIPTION
This pull request adds a nushell equivalent to a bash command in the [Coming from Bash](https://www.nushell.sh/book/coming_from_bash.html#coming-from-bash) book chapter.

This is the added equivalence:
| Bash                                 | Nu                                                            | Task                                                              |
| ------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------- |
| `echo $?`                            | `$env.LAST_EXIT_CODE`                                         | See the exit status of the last executed command                  |

This equivalence was added because $? is very common in bash scripts.

The change can be previewed here: https://rolandmarchand.github.io/nushell.github.io/book/coming_from_bash.html#command-equivalents.