### PR TITLE
Drop invalid links in translated content

### DIFF
--- a/fr/book/README.md
+++ b/fr/book/README.md
@@ -47,7 +47,7 @@ La plupart des dépôts contiennent un fichier `CONTRIBUTING.md` avec des consei
 Nushell lui-même est écrit en [Rust](https://www.rust-lang.org).
 Cependant, vous n'avez pas besoin d'être un programmeur en Rust pour aider.
 Si vous connaissez un peu le développement web, vous pouvez contribuer à l'amélioration de ce site web ou du projet Nana.
-[Les Dataframes](dataframes.md) peuvent bénéficier de votre expertise en traitement de données.
+Les Dataframes peuvent bénéficier de votre expertise en traitement de données.
 
 Si vous avez écrit un script sympa, un plugin, ou intégré Nushell quelque part, nous serions heureux de voir votre contribution à `nu_scripts` ou à Awesome Nu.
 Découvrir des bugs avec des étapes pour les reproduire et les signaler sur GitHub est également une aide précieuse !

--- a/pt-BR/book/README.md
+++ b/pt-BR/book/README.md
@@ -8,7 +8,7 @@
 - [Trabalhando com tabelas](trabalhando_com_tabelas.md) - Trabalhando com as tabelas do nushell
 - [Pipeline](pipeline.md) - Como o pipeline funciona
 - [Metadados](metadados.md) - Uma explicação sobre o sistema de metadados do nushell
-- [Shells](shells_em_shells.md) - Trabalhando com múltiplos locais
+- Shells - Trabalhando com múltiplos locais
 - [Escapando comandos](escapando.md) - Escapando para comandos nativos com o mesmo nome
 - [Plugins](plugins.md) - Melhorando o nushell com mais funcionalidades usando plugins
 - [Command Reference](command_reference.md) - A list of all Nushell's commands.


### PR DESCRIPTION
On translated pages, rather than point to non-existing pages resulting in a 404 not found page being shown to the user, do not link anywhere.

---

Before this change, launching vuepress reports

```
warning Broken links found in fr/book/README.md: dataframes.md
warning Broken links found in pt-BR/book/README.md: shells_em_shells.md
```

The live pages with the dead links:

* https://www.nushell.sh/fr/book/
* https://www.nushell.sh/pt-BR/book/