### PR TITLE
Fix feed, fix feed item sorting

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -250,14 +250,7 @@ export default defineUserConfig({
         );
       },
       sorter: (a, b) => {
-        return compareDate(
-          a.data.git?.createdTime
-            ? new Date(a.data.git?.createdTime)
-            : a.frontmatter.date,
-          b.data.git?.createdTime
-            ? new Date(b.data.git?.createdTime)
-            : b.frontmatter.date,
-        );
+        return compareDate(a.frontmatter.date, b.frontmatter.date);
       },
     }),
     sitemapPlugin({


### PR DESCRIPTION
66c88881f3a1205679adb8a45a2e61b97183a809 (#1765) added old blog posts but with a current author and commit date.

Blog items should be dated to their creation and publication rather than when this git source move took place.

Because the feed plugin used git dates, only the 30 oldest items ended up in the feed.

Falling back to front-matter date should resolve the issue.

Blog posts showing up correctly dated on `/blog/` indicates that the page date is set correctly from the file name, even without explicit front matter within the post source file.

Untested; please verify.

Hopefully resolves #1767

An alternative approach would be committing the post files individually with git commits dated back to their publication dates. But the whole git integration seems error-prone to me, so this commit seems like a better solution with less effort.