### PR TITLE
Fix blog post typos

### DIFF
--- a/blog/2024-01-06-twin0228.md
+++ b/blog/2024-01-06-twin0228.md
@@ -6,7 +6,7 @@
 - yukitomoda [refactored tests](https://github.com/nushell/nushell/pull/11479), [fixed a test which fails on Windows](https://github.com/nushell/nushell/pull/11478), and [fixed rm for symlinks pointing to directory on windows (issue #11461)](https://github.com/nushell/nushell/pull/11463)
 - NotLebedev [added some XML validation](https://github.com/nushell/nushell/pull/11487)
 - WindSoilder [updated reedline](https://github.com/nushell/nushell/pull/11490)
-- hustcer created [fixed builds fo riscv64](https://github.com/nushell/nushell/pull/11476)
+- hustcer created [fixed builds for riscv64](https://github.com/nushell/nushell/pull/11476)
 - rsteube [reverted "Return external file completions if not empty (#10898)"](https://github.com/nushell/nushell/pull/11446)
 - fdncred [bumped the rust toolchain to 1.73.0](https://github.com/nushell/nushell/pull/11445)
 

--- a/blog/2024-01-19-twin0230.md
+++ b/blog/2024-01-19-twin0230.md
@@ -27,7 +27,7 @@
 
 ## Nu_Scripts
 
-- fj0r created [use `fill -c` instead of `str repeat`](https://github.com/nushell/nu_scripts/pull/740), and [fix docker.nu and kubernetes.nu](https://github.com/nushell/nu_scripts/pull/739), and [git-v2: imporve message of `gp`](https://github.com/nushell/nu_scripts/pull/738)
+- fj0r created [use `fill -c` instead of `str repeat`](https://github.com/nushell/nu_scripts/pull/740), and [fix docker.nu and kubernetes.nu](https://github.com/nushell/nu_scripts/pull/739), and [git-v2: improve message of `gp`](https://github.com/nushell/nu_scripts/pull/738)
 - fdncred created [change the string interpolation in git aliases](https://github.com/nushell/nu_scripts/pull/735), and [tweak some git aliases so they work](https://github.com/nushell/nu_scripts/pull/734)
 
 ## reedline

--- a/blog/2024-03-01-twin0236.md
+++ b/blog/2024-03-01-twin0236.md
@@ -12,7 +12,7 @@
 - ZzMzaw [extended the clear command so it can clear the terminal's history](https://github.com/nushell/nushell/pull/12008)
 - hustcer [made coreutils umkdir the default mkdir](https://github.com/nushell/nushell/pull/12007), and [fixed Windows msvc \*.msi builds](https://github.com/nushell/nushell/pull/11986)
 - kik4444 [fixed `touch` to allow changing timestamps on directories](https://github.com/nushell/nushell/pull/12005)
-- FilipAndersson245 [replaced the Criterion benchmarking frameword with Divan](https://github.com/nushell/nushell/pull/12000), [made benchmark changes](https://github.com/nushell/nushell/pull/11998), and [fixed tests.](https://github.com/nushell/nushell/pull/11994)
+- FilipAndersson245 [replaced the Criterion benchmarking framework with Divan](https://github.com/nushell/nushell/pull/12000), [made benchmark changes](https://github.com/nushell/nushell/pull/11998), and [fixed tests.](https://github.com/nushell/nushell/pull/11994)
 - ayax79 [fixed up an issue with dataframes](https://github.com/nushell/nushell/pull/11987), and [handled more errors in the REPL so they don't propagate up and kill the REPL](https://github.com/nushell/nushell/pull/11953)
 - nils-degroot [added date support in `from xlsx`](https://github.com/nushell/nushell/pull/11952)
 - sholderbach [removed some unnecessary static `Vec`s](https://github.com/nushell/nushell/pull/11947), [fixed `cargo b -p nu-command --tests`](https://github.com/nushell/nushell/pull/11939), and [fixed a future lint by `truncate(false)` in `touch`](https://github.com/nushell/nushell/pull/11863)


### PR DESCRIPTION
The current main branch state fails CI build typo checks. These were introduced through 66c88881f3a1205679adb8a45a2e61b97183a809 (#1765).

Correct the reported typos.