### PR TITLE
Update table border configuration docs

### DIFF
--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -10,29 +10,52 @@ Many parts of Nushell's interface can have their color customized. All of these 
 
 ## Table Borders
 
-Table borders are controlled by the `$env.config.table.mode` setting in `config.nu`. Here is an example:
+Table borders are controlled by the `$env.config.table.mode` setting. It can be changed at run time, or in the `config.nu` file:
 
 ```nu
-$env.config = {
-    table: {
-        mode: rounded
-    }
-}
+$env.config.table.mode = 'rounded'
 ```
 
-Here are the current options for `$env.config.table.mode`:
+The options for `$env.config.table.mode` can be listed with `table --list`:
 
-- `rounded` # of course, this is the best one :)
+<!-- Generated with table --list | each {|| $"- `($in)`"} | sort | str join "\n"` -->
+
+- `ascii_rounded`
+- `basic_compact`
 - `basic`
-- `compact`
 - `compact_double`
+- `compact`
+- `default`
+- `dots`
+- `heavy`
 - `light`
+- `markdown`
+- `none`
+- `psql`
+- `reinforced`
+- `restructured`
+- `rounded`
 - `thin`
 - `with_love`
-- `reinforced`
-- `heavy`
-- `none`
-- `other`
+
+Examples:
+
+```nu
+> $env.config.table.mode = 'rounded'
+╭───┬────────────────╮
+│ 0 │ basic          │
+│ 1 │ compact        │
+│ 2 │ compact_double │
+│ 3 │ default        │
+│ 4 │ heavy          │
+╰───┴────────────────╯
+> $env.config.table.mode = 'psql' | first 5
+ 0 | basic
+ 1 | compact
+ 2 | compact_double
+ 3 | default
+ 4 | heavy
+ ```
 
 ### Color Symbologies
 

--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -41,21 +41,24 @@ The options for `$env.config.table.mode` can be listed with `table --list`:
 Examples:
 
 ```nu
-> $env.config.table.mode = 'rounded'
-╭───┬────────────────╮
-│ 0 │ basic          │
-│ 1 │ compact        │
-│ 2 │ compact_double │
-│ 3 │ default        │
-│ 4 │ heavy          │
-╰───┴────────────────╯
-> $env.config.table.mode = 'psql' | first 5
- 0 | basic
- 1 | compact
- 2 | compact_double
- 3 | default
- 4 | heavy
- ```
+$env.config.table.mode = 'rounded'
+table --list | first 5
+# => ╭───┬────────────────╮
+# => │ 0 │ basic          │
+# => │ 1 │ compact        │
+# => │ 2 │ compact_double │
+# => │ 3 │ default        │
+# => │ 4 │ heavy          │
+# => ╰───┴────────────────╯
+
+$env.config.table.mode = 'psql'
+table --list | first 5
+# =>  0 | basic
+# =>  1 | compact
+# =>  2 | compact_double
+# =>  3 | default
+# =>  4 | heavy
+```
 
 ### Color Symbologies
 


### PR DESCRIPTION
The `config.nu` no longer contains the full configuration, so make the suggested code a oneliner assignment.

Add a commented-out (not rendered Markdown) command to generate the list, which will ease updates in the future.

Update the list of options.

Add an example demonstrating how the border style can change.