### PR TITLE
Sort feeds based on filename date first

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -239,6 +239,7 @@ export default defineUserConfig({
       apiKey: 'dd6a8f770a42efaed5befa429d167232',
     }),
     feedPlugin({
+      devServer: true,
       rss: true,
       json: true,
       atom: true,
@@ -250,14 +251,27 @@ export default defineUserConfig({
         );
       },
       sorter: (a, b) => {
-        return compareDate(
-          a.data.git?.createdTime
-            ? new Date(a.data.git?.createdTime)
-            : a.frontmatter.date,
-          b.data.git?.createdTime
-            ? new Date(b.data.git?.createdTime)
-            : b.frontmatter.date,
+        const pathDateA = new Date(
+          a.path.replace('/blog/', '').substring(0, 10),
         );
+        const pathDateB = new Date(
+          b.path.replace('/blog/', '').substring(0, 10),
+        );
+        const effectiveDateA =
+          pathDateA != 'Invalid Date'
+            ? pathDateA
+            : a.frontmatter.date
+              ? new Date(a.frontmatter.date)
+              : new Date(a.data.git?.createdTime);
+
+        // Determine the effective date for item B
+        const effectiveDateB =
+          pathDateB != 'Invalid Date'
+            ? pathDateB
+            : b.frontmatter.date
+              ? new Date(b.frontmatter.date)
+              : new Date(b.data.git?.createdTime);
+        return compareDate(effectiveDateA, effectiveDateB);
       },
     }),
     sitemapPlugin({

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -239,7 +239,6 @@ export default defineUserConfig({
       apiKey: 'dd6a8f770a42efaed5befa429d167232',
     }),
     feedPlugin({
-      devServer: true,
       rss: true,
       json: true,
       atom: true,


### PR DESCRIPTION
Partial fix for #1765.

This at least should get the newer Blog articles back at the top of the RSS/Atom feeds, but there are still problems (and could be more):

* Feed date still shows the GitHub commit date
* Might be issues when the post filename does not have a valid date - I haven't had a chance to test yet, but will soon.
