### PR TITLE
Fix inline code format fencing

### DIFF
--- a/blog/2025-02-04-nushell_0_102_0.md
+++ b/blog/2025-02-04-nushell_0_102_0.md
@@ -227,7 +227,7 @@ open --raw ./events.sock | bytes split (char nul) | each { decode }
 
 ### New command: `help pipe-and-redirect` [[toc](#table-of-contents)]
 
-Thanks [@WindSoilder](https://github.com/WindSoilder) for the new `help pipe-and-redirect command` which lists the pipe and redirect operators ([#14821](https://github.com/nushell/nushell/pull/14821)).
+Thanks [@WindSoilder](https://github.com/WindSoilder) for the new `help pipe-and-redirect` command which lists the pipe and redirect operators ([#14821](https://github.com/nushell/nushell/pull/14821)).
 
 ### The `start` command now works with non-HTTP URIs [[toc](#table-of-contents)]
 


### PR DESCRIPTION
The inline code formatted too much as code. "command" is part of the sentence, not the code/command.