### PR TITLE
Include link to plugins

### DIFF
--- a/blog/2025-03-04-nushell_0_103_0.md
+++ b/blog/2025-03-04-nushell_0_103_0.md
@@ -20,7 +20,7 @@ Today, we're releasing version 0.103.0 of Nu. This release adds...
 
 Nu 0.103.0 is available as [pre-built binaries](https://github.com/nushell/nushell/releases/tag/0.103.0) or from [crates.io](https://crates.io/crates/nu). If you have Rust installed you can install it using `cargo install nu`.
 
-As part of this release, we also publish a set of optional plugins you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
+As part of this release, we also publish a set of [optional plugins](https://www.nushell.sh/book/plugins.html#core-plugins) you can install and use with Nu. To install, use `cargo install nu_plugin_<plugin name>`.
 
 # Table of contents
 


### PR DESCRIPTION
As pointed out in https://github.com/nushell/nushell.github.io/issues/1788, the 0.102 release notes don't link to the list of core plugins. I threw in a link to https://www.nushell.sh/book/plugins.html#core-plugins