### PR TITLE
remove mention of `build-string` from coloring_and_theming.md

### DIFF
--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -425,7 +425,7 @@ The Nushell prompt is configurable through these environment variables and confi
 Example: For a simple prompt one could do this. Note that `PROMPT_COMMAND` requires a `block` whereas the others require a `string`.
 
 ```nu
-$env.PROMPT_COMMAND = { build-string (date now | format date '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
+$env.PROMPT_COMMAND = { $"(date now | format date '%m/%d/%Y %I:%M:%S%.3f'): (pwd | path basename)" }
 ```
 
 If you don't like the default `PROMPT_INDICATOR` you could change it like this.

--- a/de/book/coloring_and_theming.md
+++ b/de/book/coloring_and_theming.md
@@ -375,7 +375,7 @@ Der Nushell Prompt ist konfigurierbar mit diesen Umgebungsvariablen:
 Beispiel: Für einen einfachen Prompt wäre folgendes mögllich. Hinweis `PROMPT_COMMAND` benötigt einen `block` wogegen die anderen einen `string` erwarten.
 
 ```nu
-$env.PROMPT_COMMAND = { build-string (date now | format date '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
+$env.PROMPT_COMMAND = { $"(date now | format date '%m/%d/%Y %I:%M:%S%.3f'): (pwd | path basename)" }
 ```
 
 Soll der standard `PROMPT_INDICATOR` geändert werden, sieht das so aus.

--- a/zh-CN/book/coloring_and_theming.md
+++ b/zh-CN/book/coloring_and_theming.md
@@ -371,7 +371,7 @@ Nushell 的提示符可以通过这些环境变量进行配置：
 例如：对于一个简单的提示，我们可以这样做。注意`PROMPT_COMMAND`需要一个`block`而其他的需要一个`string`。
 
 ```nu
-$env.PROMPT_COMMAND = { build-string (date now | format date '%m/%d/%Y %I:%M:%S%.3f') ': ' (pwd | path basename) }
+$env.PROMPT_COMMAND = { $"(date now | format date '%m/%d/%Y %I:%M:%S%.3f'): (pwd | path basename)" }
 ```
 
 如果你不喜欢默认的`PROMPT_INDICATOR`，你可以这样改变它：


### PR DESCRIPTION
`build-string` command was apparently removed years ago and somehow survived in the docs until now. Brought to attention in https://github.com/nushell/nushell/issues/15116