### PR TITLE
Fix bad localhost link in TWiN 285

### DIFF
--- a/blog/2025-02-08-twin0285.md
+++ b/blog/2025-02-08-twin0285.md
@@ -12,7 +12,7 @@ Posted Friday, 2025-02-07.
 
 ## Highlights
 
-Since this was a release-week, a number of the changes below are included in the **[0.102.0 release](http://localhost:8080/blog/2025-02-04-nushell_0_102_0.html)**, a few were housekeeping tasks related
+Since this was a release-week, a number of the changes below are included in the **[0.102.0 release](/blog/2025-02-04-nushell_0_102_0.html)**, a few were housekeeping tasks related
 to the release, and some items will, of course, appear in nightly builds and `main` (and eventually 0.103).
 
 A belated thanks to **[@0x4D5352](https://github.com/0x4D5352)** for bringing much-needed consistency to the documentation. With output now commented out in code blocks, you can copy examples directly from the docs and paste them into Nushell.


### PR DESCRIPTION
Fix a bug where I Inadvertently copied the link to the release-notes from the dev-server and put a localhost link into production last week.