### PR TITLE
Fix outdated `config path` code block

### DIFF
--- a/es/book/configuracion.md
+++ b/es/book/configuracion.md
@@ -81,11 +81,7 @@ El archivo de configuración se carga desde una ubicación predeterminada. Para 
 
 ```nu
 config path
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- <value>
-───────────────────────────────────────
- /home/nusheller/.config/nu/config.toml
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# => /home/nusheller/.config/nu/config.toml
 ```
 
 ### Cargando la configuración desde un archivo


### PR DESCRIPTION
Although outdated, it's better to be *more* correct.

*Correct me if I'm missing something here, but I don't see what else the previous code block was meant to show.*