### PR TITLE
Consistently use `nu` as code block lang

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -136,7 +136,7 @@ The Standard Library also includes a helper command. The default `path add` beha
 a directory so that it has higher precedence than the rest of the path. For example, the following can be
 added to your startup config:
 
-```nushell
+```nu
 use std/util "path add"
 path add "~/.local/bin"
 path add ($env.CARGO_HOME | path join "bin")

--- a/book/operators.md
+++ b/book/operators.md
@@ -142,7 +142,7 @@ Suppose you have multiple lists you want to concatenate together, but you also w
 some individual values. This can be done with `append` and `prepend`, but the spread
 operator can let you do it more easily.
 
-```nushell
+```nu
 let dogs = [Spot, Teddy, Tommy]
 let cats = ["Mr. Humphrey Montgomery", Kitten]
 [
@@ -166,7 +166,7 @@ let cats = ["Mr. Humphrey Montgomery", Kitten]
 ```
 
 The below code is an equivalent version using `append`:
-```nushell
+```nu
 $dogs |
   append Polly |
   append ($cats | each { |elt| $"($elt) \(cat\)" }) |
@@ -186,7 +186,7 @@ only be used before variables (`...$foo`), subexpressions (`...(foo)`), and list
 The `...` also won't be recognized as the spread operator if there's any whitespace between it and
 the next expression:
 
-```nushell
+```nu
 [ ... [] ]
 # => ╭───┬────────────────╮
 # => │ 0 │ ...            │
@@ -201,14 +201,14 @@ This is mainly so that `...` won't be confused for the spread operator in comman
 Let's say you have a record with some configuration information and you want to add more fields to
 this record:
 
-```nushell
+```nu
 let config = { path: /tmp, limit: 5 }
 ```
 
 You can make a new record with all the fields of `$config` and some new additions using the spread
 operator. You can use the spread multiple records inside a single record literal.
 
-```nushell
+```nu
 {
   ...$config,
   users: [alice bob],
@@ -244,7 +244,7 @@ external command.
 
 Here is an example custom command that has a rest parameter:
 
-```nushell
+```nu
 def foo [ --flag req opt? ...args ] { [$flag, $req, $opt, $args] | to nuon }
 ```
 
@@ -255,7 +255,7 @@ If you have a list of arguments to pass to `args`, you can spread it the same wa
 [inside a list literal](#in-list-literals). The same rules apply: the spread operator is only
 recognized before variables, subexpressions, and list literals, and no whitespace is allowed in between.
 
-```nushell
+```nu
 foo "bar" "baz" ...[1 2 3] # With ..., the numbers are treated as separate arguments
 # => [false, bar, baz, [1, 2, 3]]
 foo "bar" "baz" [1 2 3] # Without ..., [1 2 3] is treated as a single argument
@@ -265,7 +265,7 @@ foo "bar" "baz" [1 2 3] # Without ..., [1 2 3] is treated as a single argument
 A more useful way to use the spread operator is if you have another command with a rest parameter
 and you want it to forward its arguments to `foo`:
 
-```nushell
+```nu
 def bar [ ...args ] { foo --flag "bar" "baz" ...$args }
 bar 1 2 3
 # => [true, bar, baz, [1, 2, 3]]
@@ -273,14 +273,14 @@ bar 1 2 3
 
 You can spread multiple lists in a single call, and also intersperse individual arguments:
 
-```nushell
+```nu
 foo "bar" "baz" 1 ...[2 3] 4 5 ...(6..9 | take 2) last
 # => [false, bar, baz, [1, 2, 3, 4, 5, 6, 7, last]]
 ```
 
 Flags/named arguments can go after a spread argument, just like they can go after regular rest arguments:
 
-```nushell
+```nu
 foo "bar" "baz" 1 ...[2 3] --flag 4
 # => [true, bar, baz, [1, 2, 3, 4]]
 ```
@@ -288,7 +288,7 @@ foo "bar" "baz" 1 ...[2 3] --flag 4
 If a spread argument comes before an optional positional parameter, that optional parameter is treated
 as being omitted:
 
-```nushell
+```nu
 foo "bar" ...[1 2] "not opt" # The null means no argument was given for opt
 # => [false, bar, null, [1, 2, "not opt"]]
 ```

--- a/book/pipelines.md
+++ b/book/pipelines.md
@@ -64,13 +64,13 @@ Compare the following two command-lines that create a directory with tomorrow's 
 
 Using subexpressions:
 
-```nushell
+```nu
 mkdir $'((date now) + 1day | format date '%F') Report'
 ```
 
 or using pipelines:
 
-```nushell
+```nu
 date now                    # 1: today
 | $in + 1day                # 2: tomorrow
 | format date '%F'          # 3: Format as YYYY-MM-DD
@@ -95,7 +95,7 @@ Let's examine the contents of `$in` on each line of the above example:
 
 Certain [filter commands](/commands/categories/filters.html) may modify the pipeline input to their closure in order to provide more convenient access to the expected context. For example:
 
-```nushell
+```nu
 1..10 | each {$in * 2}
 ```
 
@@ -103,13 +103,13 @@ Rather than referring to the entire range of 10 digits, the `each` filter modifi
 
 In most filters, the pipeline input and its resulting `$in` will be the same as the closure parameter. For the `each` filter, the following example is equivalent to the one above:
 
-```nushell
+```nu
 1..10 | each {|value| $value * 2}
 ```
 
 However, some filters will assign an even more convenient value to their closures' input. The `update` filter is one example. The pipeline input to the `update` command's closure (as well as `$in`) refers to the _column_ being updated, while the closure parameter refers to the entire record. As a result, the following two examples are also equivalent:
 
-```nushell
+```nu
 ls | update name {|file| $file.name | str upcase}
 ls | update name {str upcase}
 ```
@@ -257,7 +257,7 @@ While `$in` can be reused as demonstrated above, assigning its value to another 
 
 Example:
 
-```nushell
+```nu
 def "date info" [] {
   let day = $in
   print ($day | format date '%v')
@@ -400,7 +400,7 @@ Are one and the same.
 ::: tip Note
 The phrase _"are one and the same"_ above only applies to the graphical output in the shell, it does not mean the two data structures are the same:
 
-```nushell
+```nu
 (ls) == (ls | table)
 # => false
 ```

--- a/book/testing.md
+++ b/book/testing.md
@@ -6,7 +6,7 @@ Nushell provides a set of "assertion" commands in the standard library.
 One could use built-in equality / order tests such as `==` or `<=` or more complex commands and throw errors manually when an expected condition fails, but using what the standard library has to offer is arguably easier!
 
 In the following, it will be assumed that the `std assert` module has been imported inside the current scope
-```nushell
+```nu
 use std assert
 ```
 
@@ -132,7 +132,7 @@ The convention is that any command fully exported from the `tests` module will b
 If your Nushell script or module is not part of a [Nupm] package, the simplest way is to write tests in standalone scripts and then call them, either from a `Makefile` or in a CI:
 
 Let's say we have a simple `math.nu` module which contains a simple Fibonacci command:
-```nushell
+```nu
 # `fib n` is the n-th Fibonacci number
 export def fib [n: int] [ nothing -> int ] {
     if $n == 0 {
@@ -145,7 +145,7 @@ export def fib [n: int] [ nothing -> int ] {
 }
 ```
 then a test script called `tests.nu` could look like
-```nushell
+```nu
 use math.nu fib
 use std assert
 
@@ -171,7 +171,7 @@ It is also possible to define tests in Nushell as functions with descriptive nam
 them dynamically without requiring a [Nupm] package. The following uses `scope commands` and a
 second instance of Nushell to run the generated list of tests.
 
-```nushell
+```nu
 use std assert
 
 source fib.nu

--- a/contributor-book/plugin_protocol_reference.md
+++ b/contributor-book/plugin_protocol_reference.md
@@ -232,7 +232,7 @@ Returns the result of following a numeric cell path (e.g. `$custom_value.0`) on 
 
 Example:
 
-```nushell
+```nu
 $version.0
 ```
 
@@ -273,7 +273,7 @@ Returns the result of following a string cell path (e.g. `$custom_value.field`) 
 
 Example:
 
-```nushell
+```nu
 $version.field
 ```
 
@@ -357,7 +357,7 @@ Returns the result of evaluating an [`Operator`](#operator) on this custom value
 
 Example:
 
-```nushell
+```nu
 $version + 7
 ```
 
@@ -1360,7 +1360,7 @@ A boolean.
 
 Example:
 
-```nushell
+```nu
 true
 ```
 
@@ -1387,7 +1387,7 @@ A 64-bit signed integer.
 
 Example:
 
-```nushell
+```nu
 -2
 ```
 
@@ -1414,7 +1414,7 @@ A 64-bit (double precision) floating point number.
 
 Example:
 
-```nushell
+```nu
 36.4
 ```
 
@@ -1441,7 +1441,7 @@ A quantity of bytes, internally a 64-bit signed integer representing the number 
 
 Example:
 
-```nushell
+```nu
 32.4MiB
 ```
 
@@ -1468,7 +1468,7 @@ A duration of time, internally a 64-bit signed integer representing the number o
 
 Example:
 
-```nushell
+```nu
 8375604528ns
 ```
 
@@ -1495,7 +1495,7 @@ A date/time value, including the time zone, represented in [RFC 3339](https://ww
 
 Example:
 
-```nushell
+```nu
 1996-12-19T16:39:57-08:00
 ```
 
@@ -1532,7 +1532,7 @@ A range of values.
 
 Examples:
 
-```nushell
+```nu
 0..
 ```
 
@@ -1554,7 +1554,7 @@ Examples:
 }
 ```
 
-```nushell
+```nu
 7..10
 ```
 
@@ -1576,7 +1576,7 @@ Examples:
 }
 ```
 
-```nushell
+```nu
 7..<10
 ```
 
@@ -1598,7 +1598,7 @@ Examples:
 }
 ```
 
-```nushell
+```nu
 0..64..128
 ```
 
@@ -1632,7 +1632,7 @@ Identical to [`IntRange`](#intrange) but for floats instead.
 
 Example:
 
-```nushell
+```nu
 7.5..10.5
 ```
 
@@ -1665,7 +1665,7 @@ A UTF-8 string.
 
 Example:
 
-```nushell
+```nu
 "Hello, nu!"
 ```
 
@@ -1695,7 +1695,7 @@ If `no_expand` is true, the expansion of wildcards is disabled and this just act
 
 Example:
 
-```nushell
+```nu
 "src/**/*.rs" | into glob
 ```
 
@@ -1723,7 +1723,7 @@ An associative key-value map. If records are contained in a list, this renders a
 
 Example:
 
-```nushell
+```nu
 {foo: 5, bar: "hello nushell"}
 ```
 
@@ -1769,7 +1769,7 @@ A list of values of any type.
 
 Example:
 
-```nushell
+```nu
 [1, 2, foo, bar]
 ```
 
@@ -1865,7 +1865,7 @@ The plugin **should not** try to inspect the contents of the closure. It is reco
 
 Example:
 
-```nushell
+```nu
 let foo = "bar"
 { || $foo }
 ```
@@ -1908,7 +1908,7 @@ The absence of a value, represented by `null` within Nushell.
 
 Example:
 
-```nushell
+```nu
 null
 ```
 
@@ -1934,7 +1934,7 @@ An error contained within a value. Trying to operate on the value will most like
 
 Example:
 
-```nushell
+```nu
 error make {
   msg: "foo"
   label: {
@@ -1983,7 +1983,7 @@ Note that the encoding of byte arrays in [JSON](#json) and [MessagePack](#messag
 
 Example:
 
-```nushell
+```nu
 0x[aa bb cc dd]
 ```
 
@@ -2026,7 +2026,7 @@ Optional path members will not cause errors if they can't be accessed - the path
 
 Example:
 
-```nushell
+```nu
 foo.0?.bar
 # [foo {value: 0, optional: true} bar] | into cell-path
 ```

--- a/cookbook/ssh_agent.md
+++ b/cookbook/ssh_agent.md
@@ -6,7 +6,7 @@ title: ssh-agent
 
 `eval` is not available in nushell, so run:
 
-```nushell
+```nu
 ^ssh-agent -c
     | lines
     | first 2
@@ -23,7 +23,7 @@ See the workarounds.
 
 Alternatively, use the third-party Nu plugin [bash-env](https://github.com/tesujimath/nu_plugin_bash_env) as follows.
 
-```nushell
+```nu
 ^ssh-agent | bash-env | load-env
 ```
 
@@ -37,7 +37,7 @@ All issues and requests for support should be directed to its own
 
 You can work around this behavior by checking if a ssh-agent is already running on your user, and start one if none is:
 
-```nushell
+```nu
 do --env {
     let ssh_agent_file = (
         $nu.temp-path | path join $"ssh-agent-($env.USER? | default $env.USERNAME).nuon"
@@ -66,7 +66,7 @@ do --env {
 
 ### [Keychain](https://www.funtoo.org/Funtoo:Keychain)
 
-```nushell
+```nu
 keychain --eval --quiet <your ssh keys, eg. id_ed25519>
     | lines
     | where not ($it | is-empty)
@@ -102,6 +102,6 @@ However, if you're using a different service manager, please refer its own docum
 
 To enable Nushell to access this socket, you need to add its path as `$env.SSH_AUTH_SOCK` like so:
 
-```nushell
+```nu
 $env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR)/ssh-agent.socket"
 ```

--- a/de/book/custom_commands.md
+++ b/de/book/custom_commands.md
@@ -6,7 +6,7 @@ Hier kommen eigene Befehle ins Spiel.
 
 Eine beispielhafte Definition eines eigenen Befehls sieht wie folgt aus:
 
-```nushell
+```nu
 def greet [name] {
   echo "hello" $name
 }
@@ -39,7 +39,7 @@ _Hinweis: Es wird empfohlen Worte in Befehlen mit `-` zur besseren Lesbarkeit zu
 
 Es ist auch möglich Unterbefehle zu definieren. Dazu wird der Unterbefehl vom Superbefehl durch ein Leerzeichen getrennt. Wenn beispielsweise der Befehl `str` durch einen Unterbefehl `mycommand` erweitert werden soll, funktioniert das wie folgt:
 
-```nushell
+```nu
 def "str mycommand" [] {
   echo hello
 }
@@ -55,7 +55,7 @@ str mycommand
 
 Wenn eigene Befehle definiert werden, kann optional auch der Typ jedes Parameters angegeben werden. Das obige Beispiel kann beispielsweise wie folgt abgeändert werden:
 
-```nushell
+```nu
 def greet [name: string] {
   echo "hello" $name
 }
@@ -65,7 +65,7 @@ Die Typen der Parameter anzugeben ist optional. Nushell erlaubt es diese wegzula
 
 Beispielhaft soll nur noch ein `int` als Typ erlaubt sein:
 
-```nushell
+```nu
 def greet [name: int] {
   echo "hello" $name
 }
@@ -116,7 +116,7 @@ Zusätzlich zu den obigen Parametern, können auch namenabhängige Parameter ver
 
 Zum Beispiel:
 
-```nushell
+```nu
 def greet [
   name: string
   --age: int
@@ -149,7 +149,7 @@ Flags können auch so definiert werden, dass es eine Kurzform gibt. Das erlaubt 
 
 Das Beispiel wird hier, um eine Kurzform für die Flag `age` erweitert:
 
-```nushell
+```nu
 def greet [
   name: string
   --age (-a): int
@@ -172,7 +172,7 @@ Um Nutzern eines eigenen Befehls zu helfen, können diese und ihre Parameter mit
 
 Es wird weiterhin das obige Beispiel verwendet:
 
-```nushell
+```nu
 def greet [
   name: string
   --age (-a): int
@@ -199,7 +199,7 @@ Wie zu sehen ist, werden der Parameter und die Flag, die definiert wurden, aufge
 
 Um diese Hilfe zu verbessern, können Beschreibungen zur Definition hinzugefügt werden:
 
-```nushell
+```nu
 # A greeting command that can greet the caller
 def greet [
   name: string      # The name of the person to greet
@@ -231,13 +231,13 @@ Flags:
 
 Eigene Befehle streamen ihre Ausgabe gleich wie eingebaute Befehle. Beispielsweise soll die folgende Pipeline umgebaut werden:
 
-```nushell
+```nu
 > ls | get name
 ```
 
 `ls` soll jetzt in einen neuen, eigenen Befehl verschoben werden:
 
-```nushell
+```nu
 def my-ls [] { ls }
 ```
 
@@ -260,7 +260,7 @@ Eigene Befehle können, wie andere Befehle, auch Eingaben verarbeiten. Diese Ein
 
 Hier soll nun beispielhaft ein eigener echo-Befehl definiert werden, der eine weitere Zeile nach jeder Zeile der Eingabe ausgibt:
 
-```nushell
+```nu
 def my-echo [] {
   each {
     echo $it "--"

--- a/de/book/pipeline.md
+++ b/de/book/pipeline.md
@@ -24,7 +24,7 @@ Andere Arten von Output geben die Daten aus der Pipeline zum Beispiel auf der Ko
 
 Die `$in` Variable sammelt die Daten in der Pipeline in einen Wert, um den ganzen Strom als Parameter verwenden zu können:
 
-```nushell
+```nu
 echo 1 2 3 | $in.1 * $in.2
 # => 6
 ```
@@ -33,7 +33,7 @@ echo 1 2 3 | $in.1 * $in.2
 
 Wenn eine Pipeline etwas lange wird für eine Zeile, kann sie mit `(` und `)` zu Unterausdrücken unterteilt werden:
 
-```nushell
+```nu
 (
     "01/22/2021" |
     parse "{month}/{day}/{year}" |

--- a/lang-guide/chapters/pipelines.md
+++ b/lang-guide/chapters/pipelines.md
@@ -17,7 +17,7 @@ You can handle stderr in multiple ways:
 
 For the next examples, let's assume this file:
 
-```nushell
+```nu
 # demo.nu
 print "foo"
 print -e "barbar"
@@ -160,7 +160,7 @@ It runs `(^cmd1 | ^cmd2; ^cmd3 | ^cmd4)` first, then pipes *stdout and stderr* t
 ### Examples for custom command
 Given the following custom commands
 
-```nushell
+```nu
 def custom-cmd [] {
     ^cmd1 | ^cmd2
     ^cmd3 | ^cmd4


### PR DESCRIPTION
CONTRIBUTING.md defines a preference of `nu` over `nushell`, which overwhelmingly matches our code blocks.

These 66 occurrences were the outliers.