### PR TITLE
fix(setup.md): Quote the EDITOR value

### DIFF
--- a/cookbook/setup.md
+++ b/cookbook/setup.md
@@ -49,7 +49,7 @@ Note: if you've never used `vim` before and you want to leave typing `:q!` will 
 Go to the end of the file and add
 
 ```nu
-$env.EDITOR = vim
+$env.EDITOR = 'vim'
 ```
 
 or `emacs`, `vscode` or whatever editor you like. Don't forget that the program needs to be accessible on the `PATH`


### PR DESCRIPTION
help: the parsing of assignments was changed in 0.97.0, and this would have previously been treated as a string. 

Alternatively, quote the string with single or double
        quotes to avoid it being interpreted as a command name. This restriction may be removed in a future release.