### PR TITLE
Fix a typo in range type explanation

### DIFF
--- a/lang-guide/chapters/types/basic_types/range.md
+++ b/lang-guide/chapters/types/basic_types/range.md
@@ -14,7 +14,7 @@
 
    Examples:
 
-   - Values from 1 to 10 inclusive:
+   - Values from 1 to 5 inclusive:
 
    ```nu
    > 1..5


### PR DESCRIPTION
I've corrected a typo in the numbers. (10 → 5)