### PR TITLE
Correct the tip for changing completion prompt marker

### DIFF
--- a/book/custom_completions.md
+++ b/book/custom_completions.md
@@ -29,7 +29,7 @@ In the second line, `string@animals` tells Nushell two things—the shape of the
 The third line is demonstration of the completion. Type the name of the custom command `my-command`, followed by a space, and then the <kbd>Tab</kbd> key. This displays a menu with the possible completions. Custom completions work the same as other completions in the system, allowing you to type `e` followed by the <kbd>Tab</kbd> key to complete "eel" automatically.
 
 ::: tip
-When the completion menu is displayed, the prompt changes to include the `|` character by default. This can be changed using `$env.config.menus.marker`.
+When the completion menu is displayed, the prompt changes to include the `|` character by default. To change the prompt marker, modify the `marker` value of the record, where the `name` key is `completion_menu`, in the `$env.config.menus` list.  See also [the completion menu configuration](/book/line_editor.md#completion-menu).
 :::
 
 ::: tip


### PR DESCRIPTION
I've updated the documentation to clarify how to change the prompt marker for the completion menu, specifically, modified the instructions to reflect that the `marker` value in the `$env.config.menus` list should be changed where the `name` key is `completion_menu`.
