### PR TITLE
Fix 0.103.0 release notes help command reference

### DIFF
--- a/blog/2025-03-18-nushell_0_103_0.md
+++ b/blog/2025-03-18-nushell_0_103_0.md
@@ -88,7 +88,7 @@ With [#14906](https://github.com/nushell/nushell/pull/14906), attributes can now
 This release includes two built-in attributes:
 
 - `@example`: Adds an example usage for the command.
-- `@search-terms`: Adds search terms that can help users discover the command with `find -f`.
+- `@search-terms`: Adds search terms that can help users discover the command with `help --find` (or `help -f`).
 
 Users can add their own attributes which will be available in the structured-data documentation accessible via
 `help commands` and `scope commands`.


### PR DESCRIPTION
`find -f` does not exist. It should be `help -f`.

I decided to primarily use `--find` instead of `-f` to make it clear what the command parameter is for.