### PR TITLE
Correct light theme instructions to use module

### DIFF
--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -597,7 +597,7 @@ if you want to go full-tilt on theming, you'll want to theme all the items I men
 
 ### Working on Light Background Terminal
 
-Nushell's [standard library](https://www.nushell.sh/book/standard_library.html) contains a `config` module with default light and dark themes.
+Nushell's [standard library](/book/standard_library.md) contains a `config` module with default light and dark themes.
 If you are working on a light background terminal, you can apply the light theme easily.
 
 ```nu

--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -597,25 +597,30 @@ if you want to go full-tilt on theming, you'll want to theme all the items I men
 
 ### Working on Light Background Terminal
 
-Nushell's default config file contains a light theme definition, if you are working on a light background terminal, you can apply the light theme easily.
+Nushell's [standard library](https://www.nushell.sh/book/standard_library.html) contains a `config` module with default light and dark themes.
+If you are working on a light background terminal, you can apply the light theme easily.
 
 ```nu
 # in $nu.config-path
+use config light-theme   # add this line to load the theme into scope
+
 $env.config = {
-  ...
-  color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
-  ...
+  # ...
+  color_config: (light_theme)   # if you want a light theme, replace `$dark_theme` to `$light_theme`
+  # ...
 }
 ```
 
-You can just change it to light theme by replacing `$dark_theme` to `$light_theme`
+You can also load the dark theme.
 
 ```nu
 # in $nu.config-path
+use config dark-theme
+
 $env.config = {
-  ...
-  color_config: $light_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
-  ...
+  # ...
+  color_config: (dark_theme)
+  # ...
 }
 ```
 


### PR DESCRIPTION
The instructions for using Nushell with the light theme used defunct variables.

The updated instructions import the values from `config` instead, which works on my machine. 

- I'm new to Nushell; I think my instructions just put the `light-theme` and `dark-theme` variables in scope, but I'm not sure. 
- I have not tested the website since I do not think my changes are just to content and I'm not confident doing the setup.