### PR TITLE
Add note about breaking completions change to 0.103.0 changelog

### DIFF
--- a/blog/2025-03-18-nushell_0_103_0.md
+++ b/blog/2025-03-18-nushell_0_103_0.md
@@ -46,6 +46,7 @@ As part of this release, we also publish a set of [optional plugins](https://www
     - [_`PROMPT_\*` environment variables are no longer inherited\_](#prompt-environment-variables-are-no-longer-inherited-toc)
     - [_Closure serialization changes_](#closure-serialization-changes-toc)
     - [_Filesize unit formatting_](#filesize-unit-formatting-toc)
+    - [_External completers are no longer used for internal commands_](#external-completers-are-no-longer-used-for-internal-commands-toc)
   - [_Removals_](#removals-toc)
     - [_`range`_](#range-toc)
     - [_`into bits`_](#into-bits-toc)
@@ -314,6 +315,36 @@ option with all of these commands, in which case a string-representation of the 
 ### Filesize unit formatting [[toc](#table-of-contents)]
 
 When setting a specific filesize unit via `$env.config.filesize.unit`, sizes will now be formatted using the default locale (e.g., separators and decimals). This returns a similar 0.98 behavior.
+
+### External completers are no longer used for internal commands [[toc](#table-of-contents)]
+
+Prior to [#15086](https://github.com/nushell/nushell/pull/15086), internal commands (including custom commands and aliases) without [custom completions](https://www.nushell.sh/book/custom_completions.html#custom-completions) would fall back to the external completer. After this PR, internal commands will not use the external completer.
+
+::: tip Note
+The zoxide completer previously listed in the cookbook relied on this functionality. To update your zoxide completer to be compatible, you can (optionally) remove your external zoxide completer, add this to your config:
+
+```nu
+def "nu-complete zoxide path" [context: string] {
+  let parts = $context | split row " " | skip 1
+  {
+    options: {
+      sort: false
+      completion_algorithm: prefix
+      positional: false
+      case_sensitive: false
+    }
+    completions: (zoxide query --list --exclude $env.PWD -- ...$parts | lines)
+  }
+}
+
+def --env --wrapped z [...rest: string@"nu-complete zoxide path"] {
+  __zoxide_z ...$rest
+}
+```
+
+Note, if your zoxide configuration from `zoxide init` is in a vendor autoload, you should also add the above snippet to either a vendor autoload or user autoload, so that the `__zoxide_z` command is defined.
+
+:::
 
 ## Removals [[toc](#table-of-contents)]
 


### PR DESCRIPTION
Adds a note about the missed breaking change, including how to update your zoxide completer.

Related: #1845, #1847