### PR TITLE
Correct `date now` docs to reflect current behavior.

### DIFF
--- a/commands/docs/date_now.md
+++ b/commands/docs/date_now.md
@@ -35,6 +35,12 @@ Get the current date and display it in a given format string.
 
 ```
 
+Get current time in full RFC 3339 format with time zone.
+```nu
+> date now | format date %+
+
+```
+
 Get the time duration since 2019-04-30.
 ```nu
 > (date now) - 2019-05-01
@@ -47,8 +53,8 @@ Get the time duration since a more specific time.
 
 ```
 
-Get current time in full RFC 3339 format with time zone.
+Get current time in RFC 2289 format with time zone.
 ```nu
-> date now | debug
+> date now | format date
 
 ```

--- a/commands/docs/format_date.md
+++ b/commands/docs/format_date.md
@@ -68,3 +68,14 @@ Format a given date using a given format string.
 > "2021-10-22 20:00:12 +01:00" | format date "%Y-%m-%d"
 2021-10-22
 ```
+
+Format a given date-time using RFC3339 format.
+```nu
+> "2021-10-22 20:00:12 +01:00" | format date %+
+2021-10-22T20:00:12+01:00
+```
+
+Format current date-time using RFC3339 format.
+```nu
+> date now | format date %+
+```


### PR DESCRIPTION
`date now` command documentation shows how to correctly output RFC3339 format.
`format date` command documentation shows how to format to RFC3339 format.

FIXES: nushell/nushell#15168