### PR TITLE
chore: move 'job' from strings category to experimental

### DIFF
--- a/commands/docs/job.md
+++ b/commands/docs/job.md
@@ -1,7 +1,7 @@
 ---
 title: job
 categories: |
-  strings
+  experimental
 version: 0.103.0
 strings: |
   Various commands for working with background jobs.


### PR DESCRIPTION
seems like the job command doc was copied from something in strings; this moves it over to experimental with the rest of the job commands.

the other change is from my markdown linter.