### PR TITLE
Update Cookbook direnv instructions for new std helper

### DIFF
--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -11,23 +11,21 @@ Configuring direnv to work with nushell requires nushell version 0.66 or later.
 
 ### Configuring direnv
 
-To make direnv work with nushell the way it does with other shells, we can use the "hooks" functionality:
+To make direnv work with nushell the way it does with other shells, we can use the "hooks" functionality along with:
+
+- [`load-env`](/commands/docs/load-env.md)
+- An `env-conversion` helper for the `PATH` from the [Standard Library](/book/standard_library.md)
 
 ```nu
-$env.config = {
-  hooks: {
-    pre_prompt: [{ ||
-      if (which direnv | is-empty) {
-        return
-      }
-
-      direnv export json | from json | default {} | load-env
-      if 'ENV_CONVERSIONS' in $env and 'PATH' in $env.ENV_CONVERSIONS {
-        $env.PATH = do $env.ENV_CONVERSIONS.PATH.from_string $env.PATH
-      }
-    }]
+use std/config *
+$env.config.hooks.pre_prompt = [{||
+  if (which direnv | is-empty) {
+    return
   }
-}
+
+  direnv export json | from json | default {} | load-env
+  $env.PATH = do (env-conversions).path.from_string $env.PATH
+}]
 ```
 
 ::: tip Note


### PR DESCRIPTION
As mentioned in https://github.com/nushell/nushell/pull/15569 - This updates the `direnv` formula in the Cookbook to utilize the new `std/config env-conversions` helper.