### PR TITLE
Update pipelines.md

### DIFF
--- a/book/pipelines.md
+++ b/book/pipelines.md
@@ -434,13 +434,13 @@ You decided to use `grep` and [pipe](https://www.nushell.sh/book/pipelines.html)
 
 ```nu
 ls /usr/share/nvim/runtime/ | get name | ^grep tutor | ^ls -la $in
-# => ls: cannot access ''$'\342\224\202'' 32 '$'\342\224\202'' /usr/share/nvim/runtime/tutor        '$'\342\224\202\n': No such file or directory
+# => ls: │ 32 │ /usr/share/nvim/runtime/tutor         │: No such file or directory
 ```
 
 What's wrong? Nushell renders lists and tables (by adding a border with characters like `╭`,`─`,`┬`,`╮`) before piping them as text to external commands. If that's not the behavior you want, you must explicitly convert the data to a string before piping it to an external. For example, you can do so with [`to text`](/commands/docs/to_text.md):
 
 ```nu
-ls /usr/share/nvim/runtime/ | get name | to text | ^grep tutor | tr -d '\n' | ^ls -la $in
+ls /usr/share/nvim/runtime/ | get name | to text | ^grep tutor | ^ls -la $in
 # => total 24
 # => drwxr-xr-x@  5 pengs  admin   160 14 Nov 13:12 .
 # => drwxr-xr-x@  4 pengs  admin   128 14 Nov 13:42 en


### PR DESCRIPTION
If there is only one file or folder named "tutor" in `/usr/share/nvim/runtime/`, removing `tr -d '\n'` does not affect the command's execution. However, if `/usr/share/nvim/runtime/` contains other files or folders besides "tutor" whose names also include "tutor" (like "tutor100" or "123tutor"), then running both `ls /usr/share/nvim/runtime/ | get name | ^grep tutor | ^ls -la $in` and `ls /usr/share/nvim/runtime/ | get name | to text | ^grep tutor | tr -d '\n' | ^ls -la $in` will result in an error.