### PR TITLE
Update external_completers.md - Fix fish quotes for ISS1881

### DIFF
--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -20,7 +20,7 @@ This completer will use [the fish shell](https://fishshell.com/) to handle compl
 
 ```nu
 let fish_completer = {|spans|
-    fish --command $'complete "--do-complete=($spans | str join " ")"'
+    fish --command $"complete '--do-complete=($spans | str join ' ')'"
     | from tsv --flexible --noheaders --no-infer
     | rename value description
     | update value {


### PR DESCRIPTION
Invert fish quotes to prevent issues where the output is a single double quote, breaking the string substitution

https://github.com/nushell/nushell.github.io/issues/1881

the TL;DR above is that if you do something like `cat <TAB>` instead of `cat scri<TAB>` the string substitution would break from some funky nushell quoting issues.

cc @ysthakur