### PR TITLE
Fix example multi-dot shortcut path expansion

### DIFF
--- a/book/moving_around.md
+++ b/book/moving_around.md
@@ -184,7 +184,7 @@ cd ....
 ```
 
 ::: tip
-Multi-dot shortcuts are available to both internal Nushell [filesystem commands](/commands/categories/filesystem.html) as well as to external commands. For example, running `^stat ....` on a Linux/Unix system will show that the path is expanded to `../../../..`
+Multi-dot shortcuts are available to both internal Nushell [filesystem commands](/commands/categories/filesystem.html) as well as to external commands. For example, running `^stat ....` on a Linux/Unix system will show that the path is expanded to `../../..`
 :::
 
 You can combine relative directory levels with directory names as well:


### PR DESCRIPTION
The ['Multi-dot shortcuts' tip](https://github.com/nushell/nushell.github.io/blob/6a606e722830622da42684091db24d4a35059443/book/moving_around.md?plain=1#L186-L188) suggests that running `^stat ....` expands to `../../../..` but this contradicts a [previous example](https://github.com/nushell/nushell.github.io/blob/6a606e722830622da42684091db24d4a35059443/book/moving_around.md?plain=1#L181-L182) demonstrating that `cd ....` is used to go up three levels, not four.

Running `^stat .... | head -1` on Fedora 42 yields:

```shell
  File: ../../..
```

And on macOS Sequoia, `^stat -x .... | head -1` produces:

```shell
  File: "../../.."
```

The expanded path in the example should read: `../../..` (i.e. three levels).
