### PR TITLE
Remove note about issue #15326

### DIFF
--- a/lang-guide/chapters/pipelines.md
+++ b/lang-guide/chapters/pipelines.md
@@ -130,12 +130,6 @@ It runs `(^cmd1 | ^cmd2; ^cmd3 | ^cmd4)` first, then pipes _stdout and stderr_ t
 | cmd3    | Piped    | Terminal |
 | cmd4    | Piped    | Piped    |
 
-::: warning
-
-Please note that the following 3 examples are currently broken due to a regression documented [issue #15326](https://github.com/nushell/nushell/issues/15326).
-
-:::
-
 - (^cmd1 | ^cmd2; ^cmd3 | ^cmd4) o> test.out
 
 | Command | Stdout | Stderr   |


### PR DESCRIPTION
I think the warning session can be removed because the relative issues is resolved.
https://github.com/nushell/nushell/issues/15561
https://github.com/nushell/nushell/issues/15416