### PR TITLE
Fix hooks.md basic hooks examples and hooks list

### DIFF
--- a/book/hooks.md
+++ b/book/hooks.md
@@ -28,15 +28,11 @@ The steps to evaluate one line in the REPL mode are as follows:
 To enable hooks, define them in your [config](configuration.md):
 
 ```nu
-$env.config = {
-    # ...other config...
-
-    hooks: {
-        pre_prompt: { print "pre prompt hook" }
-        pre_execution: { print "pre exec hook" }
-        env_change: {
-            PWD: {|before, after| print $"changing directory from ($before) to ($after)" }
-        }
+$env.config.hooks = {
+    pre_prompt: [{ print "pre prompt hook" }]
+    pre_execution: [{ print "pre exec hook" }]
+    env_change: {
+        PWD: [{|before, after| print $"changing directory from ($before) to ($after)" }]
     }
 }
 ```
@@ -47,38 +43,28 @@ When you change a directory, the `PWD` environment variable changes and the chan
 Instead of defining just a single hook per trigger, it is possible to define a **list of hooks** which will run in sequence:
 
 ```nu
-$env.config = {
-    ...other config...
-
-    hooks: {
-        pre_prompt: [
-            { print "pre prompt hook" }
-            { print "pre prompt hook2" }
+$env.config.hooks = {
+    pre_prompt: [
+        { print "pre prompt hook" }
+        { print "pre prompt hook2" }
+    ]
+    pre_execution: [
+        { print "pre exec hook" }
+        { print "pre exec hook2" }
+    ]
+    env_change: {
+        PWD: [
+            {|before, after| print $"changing directory from ($before) to ($after)" }
+            {|before, after| print $"changing directory from ($before) to ($after) 2" }
         ]
-        pre_execution: [
-            { print "pre exec hook" }
-            { print "pre exec hook2" }
-        ]
-        env_change: {
-            PWD: [
-                {|before, after| print $"changing directory from ($before) to ($after)" }
-                {|before, after| print $"changing directory from ($before) to ($after) 2" }
-            ]
-        }
     }
 }
 ```
 
-Also, it might be more practical to update the existing config with new hooks, instead of defining the whole config from scratch:
+Instead of replacing all hooks, you can append a new hook to existing configuration:
 
 ```nu
-$env.config = ($env.config | upsert hooks {
-    pre_prompt: ...
-    pre_execution: ...
-    env_change: {
-        PWD: ...
-    }
-})
+$env.config.hooks.pre_execution = $env.config.hooks.pre_execution | append { print "pre exec hook3" }
 ```
 
 ## Changing Environment

--- a/de/book/hooks.md
+++ b/de/book/hooks.md
@@ -28,15 +28,11 @@ Die Schritte zur Auswertung einer Zeile im REPL-Modus sind wie folgt:
 Um Hooks zu aktivieren, werden sie in der [config](configuration.md) definiert:
 
 ```nu
-$env.config = {
-    # ...other config...
-
-    hooks: {
-        pre_prompt: { print "pre prompt hook" }
-        pre_execution: { print "pre exec hook" }
-        env_change: {
-            PWD: {|before, after| print $"changing directory from ($before) to ($after)" }
-        }
+$env.config.hooks = {
+    pre_prompt: [{ print "pre prompt hook" }]
+    pre_execution: [{ print "pre exec hook" }]
+    env_change: {
+        PWD: [{|before, after| print $"changing directory from ($before) to ($after)" }]
     }
 }
 ```
@@ -47,39 +43,28 @@ Die Änderung löst den Hook aus und tauscht die entsprechenden Werte in `before
 Anstatt nur einen einzigen Hook pro Trigger zu definieren, ist es möglich, eine *Liste von Hooks* zu definieren, die nacheinander durchlaufen werden:
 
 ```nu
-$env.config = {
-    ...other config...
-
-    hooks: {
-        pre_prompt: [
-            { print "pre prompt hook" }
-            { print "pre prompt hook2" }
+$env.config.hooks = {
+    pre_prompt: [
+        { print "pre prompt hook" }
+        { print "pre prompt hook2" }
+    ]
+    pre_execution: [
+        { print "pre exec hook" }
+        { print "pre exec hook2" }
+    ]
+    env_change: {
+        PWD: [
+            {|before, after| print $"changing directory from ($before) to ($after)" }
+            {|before, after| print $"changing directory from ($before) to ($after) 2" }
         ]
-        pre_execution: [
-            { print "pre exec hook" }
-            { print "pre exec hook2" }
-        ]
-        env_change: {
-            PWD: [
-                {|before, after| print $"changing directory from ($before) to ($after)" }
-                {|before, after| print $"changing directory from ($before) to ($after) 2" }
-            ]
-        }
     }
 }
 ```
 
-Auch könnte es praktischer sein, die bestehende Konfiguration mit neuen Hooks zu aktualisieren,
-anstatt die gesamte Konfiguration von Grund auf neu zu definieren:
+Anstatt alle hooks zu ersetzen können neue Hooks der Liste vorhandener Hooks angehängt werden:
 
 ```nu
-$env.config = ($env.config | upsert hooks {
-    pre_prompt: ...
-    pre_execution: ...
-    env_change: {
-        PWD: ...
-    }
-})
+$env.config.hooks.pre_execution = $env.config.hooks.pre_execution | append { print "pre exec hook3" }
 ```
 
 ## Changing Environment


### PR DESCRIPTION
Fix hooks syntax; they are a list of values. The code as it was did not run.

Nushell has been using an inherent configuration and the user configuration only replacing parts. For the hooks it makes sense to set only the hooks value.

Replace "you can also use a list", which is the default and used above already, with a "you can append additional hooks" example.

For zh-CN, at least add the missing available hook docs in English instead of missing them altogether.

For zh-CN, add the new example replacement with EN text rather than keeping the old outdated one, or missing it altogether.

Resolves #1879