### PR TITLE
Fix release notes `$nu.vendor-autoload-dirs`

### DIFF
--- a/blog/2024-06-25-nushell_0_95_0.md
+++ b/blog/2024-06-25-nushell_0_95_0.md
@@ -139,7 +139,7 @@ Additionally, the constant `$nu.cache-dir` has been added for future use. Like t
 | macOS    | `$HOME/Library/Caches/nushell`    | `/home/alice/Library/Caches/nushell`   |
 | Windows  | `{FOLDERID_LocalAppData}\nushell` | `C:\Users\Alice\AppData\Local\nushell` |
 
-New constants for system-level items such as `$nu.vendor-autoload-dir` will be introduced in future releases.
+New constants for system-level items such as `$nu.vendor-autoload-dirs` will be introduced in future releases.
 
 # Changes to commands [[toc](#table-of-content)]
 

--- a/blog/2024-07-23-nushell_0_96_0.md
+++ b/blog/2024-07-23-nushell_0_96_0.md
@@ -131,7 +131,7 @@ We don't expect this to break any real code in practice, but it is a change that
 
 ## Autoload directories for package managers [[toc](#table-of-content)]
 
-`$nu.vendor-autoload-dir` is now a list of directories that will automatically be loaded from at startup. The nu script files within these directories are loaded in lexical order, and the directories are loaded in the order they appear in that list.
+`$nu.vendor-autoload-dirs` is now a list of directories that will automatically be loaded from at startup. The nu script files within these directories are loaded in lexical order, and the directories are loaded in the order they appear in that list.
 
 Added in [#13217](https://github.com/nushell/nushell/pull/13217), and further refined by [@jcgruenhage](https://github.com/jcgruenhage) in [#13382](https://github.com/nushell/nushell/pull/13382).
 


### PR DESCRIPTION
0.95.0 mentions `$nu.vendor-autoload-dir` future-facing (will be introduced in the future).
But it was introduced as `$nu.vendor-autoload-dirs` (plural) in 0.96.0.

0.96.0 mentions PRs #13217 and #13382.
The first introduced it in singular, but the second changed it to plural. The plural name `$nu.vendor-autoload-dirs` is still the correct name in the current version 0.103.0.