### PR TITLE
Fix vuepress config

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -90,7 +90,7 @@ export default defineUserConfig({
     },
   },
   head: [
-    ["link", { rel: "preload", href: "/fonts/FiraCode-Regular.woff2", as: "font", type: "font/woff2", crossorigin: "anonymous" }]
+    ["link", { rel: "preload", href: "/fonts/FiraCode-Regular.woff2", as: "font", type: "font/woff2", crossorigin: "anonymous" }],
     ['meta', { name: 'theme-color', content: '#3eaf7c' }],
     ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
     [


### PR DESCRIPTION
Regression introduced in 2ec6143edbf6b9412a2e8a951fb90a91d355bb1a

Missing comma is missing on the first, newly introduced array element, and somehow that does not lead to build errors, but probably to runtime issues.