### PR TITLE
Add missing code font var

### DIFF
--- a/.vuepress/styles/index.scss
+++ b/.vuepress/styles/index.scss
@@ -38,6 +38,8 @@ div[class*='language-'].line-numbers-mode .line-numbers {
   --code-line-height: 1.1;
   --font-family-code: 'Fira Code', Consolas, Monaco, 'Andale Mono', 'DejaVu Sans Mono',
     'Ubuntu Mono', monospace;
+  --code-font-family: 'Fira Code', Consolas, Monaco, 'Andale Mono', 'DejaVu Sans Mono',
+    'Ubuntu Mono', monospace;
 }
 
 @media screen and (min-width: 720px) and (max-width: 815px) {


### PR DESCRIPTION
Code blocks use a different variable, which this commit adds.

On the current Nushell website, for example [Quick Tour][quicktour] page, we can see that the font-family being applied is in the generated style-*.css, with declaration `code { font-family(--code-font-family); }`, which does not match our supposed override which defines a var under a different name `--font-family-code`.

This var name has been used since the introduction of the override in 83ced1debcfe2cffb6b7aad597de92134c3f4e64.

Maybe vuepress changed the variable at some point?

This is a follow-up to 2ec6143edbf6b9412a2e8a951fb90a91d355bb1a (PR #1890, PR #1906), which attempts to solve Android monospace due to missing font coverage (#83).

Instead of replacing `--font-family-code`, `--code-font-family` is added as an additional value-identical declaration just in case the other variable is being used somewhere still.

[quicktour]: https://www.nushell.sh/book/quick_tour.html#nushell-commands-output-data