### PR TITLE
Update Plugins with v0.104.0 dependencies

### DIFF
--- a/contributor-book/plugins.md
+++ b/contributor-book/plugins.md
@@ -56,8 +56,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-nu-plugin = "0.103.0"
-nu-protocol = "0.103.0"
+nu-plugin = "0.104.0"
+nu-protocol = "0.104.0"
 ```
 
 With this, we can open up `src/main.rs` and create our plugin.


### PR DESCRIPTION
Plugins compiled with v0.103.0 do not run in Nushell v0.104.0.

This sample has been compiled in v0.104.0 and runs and behaves like expected.