### PR TITLE
Fix code font family declaration

### DIFF
--- a/.vuepress/styles/index.scss
+++ b/.vuepress/styles/index.scss
@@ -38,6 +38,10 @@ div[class*='language-'].line-numbers-mode .line-numbers {
   --code-line-height: 1.1;
   --font-family-code: 'Fira Code', Consolas, Monaco, 'Andale Mono', 'DejaVu Sans Mono',
     'Ubuntu Mono', monospace;
+  }
+  
+/* override vuepress `:root` --code-font-family variable with higher specificity (`body`) because vuepress puts theirs after this one */
+body {
   --code-font-family: 'Fira Code', Consolas, Monaco, 'Andale Mono', 'DejaVu Sans Mono',
     'Ubuntu Mono', monospace;
 }


### PR DESCRIPTION
VuePress puts our `:root` declaration before their own, meaning the declaration we intended as an override was overridden instead.

Use higher specificity (`body`) to make sure it takes precedence.

This is a follow-up to #1907