### PR TITLE
Remove awkward newline from scripts.md

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -62,7 +62,6 @@ For example:
 
 ```nu
 # myscript.nu
-
 def main [x: int] {
   $x + 10
 }


### PR DESCRIPTION
Removed a newline from a code example in order to match its counterparts in this file (every other code example has "# myscript.nu" directly above the code, without an additional newline in between them). I apologize if my pedantism is a little much here! If it is, let me know and I'll stop.