### PR TITLE
Fix broken link in creating_modules.md

### DIFF
--- a/book/modules/creating_modules.md
+++ b/book/modules/creating_modules.md
@@ -112,7 +112,7 @@ use <module> [ <other_definitions> ]
 :::
 
 ::: note
-Additionally, `main` has special behavior if used in a script file, regardless of whether it is exported or not. See the [Scripts](scripts.html#parameterizing-scripts) chapter for more details.
+Additionally, `main` has special behavior if used in a script file, regardless of whether it is exported or not. See the [Scripts](../scripts.html#parameterizing-scripts) chapter for more details.
 :::
 
 ## Module Files


### PR DESCRIPTION
The link as of now sends you to https://www.nushell.sh/book/modules/scripts.html#parameterizing-scripts instead of https://www.nushell.sh/book/scripts.html#parameterizing-scripts