### PR TITLE
feat: update available table modes

### DIFF
--- a/book/coloring_and_theming.md
+++ b/book/coloring_and_theming.md
@@ -21,6 +21,7 @@ The options for `$env.config.table.mode` can be listed with `table --list`:
 - `compact`
 - `default`
 - `dots`
+- `double`
 - `heavy`
 - `light`
 - `markdown`
@@ -29,6 +30,7 @@ The options for `$env.config.table.mode` can be listed with `table --list`:
 - `reinforced`
 - `restructured`
 - `rounded`
+- `single`
 - `thin`
 - `with_love`
 


### PR DESCRIPTION
This is a follow up of nushell/nushell#16013. Its PR template says to update this documentation after the PR is merged.

This also adds missing new-ish `'single'` table mode.

One issue is that I am not sure if this is appropriate to merge right away, as `'double'` mode is for yet-not-released 0.106.0 version. If you want, I can split this PR into two: one adding `'single'` (which can be merged now) and one for `'double'` (for later).