### PR TITLE
Return an empty record instead of an empty list in capture-foreign-env

### DIFF
--- a/cookbook/foreign_shell_scripts.md
+++ b/cookbook/foreign_shell_scripts.md
@@ -115,6 +115,7 @@ def capture-foreign-env [
     | where { |line| $line not-in $env_out.before } # Only get changed lines
     | parse "{key}={value}"
     | transpose --header-row --as-record
+    | if $in == [] { {} } else { $in }
 }
 ```
 


### PR DESCRIPTION
- load-env happily accepts an empty record but not an empty list
- A small workaround to return an empty record in that case, as anyway we aim to return a record