### PR TITLE
Use more concise home feature title

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ tagline: A new type of shell
 actionText: Get Started →
 actionLink: /book/
 features:
-  - title: Pipelines to control any OS
+  - title: Cross-platform
     details: Nu works on Linux, macOS, BSD, and Windows. Learn it once, then use it anywhere.
   - title: Everything is data
     details: Nu pipelines use structured data so you can safely select, filter, and sort the same way every time. Stop parsing strings and start solving problems.


### PR DESCRIPTION
Use `Cross-platform` instead of `Pipelines to control any OS`.

It's not necessarily clear what pipelines refers to. Pipelines may refer to one of many use cases. Pipelines may be a misleading ambiguity to command piping (shell terminology).

The previous title lead to a line break. Making it more concise to fit on one line is more consistent with the other two feature titles - leading to a more consistent and balanced layout too. (Body starts on the same vertical position now.)

| `main` | suggestion |
| --- | --- |
| <img width="1920" height="1080" alt="1080p-main" src="https://github.com/user-attachments/assets/da90d0d1-537d-4f2c-b51d-72a018ffd2d0" /> | <img width="1920" height="1080" alt="1080p-suggestion" src="https://github.com/user-attachments/assets/e454452f-4521-4590-a03e-3054dca12e63" /> |
| <img width="1125" height="2436" alt="narrow-main" src="https://github.com/user-attachments/assets/e124efe3-2a10-4cbe-82d5-ace056f248a4" /> | <img width="1125" height="2436" alt="narrow-suggestion" src="https://github.com/user-attachments/assets/a149bb70-fcfb-4d50-b049-c367efac8eb0" /> |