### PR TITLE
Order `$env` variables in Special Variables

### DIFF
--- a/book/special_variables.md
+++ b/book/special_variables.md
@@ -49,19 +49,31 @@ The `$nu` constant is a record containing several useful values:
 
 There are also several environment variables that Nushell uses for specific purposes:
 
+### `$env.CMD_DURATION_MS`
+
+The amount of time in milliseconds that the previous command took to run.
+
 ### `$env.config`
 
 `$env.config` is the main configuration record used in Nushell. Settings are documented in `config nu --doc`.
 
-### `$env.PATH`
+### `$env.CURRENT_FILE`
 
-The search path for executing other applications. It is initially inherited from the parent process as a string, but converted to a Nushell `list` at startup for easy access.
-
-It is converted back to a string before running a child-process.
+Inside a script, module, or sourced-file, this variable holds the fully-qualified filename. Note that this
+information is also available as a constant through the [`path self`](/commands/docs/path_self.md) command.
 
 ### `$env.ENV_CONVERSIONS`
 
 Allows users to specify how to convert certain environment variables to Nushell types. See [ENV_CONVERSIONS](./configuration.md#env-conversions).
+
+### `$env.FILE_PWD`
+
+Inside a script, module, or sourced-file, this variable holds the fully qualified name of the directory in which
+the file resides. Note that this value is also available as a constant through:
+
+```nu
+path self | path dirname
+```
 
 ### `$env.LAST_EXIT_CODE`
 
@@ -81,35 +93,6 @@ try {
 # => 2
 ```
 
-### `$env.CMD_DURATION_MS`
-
-The amount of time in milliseconds that the previous command took to run.
-
-### `$env.NU_VERSION`
-
-The current Nushell version. The same as `(version).version`, but, as an environment variable, it is exported to and can be read by child processes.
-
-### `$env.CURRENT_FILE`
-
-Inside a script, module, or sourced-file, this variable holds the fully-qualified filename. Note that this
-information is also available as a constant through the [`path self`](/commands/docs/path_self.md) command.
-
-### `$env.FILE_PWD`
-
-Inside a script, module, or sourced-file, this variable holds the fully qualified name of the directory in which
-the file resides. Note that this value is also available as a constant through:
-
-```nu
-path self | path dirname
-```
-
-### `$env.PROCESS_PATH`
-
-When _executing a script_, this variable represents the name and relative path of the script. Unlike the two variables
-above, it is not present when sourcing a file or importing a module.
-
-Note: Also unlike the two variables above, the exact path (including symlinks) that was used to _invoke_ the file is returned.
-
 ### `$env.NU_LIB_DIRS`
 
 A list of directories which will be searched when using the `source`, `use`, or `overlay use` commands. See also:
@@ -123,6 +106,23 @@ A list of directories which will be searched when using the `source`, `use`, or 
 A list of directories which will be searched when registering plugins with `plugin add`. See also:
 
 - [Plugin Search Path](./plugins.md#plugin-search-path)
+
+### `$env.NU_VERSION`
+
+The current Nushell version. The same as `(version).version`, but, as an environment variable, it is exported to and can be read by child processes.
+
+### `$env.PATH`
+
+The search path for executing other applications. It is initially inherited from the parent process as a string, but converted to a Nushell `list` at startup for easy access.
+
+It is converted back to a string before running a child-process.
+
+### `$env.PROCESS_PATH`
+
+When _executing a script_, this variable represents the name and relative path of the script. Unlike the two variables
+above, it is not present when sourcing a file or importing a module.
+
+Note: Also unlike the two variables above, the exact path (including symlinks) that was used to _invoke_ the file is returned.
 
 ### `$env.PROMPT_*` and `$env.TRANSIENT_PROMPT_*`
 


### PR DESCRIPTION
The order C P E L C N C F P N N P S X X was quite confusing.

While there is value in putting the config and PATH first, because they are common and important variables, the table of contents becomes very inconsistent and confusing when mixed like before.