### PR TITLE
Fix completions folder path

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -386,7 +386,7 @@ The variables that affect Nushell file locations are:
 
 - `$env.XDG_DATA_HOME`: If this environment variable is set, Nushell sets the `$nu.data-dir` constant to this value. The `data-dir` is used in several startup tasks:
 
-  - `($nu.data-dir)/nushell/completions` is added to the `$env.NU_LIB_DIRS` search path.
+  - `($nu.data-dir)/completions` is added to the `$env.NU_LIB_DIRS` search path.
   - `($nu.data-dir)/vendor/autoload` is added as the last path in `nu.vendor-autoload-dirs`. Files in this directory will be read after the other vendor-auto-load directories, thus overriding any of their settings.
 
   Note that the directory represented by `$nu.data-dir`, nor any of its subdirectories, are created by default. Creation and use of these directories is up to the user.


### PR DESCRIPTION
The old code produces "/home/user/.local/share/nushell/nushell/completions", which is wrong with double "nushell".