### PR TITLE
Manually link page next-prev across child borders

### DIFF
--- a/book/advanced.md
+++ b/book/advanced.md
@@ -1,3 +1,11 @@
+---
+prev:
+  text: How Nushell Code Gets Run
+  link: /book/how_nushell_code_gets_run.md
+next:
+  text: Standard Library (Preview)
+  link: /book/standard_library.md
+---
 # (Not so) Advanced
 
 While the "Advanced" title might sound daunting and you might be tempted to skip this chapter, in fact, some of the most interesting and powerful features can be found here.

--- a/book/background_jobs.md
+++ b/book/background_jobs.md
@@ -1,3 +1,8 @@
+---
+next:
+  text: Coming to Nu
+  link: /book/coming_to_nu.md
+---
 # Background Jobs
 
 Nushell currently has experimental support for thread-based background jobs.

--- a/book/cheat_sheet.md
+++ b/book/cheat_sheet.md
@@ -1,3 +1,8 @@
+---
+next:
+  text: Nu Fundamentals
+  link: /book/nu_fundamentals.md
+---
 # Nushell Cheat Sheet
 
 ## Data Types

--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -1,3 +1,8 @@
+---
+prev:
+  text: Coming to Nu
+  link: /book/coming_to_nu.md
+---
 # Coming from Bash
 
 ::: tip

--- a/book/coming_to_nu.md
+++ b/book/coming_to_nu.md
@@ -1,3 +1,11 @@
+---
+prev:
+  text: Background Jobs
+  link: /book/background_jobs.md
+next:
+  text: Coming from Bash
+  link: /book/coming_from_bash.md
+---
 # Coming to Nu
 
 If you are familiar with other shells or programming languages, you might find this chapter useful to get up to speed.

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -1,3 +1,8 @@
+---
+prev:
+  text: Nu as a Shell
+  link: /book/nu_as_a_shell.md
+---
 # Configuration
 
 ## Quickstart

--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -1,3 +1,8 @@
+---
+prev:
+  text: Programming in Nu
+  link: /book/programming_in_nu.md
+---
 # Custom Commands
 
 As with any programming language, you'll quickly want to save longer pipelines and expressions so that you can call them again easily when needed.

--- a/book/design_notes.md
+++ b/book/design_notes.md
@@ -1,3 +1,11 @@
+---
+prev:
+  text: Nushell operator map
+  link: /book/nushell_operator_map.md
+next:
+  text: How Nushell Code Gets Run
+  link: /book/how_nushell_code_gets_run.md
+---
 # Design Notes
 
 This chapter intends to give more in-depth overview of certain aspects of Nushell's design. The topics are not necessary for a basic usage, but reading them will help you understand how Nushell works and why.

--- a/book/getting_started.md
+++ b/book/getting_started.md
@@ -1,3 +1,8 @@
+---
+next:
+  text: Quick Tour
+  link: /book/quick_tour.md
+---
 # Getting Started
 
 Let's get started! :elephant:

--- a/book/how_nushell_code_gets_run.md
+++ b/book/how_nushell_code_gets_run.md
@@ -1,3 +1,11 @@
+---
+prev:
+  text: Design Notes
+  link: /book/design_notes.md
+next:
+  text: (Not so) Advanced
+  link: /book/advanced.md
+---
 # How Nushell Code Gets Run
 
 In [Thinking in Nu](./thinking_in_nu.md#think-of-nushell-as-a-compiled-language), we encouraged you to _"Think of Nushell as a compiled language"_ due to the way in which Nushell code is processed. We also covered several code examples that won't work in Nushell due that process.

--- a/book/nu_as_a_shell.md
+++ b/book/nu_as_a_shell.md
@@ -1,3 +1,11 @@
+---
+prev:
+  text: Best Practices
+  link: /book/style_guide.md
+next:
+  text: Configuration
+  link: /book/configuration.md
+---
 # Nu as a Shell
 
 The [Nu Fundamentals](nu_fundamentals.md) and [Programming in Nu](programming_in_nu.md) chapter focused mostly on the language aspects of Nushell.

--- a/book/nu_fundamentals.md
+++ b/book/nu_fundamentals.md
@@ -1,3 +1,11 @@
+---
+prev:
+  text: Nushell Cheat Sheet
+  link: cheat_sheet.md
+next:
+  text: Types of Data
+  link: /book/types_of_data.md
+---
 # Nu Fundamentals
 
 This chapter explains some of the fundamentals of the Nushell programming language.

--- a/book/nushell_operator_map.md
+++ b/book/nushell_operator_map.md
@@ -1,3 +1,8 @@
+---
+next:
+  text: Design Notes
+  link: /book/design_notes.md
+---
 # Nushell operator map
 
 The idea behind this table is to help you understand how Nu operators relate to other language operators. We've tried to produce a map of all the nushell operators and what their equivalents are in other languages. Contributions are welcome.

--- a/book/programming_in_nu.md
+++ b/book/programming_in_nu.md
@@ -1,3 +1,11 @@
+---
+prev:
+  text: Special Variables
+  link: /book/special_variables.md
+next:
+  text: Custom Commands
+  link: /book/custom_commands.md
+---
 # Programming in Nu
 
 This chapter goes into more detail of Nushell as a programming language.

--- a/book/quick_tour.md
+++ b/book/quick_tour.md
@@ -1,3 +1,8 @@
+---
+prev:
+  text: Getting Started
+  link: /book/getting_started.md
+---
 # Quick Tour
 
 [[toc]]

--- a/book/special_variables.md
+++ b/book/special_variables.md
@@ -1,3 +1,8 @@
+---
+next:
+  text: Programming in Nu
+  link: /book/programming_in_nu.md
+---
 # Special Variables
 
 Nushell makes available and uses a number of special variables and constants. Many of these are mentioned or documented in other places in this Book, but this page

--- a/book/standard_library.md
+++ b/book/standard_library.md
@@ -1,3 +1,8 @@
+---
+prev:
+  text: (Not so) Advanced
+  link: /book/advanced.md
+---
 # Standard Library (Preview)
 
 Nushell ships with a standard library of useful commands written in native Nu. By default, the standard library is loaded into memory (but not automatically imported) when Nushell starts.

--- a/book/style_guide.md
+++ b/book/style_guide.md
@@ -1,3 +1,8 @@
+---
+next:
+  text: Nu as a Shell
+  link: /book/nu_as_a_shell.md
+---
 # Best Practices
 
 This page is a working document collecting syntax guidelines and best practices we have discovered so far.

--- a/book/types_of_data.md
+++ b/book/types_of_data.md
@@ -1,3 +1,8 @@
+---
+prev:
+  text: Nu Fundamentals
+  link: /book/nu_fundamentals.md
+---
 # Types of Data
 
 Traditional Unix shell commands communicate with each other using strings of text -- One command writes text to standard output (often abbreviated `stdout`) and the other reads text from standard input (or `stdin`). This allows multiple commands to be combined together to communicate through what is called a "pipeline".


### PR DESCRIPTION
The previous and next navigation links at the bottom of the page get filled automatically by vuepress, sourced from the (locale-specific) sidebar configuration.

We define the sidebar through sections - which may be single page sections or a section with child pages.

Previously, the website did not guide the user through our book.

* Section prev always linked to previous section, never previous sections last child if available
* Section next never linked to first child of section, if available
* First child did not offer a prev link
* Last child did not offer a next link

I did not see documentation about customizing the auto-discover behavior, nor the sidebar structure dependency of the automatic determination. But page frontmatter can override the prev and next links.

As a fixup, overriding the automatic discovery from the sidebar, we manually set the prev and next links on section child borders. The link text matches the headline/sidebar, and the links the sidebar structure. Given that this is manual configuration, there's a risk of it eventually being missed and becoming outdated or wrong when structure changes are made.

I did not test. I don't have a local nodejs env.

Resolves #1818

* https://v1.vuepress.vuejs.org/theme/default-theme-config.html#prev-next-links
* https://v1.vuepress.vuejs.org/guide/i18n.html#default-theme-i18n-config
* https://ecosystem.vuejs.press/themes/default/frontmatter.html#prev