### PR TITLE
Use null character ending with env

### DIFF
--- a/cookbook/foreign_shell_scripts.md
+++ b/cookbook/foreign_shell_scripts.md
@@ -101,12 +101,12 @@ def capture-foreign-env [
         echo '<ENV_CAPTURE_EVAL_FENCE>'
         eval "$SCRIPT_TO_SOURCE"
         echo '<ENV_CAPTURE_EVAL_FENCE>'
-        env -u _ -u _AST_FEATURES -u SHLVL` # Filter out known changing variables
+        env -0 -u _ -u _AST_FEATURES -u SHLVL` # Filter out known changing variables
     }
     | split row '<ENV_CAPTURE_EVAL_FENCE>'
     | {
         before: ($in | first | str trim | lines)
-        after: ($in | last | str trim | lines)
+        after: ($in | last | str trim | split row (char --integer 0))
     }
 
     # Unfortunate Assumption:


### PR DESCRIPTION
Line splitting was less safe as some scripts inject `BASH_FUNC_...` env variables which have newlines in them