### PR TITLE
book: write Control key as just «Ctrl», not «Ctrl>»

### DIFF
--- a/book/line_editor.md
+++ b/book/line_editor.md
@@ -155,8 +155,8 @@ These keybinding events apply only to Vi-normal mode:
 | <kbd>↓</kbd> (Down Arrow)                   | Move down           |
 | <kbd>←</kbd> (Left Arrow)                   | Move left           |
 | <kbd>→</kbd> (Right Arrow)                  | Move right          |
-| <kbd>Ctrl></kbd>+<kbd>→</kbd> (Right Arrow) | Move right one word |
-| <kbd>Ctrl></kbd>+<kbd>←</kbd> (Left Arrow)  | Move left one word  |
+| <kbd>Ctrl</kbd>+<kbd>→</kbd> (Right Arrow) | Move right one word |
+| <kbd>Ctrl</kbd>+<kbd>←</kbd> (Left Arrow)  | Move left one word  |
 
 ### Vi-normal Motions
 


### PR DESCRIPTION
Also to make this consistent with other parts of the same page, such as
https://github.com/nushell/nushell.github.io/blob/6b4312b1a329498756af4d02c45a03b78a279056/book/line_editor.md?plain=1#L122-L124