### PR TITLE
Update external_completers.md

### DIFF
--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -116,7 +116,7 @@ let carapace_completer = {|spans: list<string>|
 let external_completer = {|spans|
     let expanded_alias = scope aliases
     | where name == $spans.0
-    | get -i 0.expansion
+    | get -o 0.expansion
 
     let spans = if $expanded_alias != null {
         $spans


### PR DESCRIPTION
```
Warning: nu::parser::deprecated

  ⚠ Flag deprecated.
    ╭─[/home/slashlogin/.config/nushell/config.nu:34:11]
 33 │     | where name == $spans.0
 34 │     | get -i 0.expansion
    ·           ─┬
    ·            ╰── get --ignore-errors was deprecated in 0.106.0 and will be removed in a future release.
 35 │
    ╰────
  help: This flag has been renamed to `--optional (-o)` to better reflect its behavior.
```