### PR TITLE
add custom help command information

### DIFF
--- a/cookbook/help.md
+++ b/cookbook/help.md
@@ -53,3 +53,9 @@ help http get
 # =>   http get content from example.com, with custom header
 # =>   > http get -H [my-header-key my-header-value] https://www.example.com
 ```
+
+### Custom help command
+If you want to change the `help` output, you can specify your own custom command named `help` and it will also be used for all `--help` invocations. An example of this is in the standard library.
+```nu
+use std/help
+```


### PR DESCRIPTION
Add indication in the docs that you can specify your own `help` command and it will also be used for `--help`