### PR TITLE
Report and forgive missing plugins in make_docs.nu

### DIFF
--- a/make_docs.nu
+++ b/make_docs.nu
@@ -14,12 +14,17 @@ def plugin-paths [ nu_path?: path ] {
         _ => ($nu_path | path dirname)
     }
 
-    $PLUGINS | each {|plugin|
+    let plugin_paths = $PLUGINS | each {|plugin|
         match (sys host | get name) {
             'Windows' => $'($nu_dir | path join $plugin).exe'
             _ => $'($nu_dir | path join $plugin)'
         }
     }
+
+    let decorated = $plugin_paths | wrap path | insert exists {|x| $x.path | path exists }
+    $decorated | where not exists | each {|x| print $"(ansi red)No plugin under path '($x.path)', will be skipped...(ansi reset)" }
+
+    $decorated | where exists | get path
 }
 
 # get all command names from a clean scope


### PR DESCRIPTION
Example screenshot of constructed error case:

<img width="836" height="130" alt="image" src="https://github.com/user-attachments/assets/54921bb2-6297-46c9-810f-09709c745ad4" />

Resolves #2010

---

I would have preferred an error exit, but I'm not sure how to do that in a way that it works for this script both when calling it as a script via `nu` as well as when running it via `source` then `make_docs` command.

Checking for invalid paths, reporting them and skipping them seems like a reasonable improvement, especially in the context of #2010 (runtime errors further down the script and command pipeline).