### PR TITLE
Fix tip breaking content layout in variables.md

### DIFF
--- a/book/variables.md
+++ b/book/variables.md
@@ -63,7 +63,8 @@ There are a couple of assignment operators used with mutable variables
 
 1. `+=`, `-=`, `*=` and `/=` are only valid in the contexts where their root operations are expected to work. For example, `+=` uses addition, so it can not be used for contexts where addition would normally fail
 2. `++=` requires that either the variable **or** the argument is a list.
-   :::
+
+:::
 
 #### More on Mutability
 


### PR DESCRIPTION
Correctly close `:::` tip block.

As mentioned in #2016.

Using a newline after the numbered list makes sure the lefthook npx prettier run does not reintroduce the Markdown formatting issue of the `:::` tip not being closed.