### PR TITLE
0.107 release notes: Fix extremely minor inconsistency

### DIFF
--- a/blog/2025-09-02-nushell_0_107_0.md
+++ b/blog/2025-09-02-nushell_0_107_0.md
@@ -380,7 +380,7 @@ Previously, converting values to `binary` with `into binary` could only do so in
 # => 00000000:   00 00 00 00  00 00 01 02
 ```
 
-Note that this only affects `int`, `float`, `filesize`, `bool` and `duration` (i.e. it does not affect `string`s, `date`s and `binary`). Likewise, only the individual elements in `table`s and `record`s are affected (not the `table` or `record` itself)
+Note that this only affects `int`, `float`, `filesize`, `bool` and `duration` (i.e. it does not affect `string`, `date` and `binary`). Likewise, only the individual elements in `table`s and `record`s are affected (not the `table` or `record` itself)
 
 ### Other additions
 

--- a/blog/2025-09-02-nushell_0_107_0.md
+++ b/blog/2025-09-02-nushell_0_107_0.md
@@ -380,7 +380,7 @@ Previously, converting values to `binary` with `into binary` could only do so in
 # => 00000000:   00 00 00 00  00 00 01 02
 ```
 
-Note that this only affects `int`, `float`, `filesize`, `bool` and `duration` (i.e. it does not affect `string`, `date` and `binary`). Likewise, only the individual elements in `table`s and `record`s are affected (not the `table` or `record` itself)
+Note that this only affects `int`, `float`, `filesize`, `bool` and `duration` (i.e. it does not affect `string`, `date` and `binary`). Likewise, only the individual elements in `table` and `record` values are affected (not the `table` or `record` itself)
 
 ### Other additions
 

--- a/blog/2025-09-02-nushell_0_107_0.md
+++ b/blog/2025-09-02-nushell_0_107_0.md
@@ -380,7 +380,7 @@ Previously, converting values to `binary` with `into binary` could only do so in
 # => 00000000:   00 00 00 00  00 00 01 02
 ```
 
-Note that this only affects `int`, `float`, `filesize`, `bool` and `duration` (i.e. it does not affect `string`, `date` and `binary`). Likewise, only the individual elements in `table` and `record` values are affected (not the `table` or `record` itself)
+Note that this only affects `int`, `float`, `filesize`, `bool` and `duration` (i.e. it does not affect `string`, `date` and `binary`). Likewise, only the individual elements in `table` and `record` values are affected (not the `table` or `record` itself).
 
 ### Other additions
 


### PR DESCRIPTION
This PR will update #1999.

The types that are affected by the `into binary` change were listed in the singular form, but the ones that weren't were listed with an "s". 

In a separate commit, I also reworded the next sentence to avoid code text being directly followed with an "s" (e.g.  `record`s). That form is fine for GitHub comments and such of course, and it looks great when viewing the raw markdown, but IMO the "s" looks too disconnected from what it's attached to when rendered.

Here's an example of how that pattern gets rendered on the website: https://www.nushell.sh/book/control_flow.html#if (search for  "We can also chain multiple"). There aren't many instances of this on the website (outside of the blog), but I'll wait to see if this is something other people agree with me on before proposing any changes to them.