### PR TITLE
0.107.0 release ntoes: Fix incorrect tense in release notes entry

### DIFF
--- a/blog/2025-09-02-nushell_0_107_0.md
+++ b/blog/2025-09-02-nushell_0_107_0.md
@@ -766,7 +766,7 @@ Thanks to all the contributors below for helping us solve issues, improve docume
 | [@sholderbach](https://github.com/sholderbach)     | Add "did my homework" checkboxes to issue template                                                                                                                      | [#16520](https://github.com/nushell/nushell/pull/16520) |
 | [@fdncred](https://github.com/fdncred)             | Pin polars dependency planus to version 1.1.1                                                                                                                           | [#16538](https://github.com/nushell/nushell/pull/16538) |
 | [@sholderbach](https://github.com/sholderbach)     | Fix issue form syntax                                                                                                                                                   | [#16541](https://github.com/nushell/nushell/pull/16541) |
-| [@ItsHarper](https://github.com/ItsHarper)         | Fixes incorrect documentation of the default behavior of the `bits rol`, `bits ror`, `bits shl`, and `bits shr` commands when the `--number-bytes` flag is not provided | [#16542](https://github.com/nushell/nushell/pull/16542) |
+| [@ItsHarper](https://github.com/ItsHarper)         | Fix incorrect documentation of the default behavior of the `bits rol`, `bits ror`, `bits shl`, and `bits shr` commands when the `--number-bytes` flag is not provided | [#16542](https://github.com/nushell/nushell/pull/16542) |
 
 # Full changelog
 


### PR DESCRIPTION
This PR will update #1999 

I made a bad assumption when filling out the new PR template