### PR TITLE
fix: fix incorrect winget install cmd

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -30,9 +30,9 @@ For Windows:
 
 - [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/)
 
-  - Machine scope installation: `winget install nushell --scope machine`
+  - Machine scope installation: `winget install nu --source winget --scope machine`
   - Machine scope upgrade: `winget update nushell`
-  - User scope installation: `winget install nushell` or `winget install nushell --scope user`
+  - User scope installation: `winget install nu --source winget` or `winget install nu --source winget --scope user`
   - User scope upgrade: Due to [winget-cli issue #3011](https://github.com/microsoft/winget-cli/issues/3011), running `winget update nushell` will unexpectedly install the latest version to `C:\Program Files\nu`. To work around this, run `winget install nushell` again to install the latest version in the user scope.
 
 - [Chocolatey](https://chocolatey.org/) (`choco install nushell`)


### PR DESCRIPTION
the previous version of the recommended command line was throwing an error.

this new proposed one will actually install the correct nushell from the winget store.