### PR TITLE
Fixing non-clickable link

### DIFF
--- a/commands/docs/def.md
+++ b/commands/docs/def.md
@@ -77,4 +77,4 @@ Define a custom command with a type signature. Passing a non-int value will resu
 
 ## Notes
 This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nu.html
+  [Thinking in Nu](https://www.nushell.sh/book/thinking_in_nu.html)


### PR DESCRIPTION
The previous version is plain url. I've changed it to normal markdown link.