### PR TITLE
docs: fix syntax

### DIFF
--- a/book/hooks.md
+++ b/book/hooks.md
@@ -192,7 +192,7 @@ $env.config = ($env.config | upsert hooks {
             code: 'print $"changing directory from ($before) to ($after)"'
         }
     }
-}
+})
 ```
 
 ## Examples


### PR DESCRIPTION
Add missing `)` to docs.