### PR TITLE
Fix typo/wording in v108 release notes

### DIFF
--- a/blog/2025-10-15-nushell_v0_108_0.md
+++ b/blog/2025-10-15-nushell_v0_108_0.md
@@ -1225,7 +1225,7 @@ This was due to a miscompilation bug, which is now fixed.
 
 - The LSP should now work better with unsaved files and with overlays used as prefixes (ex. `overlay use foo as bar --prefix`) ([#16568])
 
-- Variables defined as custom command arguments show now be available to autocomplete inside that command. ([#16531])
+- Variables defined as custom command arguments now autocomplete inside that command. ([#16531])
 
 - Fixed building `nu-command` by itself. ([#16616])
 


### PR DESCRIPTION
While I assume it's a word typo of 'show' -> 'should', the two closed bug ticket samples work now, so I would find it more appropriate to make it a definite statement. 'should' would unnecessarily leave open why it may still not be working.