### PR TITLE
Fix /blog/* is missing sidebar config in build output

### DIFF
--- a/.vuepress/configs/sidebar/de.ts
+++ b/.vuepress/configs/sidebar/de.ts
@@ -73,4 +73,5 @@ export const sidebarDe: SidebarConfig = {
       children: ['/de/book/plugins', '/de/book/metadata.md'],
     },
   ],
+  '/blog/': false,
 };

--- a/.vuepress/configs/sidebar/en.ts
+++ b/.vuepress/configs/sidebar/en.ts
@@ -267,4 +267,5 @@ export const sidebarEn: SidebarConfig = {
       ],
     },
   ],
+  '/blog/': false,
 };

--- a/.vuepress/configs/sidebar/es.ts
+++ b/.vuepress/configs/sidebar/es.ts
@@ -29,4 +29,5 @@ export const sidebarEs: SidebarConfig = {
       ],
     },
   ],
+  '/blog/': false,
 };

--- a/.vuepress/configs/sidebar/fr.ts
+++ b/.vuepress/configs/sidebar/fr.ts
@@ -26,4 +26,5 @@ export const sidebarFr: SidebarConfig = {
       ],
     },
   ],
+  '/blog/': false,
 };

--- a/.vuepress/configs/sidebar/ja.ts
+++ b/.vuepress/configs/sidebar/ja.ts
@@ -104,4 +104,5 @@ export const sidebarJa: SidebarConfig = {
       ],
     },
   ],
+  '/blog/': false,
 };

--- a/.vuepress/configs/sidebar/ko.ts
+++ b/.vuepress/configs/sidebar/ko.ts
@@ -120,4 +120,5 @@ export const sidebarKo: SidebarConfig = {
       ],
     },
   ],
+  '/blog/': false,
 };

--- a/.vuepress/configs/sidebar/pt-BR.ts
+++ b/.vuepress/configs/sidebar/pt-BR.ts
@@ -21,4 +21,5 @@ export const sidebarPtBR: SidebarConfig = {
       ],
     },
   ],
+  '/blog/': false,
 };

--- a/.vuepress/configs/sidebar/ru.ts
+++ b/.vuepress/configs/sidebar/ru.ts
@@ -113,4 +113,5 @@ export const sidebarRU: SidebarConfig = {
     //   ],
     // },
   ],
+  '/blog/': false,
 };

--- a/.vuepress/configs/sidebar/zh-CN.ts
+++ b/.vuepress/configs/sidebar/zh-CN.ts
@@ -170,4 +170,5 @@ export const sidebarZhCN: SidebarConfig = {
       ],
     },
   ],
+  '/blog/': false,
 };


### PR DESCRIPTION
Fix /blog/* is missing sidebar config in build output, make it more clean: 
Before:
https://github.com/nushell/nushell.github.io/actions/runs/19594815145/job/56118014786#step:5:39
After:
https://github.com/nushell/nushell.github.io/actions/runs/19603579626/job/56138675782?pr=2079

```console
/blog/2019-08-23-introducing-nushell.html is missing sidebar config.
/blog/2019-08-30-twin0001.html is missing sidebar config.
/blog/2019-09-06-twin0002.html is missing sidebar config.
/blog/2019-09-13-twin0003.html is missing sidebar config.
/blog/2019-09-20-twin0004.html is missing sidebar config.
/blog/2019-09-24-nushell_0_3_0.html is missing sidebar config.
/blog/2019-09-27-twin0005.html is missing sidebar config.
/blog/2019-10-04-twin0006.html is missing sidebar config.
/blog/2019-10-11-twin0007.html is missing sidebar config.
/blog/2019-10-15-nushell-0_4_0.html is missing sidebar config.
/blog/2019-10-18-twin0008.html is missing sidebar config.
/blog/2019-10-25-twin0009.html is missing sidebar config.
/blog/2019-11-01-twin0010.html is missing sidebar config.
/blog/2019-11-05-nushell-0_5_0.html is missing sidebar config.
/blog/2019-11-08-twin0011.html is missing sidebar config.
/blog/2019-11-15-twin0012.html is missing sidebar config.
/blog/2019-11-22-twin0013.html is missing sidebar config.
/blog/2019-11-23-nushell-survey-results.html is missing sidebar config.
.....
```