### PR TITLE
Use explicit key for Debian / Ubuntu repo

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -40,8 +40,8 @@ For Windows:
 For Debian & Ubuntu:
 
 ```sh
-curl -fsSL https://apt.fury.io/nushell/gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/fury-nushell.gpg
-echo "deb https://apt.fury.io/nushell/ /" | sudo tee /etc/apt/sources.list.d/fury.list
+wget -qO- https://apt.fury.io/nushell/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/fury-nushell.gpg
+echo "deb [signed-by=/etc/apt/keyrings/fury-nushell.gpg] https://apt.fury.io/nushell/ /" | sudo tee /etc/apt/sources.list.d/fury.list
 sudo apt update
 sudo apt install nushell
 ```


### PR DESCRIPTION
Debian in recent years prefers explicit key for 3rd-party repo. So this PR moves the key to _/etc/apt/keyrings/_, and add `signed-by` option to the .list file.
Note, in the latest versions, Debian recommends to use [deb282 format](https://wiki.debian.org/SourcesList#debian.sources_format). But we don't have an one-line command to quickly add file of this format yet, so we continue to use "list" format.

This PR also changes from `curl` to `wget` for downloading key, because `wget` is pre-installed on Debian / Ubuntu, whereas `curl` needs to be installed by users.