### PR TITLE
fix-carapace-examples

### DIFF
--- a/cookbook/external_completers.md
+++ b/cookbook/external_completers.md
@@ -95,7 +95,7 @@ The solution to this involves manually checking the value to filter it out:
 let carapace_completer = {|spans: list<string>|
     carapace $spans.0 nushell ...$spans
     | from json
-    | if ($in | default [] | where value == $"($spans | last)ERR" | is-empty) { $in } else { null }
+    | if ($in | default [] | any {|| $in.display | str starts-with "ERR"}) { null } else { $in }
 }
 ```
 
@@ -109,7 +109,7 @@ let fish_completer = ...
 let carapace_completer = {|spans: list<string>|
     carapace $spans.0 nushell ...$spans
     | from json
-    | if ($in | default [] | where value =~ '^-.*ERR$' | is-empty) { $in } else { null }
+    | if ($in | default [] | any {|| $in.display | str starts-with "ERR"}) { null } else { $in }
 }
 
 # This completer will use carapace by default


### PR DESCRIPTION
<!-- PR_SUMMARY_START -->
- fix(carapace example): update invariant

  Using previous invariant can sometimes be incorrect.

  See:
  https://github.com/carapace-sh/carapace/blob/09b28a62d9ce4acbade91bc967cee173454407c1/internal/common/message.go#L92-L114
<!-- PR_SUMMARY_END -->


---

With the new completers stuff that recently came out, I tried to first use these recipes, but found they were sometimes not working... especially for nix commands when it runs into db error:
```nu
> carapace "nix" nushell ...["nix" "run" "nixpkgs#"] | from json | select value
───┬───────────────
 # │     value
───┼───────────────
 0 │ "nixpkgs#ERR"
 1 │ "nixpkgs#_"
───┴───────────────
```

If we try and apply documented recipe to the first element, it does not work:
```nu
> let spans = ["nix" "run" "nixpkgs#"]
> carapace "nix" nushell ...["nix" "run" $last_span] | from json | get value | first
"nixpkgs#ERR"
> (carapace $spans.0 nushell ...$spans | from json | get value | first) == $"($spans | last)ERR"
false
```
This is because the `value` literally includes the chars `"` at beginning at end. I am not sure exactly how it happens, but we could fix the recipe in this instance by wrapping the check with quotes.
```nu
> (carapace $spans.0 nushell ...$spans | from json | get value | first) == $"\"($spans | last)ERR\""
true
```
--but this is not very good for things like the `cargo -1` example, which is not output with quotes. A more reliable solution is to use the `display` column. According to this code:
https://github.com/carapace-sh/carapace/blob/09b28a62d9ce4acbade91bc967cee173454407c1/internal/common/message.go#L92-L114

the `display` column will always at least *start-with* "ERR". 

Therefore, let us update this example to be more robust and use a better heuristic :).

---

p.s. I hope to also add docs/examples for the new completion methods and stuffs after this :)