### PR TITLE
Improve v0.109.0 Release Notes

### DIFF
--- a/blog/2025-11-29-nushell_v0_109_0.md
+++ b/blog/2025-11-29-nushell_v0_109_0.md
@@ -102,7 +102,7 @@ The `plugin list` command now adds an inline table containing the plugin command
 
 ## Other changes [[toc](#table-of-contents)]
 
-- add a `--dry` flag to `mktemp`. Edit or respond to this thread with what should go on this line ([#17039](https://github.com/nushell/nushell/pull/17039))
+- add a `--dry` flag to `mktemp`: Don't create a file and just return the path that would have been created. ([#17039](https://github.com/nushell/nushell/pull/17039))
 
 ## Bug fixes [[toc](#table-of-contents)]
 
@@ -143,7 +143,7 @@ Error: [31mnu::shell::only_supports_this_input_type
 [0m
 ```
 
-### Fix(`split column`): switch to 0-index like other commands [[toc](#table-of-contents)]
+### Switch `split column` to 0-index like other commands [[toc](#table-of-contents)]
 
 Like `detect columns` or `parse`, `split column` now also uses 0-index for the default column names.
 
@@ -195,7 +195,7 @@ Now, when you specify an optional cellpath in `update`, it won't error if it is 
 
 - Fixed a regression of custom-completion for short flags without a long name. ([#16967](https://github.com/nushell/nushell/pull/16967))
 
-- This PR fixes the "polars slice" command so that it will return a lazyframe output when given a lazyframe as input. Fixes #17065 ([#17067](https://github.com/nushell/nushell/pull/17067))
+- Fixed the "polars slice" command so that it will return a lazyframe output when given a lazyframe as input. Fixes #17065 ([#17067](https://github.com/nushell/nushell/pull/17067))
 
 # Notes for plugin developers [[toc](#table-of-contents)]
 


### PR DESCRIPTION
Fix mktemp dry description (replace text indended for PR with command description).

Adjust `split column` headline from a commit title format to conform to the release notes.

Adjust 'other fix' text to conform to the others listed. (Drops confusing "this PR" reference.)