### PR TITLE
Add 'chunks' subcommand to binary common commands

### DIFF
--- a/lang-guide/chapters/types/basic_types/binary.md
+++ b/lang-guide/chapters/types/basic_types/binary.md
@@ -23,3 +23,4 @@
 - `bytes` subcommands (see `help bytes` for a list)
 - `encode`
 - `take`
+- `chunks` to split binary into individual bytes or groups


### PR DESCRIPTION
It is not obvious how to split a binary value into comprising bytes as discussed in this issue https://github.com/nushell/nushell/issues/14891
There was a proposal to add `chunks` to the docs and it would have helped me when I ran into this.
