### PR TITLE
Non-conflicting .list filename in install instructions

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -41,7 +41,7 @@ For Debian & Ubuntu:
 
 ```sh
 wget -qO- https://apt.fury.io/nushell/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/fury-nushell.gpg
-echo "deb [signed-by=/etc/apt/keyrings/fury-nushell.gpg] https://apt.fury.io/nushell/ /" | sudo tee /etc/apt/sources.list.d/fury.list
+echo "deb [signed-by=/etc/apt/keyrings/fury-nushell.gpg] https://apt.fury.io/nushell/ /" | sudo tee /etc/apt/sources.list.d/fury-nushell.list
 sudo apt update
 sudo apt install nushell
 ```


### PR DESCRIPTION
`fury.list` is an example filename that comes from Gemfury's APT repo documentation. However the name is entirely too generic, and can easily conflict with other projects who also host their APT repos on Gemfury.

Making the name Nushell-specific makes it less likely that users will blow away existing Gemfury repo configurations by accident.