### PR TITLE
remove bash-env external command from docs

### DIFF
--- a/cookbook/foreign_shell_scripts.md
+++ b/cookbook/foreign_shell_scripts.md
@@ -63,19 +63,6 @@ This quickly gets tricky though, for example when the script is declaring a
 There are ways to implement some form of expansion too, but at some point it
 might make more sense to leave the parsing to the shell it was meant for.
 
-## Bash Env Plugin
-
-There is a third-party Nu plugin [bash-env](https://github.com/tesujimath/nu_plugin_bash_env)
-for importing environment variables from Bash format files and pipes.
-This plugin uses Bash itself to parse the environment definitions,
-and can therefore cope with arbitrarily complex Bash sources.
-
-::: warning
-Please note that the `bash-env` plugin is not supported by the core Nushell team.
-All issues and requests for support should be directed to its own
-[issue tracker](https://github.com/tesujimath/nu_plugin_bash_env/issues).
-:::
-
 ## Capturing the environment from a foreign shell script
 
 A more complex approach is to run the script in the shell it is written for and

--- a/cookbook/ssh_agent.md
+++ b/cookbook/ssh_agent.md
@@ -21,18 +21,6 @@ Adding this to your `env.nu` will however start a new ssh-agent process every ti
 See the workarounds.
 :::
 
-Alternatively, use the third-party Nu plugin [bash-env](https://github.com/tesujimath/nu_plugin_bash_env) as follows.
-
-```nu
-^ssh-agent | bash-env | load-env
-```
-
-::: warning
-Please note that the `bash-env` plugin is not supported by the core Nushell team.
-All issues and requests for support should be directed to its own
-[issue tracker](https://github.com/tesujimath/nu_plugin_bash_env/issues).
-:::
-
 ## Workarounds
 
 You can work around this behavior by checking if a ssh-agent is already running on your user, and start one if none is:

--- a/zh-CN/cookbook/foreign_shell_scripts.md
+++ b/zh-CN/cookbook/foreign_shell_scripts.md
@@ -50,16 +50,6 @@ print $"($env.GREETING) ($env.FROM)" # "Hello from bash"
 
 也有方法实现某种形式的扩展，但在某些时候，将其解析留给它原本为之设计的 shell 可能更有意义。
 
-## Bash Env 插件
-
-有一个第三方 Nu 插件 [bash-env](https://github.com/tesujimath/nu_plugin_bash_env)，用于从 Bash 格式的文件和管道导入环境变量。
-该插件使用 Bash 本身来解析环境定义，因此可以处理任意复杂的 Bash 源。
-
-::: warning
-请注意，`bash-env` 插件不受核心 Nushell 团队支持。
-所有问题和支持请求应直接发送到其自己的 [问题跟踪器](https://github.com/tesujimath/nu_plugin_bash_env/issues)。
-:::
-
 ## 从外部 shell 脚本捕获环境
 
 更复杂的方法是在为其编写的 shell 中运行脚本，然后进行一些黑客操作来捕获脚本的变量。

--- a/zh-CN/cookbook/ssh_agent.md
+++ b/zh-CN/cookbook/ssh_agent.md
@@ -21,17 +21,6 @@ title: ssh-agent
 请参阅解决方法。
 :::
 
-或者，使用第三方 Nu 插件 [bash-env](https://github.com/tesujimath/nu_plugin_bash_env)，如下所示。
-
-```nu
-^ssh-agent | bash-env | load-env
-```
-
-::: warning
-请注意，`bash-env` 插件不受核心 Nushell 团队支持。
-所有问题和支持请求应直接发送到他们团队自己的 [问题跟踪器](https://github.com/tesujimath/nu_plugin_bash_env/issues)。
-:::
-
 ## 解决方法
 
 你可以通过检查是否已经有 ssh-agent 在你的用户上运行来解决此行为，如果没有则启动一个：


### PR DESCRIPTION
I was looking over some of the documentation again and decided it wasn't fair to suggest using commands like bash-env that aren't supported by the nushell team.