### PR TITLE
`error_style = nested` docs

### DIFF
--- a/blog/2026-01-17-nushell_v0_110_0.md
+++ b/blog/2026-01-17-nushell_v0_110_0.md
@@ -444,9 +444,9 @@ $ ll
 Error: External command failed: Command `ll` not found (Did you mean `all`?)
 ```
 
-#### New `error_style = tree` setting
+#### New `error_style = nested` setting
 
-[#17105](https://github.com/nushell/nushell/pull/17105) adds a new `tree` option for `$env.config.error_style` to show related/nested errors.
+[#17105](https://github.com/nushell/nushell/pull/17105) adds a new `nested` option for `$env.config.error_style` to show related/nested errors.
 
 #### New `error_lines` setting
 


### PR DESCRIPTION
It appears the value was renamed, but the PR description wasn't updated: https://github.com/nushell/nushell/pull/17105/changes
