### PR TITLE
Fix `unlet` example code in 0.110.0 release notes

### DIFF
--- a/blog/2026-01-17-nushell_v0_110_0.md
+++ b/blog/2026-01-17-nushell_v0_110_0.md
@@ -92,7 +92,7 @@ To bring balance to the universe, [#17270](https://github.com/nushell/nushell/pu
 ❯ let a = 1;let b = 2;let c = 3;let d = 4
 ❯ $"($a)($b)($c)($d)"
 1234
-❯ unlet $a $b $cM
+❯ unlet $a $b $c $d
 ❯ $"($a)($b)($c)($d)"
 Error: nu::shell::variable_not_found
 


### PR DESCRIPTION
The code example is invalid. As it was, `$cM` leads to an error when calling `unlet`.

The linked pull request has the same issue.

Presumably, the example should unlet all four declared variables.
Alternatively, it could unlet three of the four variables. The code that follows would fail on referencing `$a` either way.