### PR TITLE
Drop duplicate windows ls change listing

### DIFF
--- a/blog/2026-01-17-nushell_v0_110_0.md
+++ b/blog/2026-01-17-nushell_v0_110_0.md
@@ -229,7 +229,7 @@ Examples:
 
 ## Faster `ls` on Windows [[toc](#table-of-contents)]
 
-[#17339](https://github.com/nushell/nushell/pull/17339) makes `ls` much faster on Windows.
+[#17339](https://github.com/nushell/nushell/pull/17339) makes `ls` much faster on Windows by caching and not calling `metadata()` so frequently.
 
 Before:
 
@@ -695,7 +695,6 @@ Previously, `bar` would be available to use even after `overlay hide spam`. This
 - `glob` no longer canonicalizes paths internally ([#17312](https://github.com/nushell/nushell/pull/17312))
 - Fixed the issue where "Duplicate Pane" in Windows Terminal failed when the current path contained Chinese characters by removing unnecessary URL-encoding in OSC 9;9 sequences. ([#17311](https://github.com/nushell/nushell/pull/17311))
 - Enable `detect columns` to be more robust, specifically for handling the output of tablelike structures that are created with ascii or unicode table characters like we use in nushell today. Many tools are starting to use this columnar data output so hopefully this will enable nushell to be able to parse this data better. ([#17317](https://github.com/nushell/nushell/pull/17317))
-- General speed up increase in the `ls` command by caching and not calling `metadata()` so frequently. ([#17339](https://github.com/nushell/nushell/pull/17339))
 - `input -s` will append newline when user finishes typing. ([#17298](https://github.com/nushell/nushell/pull/17298))
 - `std/help`: Add colors, proper examples, fix output ([#17010](https://github.com/nushell/nushell/pull/17010))
 - `table -i false` no longer panic when there is an index column, e.g: `[{index: 0, data: yes}] | table -i false` ([#17126](https://github.com/nushell/nushell/pull/17126))


### PR DESCRIPTION
The change has a dedicated section earlier in the content, so listing it under “other fixes” again is wrong.

I moved the more technical note up for technical context and information.