### PR TITLE
Improve code blocks with common format and output

### DIFF
--- a/blog/2026-01-17-nushell_v0_110_0.md
+++ b/blog/2026-01-17-nushell_v0_110_0.md
@@ -89,19 +89,19 @@ let files = ls | get name
 To bring balance to the universe, [#17270](https://github.com/nushell/nushell/pull/17270) introduces a new command `unlet` for deleting variables from memory.
 
 ```nu
-❯ let a = 1;let b = 2;let c = 3;let d = 4
-❯ $"($a)($b)($c)($d)"
-1234
-❯ unlet $a $b $c $d
-❯ $"($a)($b)($c)($d)"
-Error: nu::shell::variable_not_found
-
-  × Variable not found
-   ╭─[entry #21:1:4]
- 1 │ $"($a)($b)($c)($d)"
-   ·    ─┬
-   ·     ╰── variable not found
-   ╰────
+let a = 1;let b = 2;let c = 3;let d = 4
+$"($a)($b)($c)($d)"
+# => 1234
+unlet $a $b $c $d
+$"($a)($b)($c)($d)"
+# => Error: nu::shell::variable_not_found
+# => 
+# =>   × Variable not found
+# =>    ╭─[entry #21:1:4]
+# =>  1 │ $"($a)($b)($c)($d)"
+# =>    ·    ─┬
+# =>    ·     ╰── variable not found
+# =>    ╰────
 ```
 
 Accompanying this is a new `mem_size` column in the output of the `scope variables` command for showing the size of each variable in memory (implemented in [#17287](https://github.com/nushell/nushell/pull/17287)).
@@ -577,7 +577,7 @@ With [#17121](https://github.com/nushell/nushell/pull/17121), variables and envi
 
 ```nu
 $env.MY_VAR = "hello"  # First call
-$env.MY_VAR             # Second call returns "hello"
+$env.MY_VAR            # Second call returns "hello"
 ```
 
 ### Use structured response format for MCP server [[toc](#table-of-contents)]
@@ -608,6 +608,10 @@ Ranges that include a parenthesized expression will now be parsed correctly afte
 
 ```nu
 0..(1..2 | first)
+# => ╭───┬───╮
+# => │ 0 │ 0 │
+# => │ 1 │ 1 │
+# => ╰───┴───╯
 ```
 
 ### Fixed parsing issue with multiarm match + guard [[toc](#table-of-contents)]
@@ -618,6 +622,7 @@ Match statements with multiple arms and a guard expression, such as the below ex
 match 3 {
   1 | 2 | 3 if true => 'test'
 }
+# => test
 ```
 
 ### Infinite sequences can be terminated when piped to other commands [[toc](#table-of-contents)]


### PR DESCRIPTION
Follow our documentation code block guidelines. (Executable prompts and commented output.)

* Use common prompt code format for unlet example code
* Fix code example comment alignment
* Add code example output