### PR TITLE
Add attributes documentation for custom commands.

### DIFF
--- a/book/custom_commands.md
+++ b/book/custom_commands.md
@@ -939,7 +939,7 @@ A Nushell comment that continues on the same line for argument documentation pur
 
 As of version 0.103.0, Nushell allows authors of custom commands to enrich their work
 with attributes with subcommands of the `attr` builtin, prefixed by the `@` symbol
-before the defintion of the command. For those coming from Python, Java, or JavaScript, this
+before the definition of the command. For those coming from Python, Java, or JavaScript, this
 will appear similar to decorators or annotations, but serve a slightly different purpose.
 
 Let's improve the documentation for the `vip-greet` custom command. The `example`


### PR DESCRIPTION
This PR updates `/book/custom_commands.md` with a short section on utilizing attributes.

I couldn't think of a good way to incorporate the completion examples based on the section I wrote, so this could be improved in future updates. I erred on the side of minimizing examples and pointing users towards the command reference which will be more likely to remain current with the available attributes, which I assume will be extended over time.

Is there a defined "voice" or style guide for writing sections for the Nu Book? I tried to stick closely to the wording of other sections, but would appreciate more clarity on how to maintain cohesion between different authors when contributing.
