### PR TITLE
Fix `buffer_editor` example for `code`

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -20,7 +20,7 @@ can get started with just a few simple steps:
    For example:
 
    ```nu
-   $env.config.buffer_editor = "code"
+   $env.config.buffer_editor = ["code", "-w"]
    # or
    $env.config.buffer_editor = "nano"
    # or


### PR DESCRIPTION
The editor is supposed to exit only when the editing is done, and `-w` makes `code` to behave that way.

Partially addresses nushell/nushell#17536