### PR TITLE
Making the parser error explicit

### DIFF
--- a/book/thinking_in_nu.md
+++ b/book/thinking_in_nu.md
@@ -270,8 +270,8 @@ The following examples use the [`source` command](/commands/docs/source.md), but
 Consider this scenario:
 
 ```nu
-"print Hello" | save output.nu
-source output.nu
+("print Hello" | save output.nu;
+source output.nu)
 # => Error: nu::parser::sourced_file_not_found
 # =>
 # =>   × File not found


### PR DESCRIPTION
If a user typed the error as it was originally it wouldn't trigger the expected parsing error.

With this modification now the error message, appears as it is expected in the document.