### PR TITLE
Fix typo in `--experimental-options` option name in NuShell 0.111.0 release blog article

### DIFF
--- a/blog/2026-02-28-nushell_v0_111_0.md
+++ b/blog/2026-02-28-nushell_v0_111_0.md
@@ -551,7 +551,7 @@ Example:
 
 ::: important Experimental option
 This feature is behind an experimental option.
-Run Nushell with `--experimental-option=native-clip` or set before running Nushell the environment variable to `NU_EXPERIMENTAL_OPTIONS=native-clip`.
+Run Nushell with `--experimental-options=native-clip` or set before running Nushell the environment variable to `NU_EXPERIMENTAL_OPTIONS=native-clip`.
 :::
 
 Two new commands were added `clip copy` and `clip paste`. They replace the implementation of `std/clip` with a native implementation and are now built-in commands that are available all the time.
@@ -1068,7 +1068,7 @@ Note that this only occurs for _explicit_ `collect`s, and not _implicit_ collect
 
 ::: important Experimental option
 This feature is behind an experimental option.
-Run Nushell with `--experimental-option=native-clip` or set before running Nushell the environment variable to `NU_EXPERIMENTAL_OPTIONS=native-clip`.
+Run Nushell with `--experimental-options=native-clip` or set before running Nushell the environment variable to `NU_EXPERIMENTAL_OPTIONS=native-clip`.
 :::
 
 Copy nushell tables to the clipboard without ansi escape sequences.


### PR DESCRIPTION
In the NuShell 0.111.0 release blog article, there is a typo in two locations where it describes the experimental option required to enable the experimental native clipboard feature. The typo is at the command line option name `--experimental-options`. This PR fixes it.

It says:

> Run Nushell with `--experimental-option=native-clip` ...

where instead it should say:

> Run Nushell with `--experimental-options=native-clip` ...

By the way, even with the typo, the error message suggests the correct option name:

```
❯ nu --experimental-option=native-clip
Error: nu::shell::error

  × Unknown flag '--experimental-option'
  help: Did you mean '--experimental-options'?
```