### PR TITLE
Add ESC-to-clear keybind to "Coming from CMD" and "Coming from PowerShell" pages

### DIFF
--- a/book/coming_from_cmd.md
+++ b/book/coming_from_cmd.md
@@ -73,3 +73,19 @@ Executing `./ver` or `ver.bat` *will* execute the local bat file though.
 
 Note that Nushell has its own [`start` command](/commands/docs/start.md) which takes precedence.
 You can call the CMD.EXE's internal `START` command with the external command syntax `^start`.
+
+## Clearing the commandline buffer by pressing ESC
+
+CMD.EXE features the ability to clear the commandline buffer by pressing the ESC key.
+
+While Nu does not replicate this by default, a keybind can be added to your `config.nu` to enable similar functionality:
+
+```nu
+$env.config.keybindings ++= [{
+    name: 'esc_clear'
+    modifier: 'None'
+    keycode: 'Esc'
+    mode: ['Emacs', 'Vi_Normal']
+    event: {edit: 'Clear'}
+}]
+```

--- a/book/coming_from_powershell.md
+++ b/book/coming_from_powershell.md
@@ -65,3 +65,19 @@ This means:
 | `Get-Location` or `$PWD`                                          | `pwd` or `$env.PWD`                           | Show current directory                                            |
 | `Read-Host`                                                       | `let var = input`                             | Read user input                                                   |
 | `Read-Host -AsSecureString`                                       | `let secret = input -s`                       | Read secret input                                                 |
+
+## Clearing the commandline buffer by pressing ESC
+
+Legacy versions of PowerShell feature the ability to clear the commandline buffer by pressing the ESC key.
+
+While Nu does not replicate this by default, a keybind can be added to your `config.nu` to enable similar functionality:
+
+```nu
+$env.config.keybindings ++= [{
+    name: 'esc_clear'
+    modifier: 'None'
+    keycode: 'Esc'
+    mode: ['Emacs', 'Vi_Normal']
+    event: {edit: 'Clear'}
+}]
+```


### PR DESCRIPTION
Per the discussion in <https://github.com/nushell/nushell/issues/17725>.

I don't edit books for apps and crates too often, so it's possible that there may be ways to improve upon what I've written here. If you notice any, please let me know.

(P.S. Maintainers have permission to edit this branch. If there's anything you want to fix without going through me, please feel free to do so.)