### PR TITLE
Implement page search URL + Opensearch XML

### DIFF
--- a/.vuepress/client.js
+++ b/.vuepress/client.js
@@ -10,6 +10,7 @@ import BlogPosts from './components/BlogPosts.vue';
 import JumpToc from './components/JumpToc.vue';
 import PrBy from './components/PrBy.vue';
 import ReleaseToc from './components/ReleaseToc.vue';
+import URLDocSearch from './components/URLDocSearch.vue';
 
 export default defineClientConfig({
   enhance({ app }) {
@@ -18,5 +19,8 @@ export default defineClientConfig({
     app.component('JumpToc', JumpToc);
     app.component('PrBy', PrBy);
     app.component('ReleaseToc', ReleaseToc);
+
+    // Override the builtin searchbox
+    app.component('SearchBox', URLDocSearch);
   },
 });

--- a/.vuepress/components/URLDocSearch.vue
+++ b/.vuepress/components/URLDocSearch.vue
@@ -1,5 +1,5 @@
 <template>
-  <DocSearch :options="docsearchOptions" />
+  <DocSearch />
 </template>
 
 <script setup lang="ts">
@@ -18,7 +18,6 @@ const SEARCH_INPUT_ID = 'docsearch-input';
 const router = useRouter();
 const route = useRoute();
 
-const docsearchOptions = ref<DocSearchOptions>({});
 const inputElement = ref<HTMLInputElement>();
 const isNavigating = ref(false);
 

--- a/.vuepress/components/URLDocSearch.vue
+++ b/.vuepress/components/URLDocSearch.vue
@@ -1,0 +1,46 @@
+<template>
+  <DocSearch :options="docsearchOptions" />
+</template>
+
+<script setup lang="ts">
+import { DocSearch } from '@vuepress/plugin-docsearch/client';
+import { useDebounceFn, useEventListener } from '@vueuse/core';
+import { onMounted, onUnmounted, ref } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+
+const SEARCH_KEY = 'search';
+const docsearchOptions = ref({});
+const router = useRouter();
+const route = useRoute();
+
+// Handle initial search query, if one is set
+onMounted(() => {
+  const query = new URL(window.location.href).searchParams.get(SEARCH_KEY);
+  if (query) {
+    docsearchOptions.value.initialQuery = query;
+    document.querySelector('.DocSearch-Button').click();
+  }
+});
+
+// There's some debounce builtin to docsearch, this mimics that and should
+// help prevent browser history from getting filled with partial queries.
+const inputHandler = useDebounceFn(handleSearchInput, 500);
+useEventListener('input', inputHandler);
+
+// Update the URL bar when the search input changes.
+function handleSearchInput(event) {
+  const searchQuery = event.target.value;
+
+  if (event.target.id !== 'docsearch-input' || !searchQuery) {
+    return;
+  }
+
+  // If we had already started a search, replace it instead of appending
+  const { path, query: routeQuery } = route;
+  const replace = routeQuery?.hasOwnProperty(SEARCH_KEY);
+  const query = { ...routeQuery }; // NOTE: must copy the query object
+  query[SEARCH_KEY] = searchQuery;
+
+  router.push({ path, query: { ...query }, replace });
+}
+</script>

--- a/.vuepress/components/URLDocSearch.vue
+++ b/.vuepress/components/URLDocSearch.vue
@@ -4,43 +4,101 @@
 
 <script setup lang="ts">
 import { DocSearch, DocSearchOptions } from '@vuepress/plugin-docsearch/client';
-import { useDebounceFn, useEventListener } from '@vueuse/core';
-import { onMounted, Ref, ref } from 'vue';
+import {
+  useDebounceFn,
+  useElementVisibility,
+  useEventListener,
+} from '@vueuse/core';
+import { onMounted, ref, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 
 const SEARCH_KEY = 'search';
-const docsearchOptions: Ref<DocSearchOptions> = ref({});
+const SEARCH_INPUT_ID = 'docsearch-input';
+
 const router = useRouter();
 const route = useRoute();
 
+const docsearchOptions = ref<DocSearchOptions>({});
+const inputElement = ref<HTMLInputElement>();
+const isNavigating = ref(false);
+
 // Handle initial search query, if one is set
-onMounted(() => {
+onMounted(async () => {
   const query = new URL(window.location.href).searchParams.get(SEARCH_KEY);
   if (query) {
-    docsearchOptions.value.initialQuery = query;
     (document.querySelector('.DocSearch-Button') as HTMLButtonElement).click();
+    // Set value in the input element once it appears
+    performInitialQuery(query);
   }
 });
 
+function performInitialQuery(query: string) {
+  const found = document.getElementById(SEARCH_INPUT_ID);
+  if (found) {
+    inputElement.value = found as HTMLInputElement;
+    inputElement.value.value = query;
+    inputElement.value.dispatchEvent(new Event('input'));
+  } else {
+    setTimeout(() => performInitialQuery(query), 50);
+  }
+}
+
 // There's some debounce builtin to docsearch, this mimics that and should
 // help prevent browser history from getting filled with partial queries.
-const inputHandler = useDebounceFn(handleSearchInput, 500);
-useEventListener('input', (event) => inputHandler(event as InputEvent));
+const setURLQueryDebounced = useDebounceFn(setURLQuery, 500);
 
-// Update the URL bar when the search input changes.
-function handleSearchInput(event: InputEvent) {
+// When the user types a search query, update URL query param accordingly
+useEventListener('input', (event) => {
   const target = event.target as HTMLInputElement | undefined;
   const searchQuery = target?.value;
-  if (target?.id !== 'docsearch-input' || !searchQuery) {
+  if (target?.id !== SEARCH_INPUT_ID) {
     return;
   }
+  inputElement.value = target;
+  setURLQueryDebounced(searchQuery);
+});
 
-  // If we had already started a search, replace it instead of appending
-  const { path, query: routeQuery } = route;
-  const replace = routeQuery?.hasOwnProperty(SEARCH_KEY);
-  const query = { ...routeQuery }; // NOTE: must copy the query object
-  query[SEARCH_KEY] = searchQuery;
+// Clear the URL query param when search input is reset (i.e. "Clear" button).
+useEventListener('reset', (event) => {
+  const target = event.target as HTMLFormElement | undefined;
+  if (target?.classList.contains('DocSearch-Form')) {
+    setURLQuery();
+  }
+});
 
-  router.push({ path, query: { ...query }, replace });
+// Clear the URL query param when the search modal is dismissed.
+// NOTE: newer versions of @docsearch/js also provide a callback option for this.
+const inputIsVisible = useElementVisibility(inputElement);
+watch(inputIsVisible, (isVisible, wasVisible) => {
+  if (wasVisible && !isVisible && !isNavigating.value) {
+    setURLQuery();
+  }
+});
+
+// When a search result is selected, the modal is dismissed and its route is pushed, without `?search=`.
+// Track this to avoid running visibility watch logic to clear the URL in this case.
+router.beforeEach((route) => {
+  if (!route.query[SEARCH_KEY]) {
+    isNavigating.value = true;
+  }
+});
+router.afterEach(() => {
+  isNavigating.value = false;
+});
+
+// Set `?search=` query param; if passed empty string or undefined, clear the param instead.
+function setURLQuery(newSearch?: string) {
+  const { path, query: oldQuery, hash } = route;
+  const { [SEARCH_KEY]: oldSearch, ...query } = oldQuery;
+
+  // Replace the history entry if the only the search query changed, to avoid
+  // polluting the user's browser history with partial/incomplete search queries.
+  const replace = oldSearch !== undefined || newSearch === undefined;
+
+  if (newSearch) {
+    query[SEARCH_KEY] = newSearch;
+  }
+
+  router.push({ path, query, hash, replace });
 }
 </script>

--- a/.vuepress/components/URLDocSearch.vue
+++ b/.vuepress/components/URLDocSearch.vue
@@ -3,13 +3,13 @@
 </template>
 
 <script setup lang="ts">
-import { DocSearch } from '@vuepress/plugin-docsearch/client';
+import { DocSearch, DocSearchOptions } from '@vuepress/plugin-docsearch/client';
 import { useDebounceFn, useEventListener } from '@vueuse/core';
-import { onMounted, onUnmounted, ref } from 'vue';
+import { onMounted, Ref, ref } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 
 const SEARCH_KEY = 'search';
-const docsearchOptions = ref({});
+const docsearchOptions: Ref<DocSearchOptions> = ref({});
 const router = useRouter();
 const route = useRoute();
 
@@ -18,20 +18,20 @@ onMounted(() => {
   const query = new URL(window.location.href).searchParams.get(SEARCH_KEY);
   if (query) {
     docsearchOptions.value.initialQuery = query;
-    document.querySelector('.DocSearch-Button').click();
+    (document.querySelector('.DocSearch-Button') as HTMLButtonElement).click();
   }
 });
 
 // There's some debounce builtin to docsearch, this mimics that and should
 // help prevent browser history from getting filled with partial queries.
 const inputHandler = useDebounceFn(handleSearchInput, 500);
-useEventListener('input', inputHandler);
+useEventListener('input', (event) => inputHandler(event as InputEvent));
 
 // Update the URL bar when the search input changes.
-function handleSearchInput(event) {
-  const searchQuery = event.target.value;
-
-  if (event.target.id !== 'docsearch-input' || !searchQuery) {
+function handleSearchInput(event: InputEvent) {
+  const target = event.target as HTMLInputElement | undefined;
+  const searchQuery = target?.value;
+  if (target?.id !== 'docsearch-input' || !searchQuery) {
     return;
   }
 

--- a/.vuepress/components/URLDocSearch.vue
+++ b/.vuepress/components/URLDocSearch.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { DocSearch, DocSearchOptions } from '@vuepress/plugin-docsearch/client';
+import { DocSearch } from '@vuepress/plugin-docsearch/client';
 import {
   useDebounceFn,
   useElementVisibility,
@@ -22,10 +22,13 @@ const inputElement = ref<HTMLInputElement>();
 const isNavigating = ref(false);
 
 // Handle initial search query, if one is set
-onMounted(async () => {
+onMounted(() => {
   const query = new URL(window.location.href).searchParams.get(SEARCH_KEY);
   if (query) {
-    (document.querySelector('.DocSearch-Button') as HTMLButtonElement).click();
+    const button =
+      document.querySelector<HTMLButtonElement>('.DocSearch-Button');
+    if (!button) return;
+    button.click();
     // Set value in the input element once it appears
     performInitialQuery(query);
   }

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -110,6 +110,15 @@ export default defineUserConfig({
       { name: 'apple-mobile-web-app-status-bar-style', content: 'black' },
     ],
     ['link', { rel: 'icon', href: '/icon.png' }],
+    [
+      'link',
+      {
+        rel: 'search',
+        type: 'application/opensearchdescription+xml',
+        title: 'Nushell Docs', // NOTE: must match ShortName
+        href: '/opensearch.xml',
+      },
+    ],
   ],
   markdown: {
     importCode: {

--- a/.vuepress/public/opensearch.xml
+++ b/.vuepress/public/opensearch.xml
@@ -1,0 +1,12 @@
+<OpenSearchDescription
+  xmlns="http://a9.com/-/spec/opensearch/1.1/"
+  xmlns:moz="http://www.mozilla.org/2006/browser/search/"
+>
+  <ShortName>Nushell Docs</ShortName>
+  <Description>Search Nushell documentation</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/png">https://www.nushell.sh/icon.png</Image>
+  <Url type="text/html" template="https://www.nushell.sh/?search={searchTerms}" />
+  <Url type="application/opensearchdescription+xml" rel="self" template="https://www.nushell.sh/opensearch.xml" />
+  <!-- TODO: it might be possible to provide suggestions via some Algolia API? -->
+</OpenSearchDescription>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vuepress/plugin-shiki": "2.0.0-rc.118",
     "@vuepress/plugin-sitemap": "2.0.0-rc.118",
     "@vuepress/theme-default": "2.0.0-rc.118",
+    "@vueuse/core": "^14.0.0",
     "asciinema-player": "^3.15.1",
     "cross-env": "^10.1.0",
     "lefthook": "1.8.2",


### PR DESCRIPTION
Closes #1093 

I tend to create a lot of [shortcuts to doc searches](https://kb.mozillazine.org/Using_keyword_searches) in my browser, so I wanted the same thing for Nushell! I decided to take a crack at implementing the search URL logic I've seen used by many other docs websites.

https://github.com/user-attachments/assets/fc48510c-64a7-4645-83b7-ac123e76d5a1


Also set up [Opensearch XML](https://developer.mozilla.org/en-US/docs/Web/XML/Guides/OpenSearch#overview) so some browsers can more easily add a search engine:

<img width="291" height="249" alt="image" src="https://github.com/user-attachments/assets/b36085fd-c621-4b8b-8451-d1eb0dacd8c0" />


## Implementation

- Wrap the `DocSearch` component provided by the `docsearchPlugin`, and override its registration with our custom component

In the new `URLDocSearch` component:

- Prefill and execute search when a page loads with the `search` param set, at `onMounted`

- Add an `input` event handler, which updates the URL bar when the search bar is updated. Use a 500ms debounce to avoid flooding the user's browser history with partial searches