### PR TITLE
doc: change filesize unit tip to warning for clarity

### DIFF
--- a/lang-guide/chapters/types/basic_types/filesize.md
+++ b/lang-guide/chapters/types/basic_types/filesize.md
@@ -26,7 +26,7 @@ The full list of `filesize` units is:
 | `EB`: exabytes           | `EiB`: exbibytes        |
 
 ::: warning
-File size units are case-insensitive. E.g., `1KiB`, `1kib`, and `1Kib` are all equivalent.
+File size units are case-insensitive. E.g., `1KiB`, `1kib`, and `1Kib` are all equivalent. Do not confuse it with bit!
 :::
 
 ## Common commands that can work with `filesizes`

--- a/lang-guide/chapters/types/basic_types/filesize.md
+++ b/lang-guide/chapters/types/basic_types/filesize.md
@@ -25,7 +25,7 @@ The full list of `filesize` units is:
 | `PB`: petabytes          | `PiB`: pebibytes        |
 | `EB`: exabytes           | `EiB`: exbibytes        |
 
-::: tip
+::: warning
 File size units are case-insensitive. E.g., `1KiB`, `1kib`, and `1Kib` are all equivalent.
 :::
 


### PR DESCRIPTION
Change from tip to warning to highlight potential pitfall: case does not distinguish between bits and bytes.