### PR TITLE
Update `metadata set` example of the book

### DIFF
--- a/book/metadata.md
+++ b/book/metadata.md
@@ -40,7 +40,7 @@ The span "start" and "end" here refer to where the underline will be in the line
 
 ## Custom Metadata
 
-You can attach arbitrary metadata to pipeline data using the [`metadata set`](/commands/docs/metadata_set.md) command with the `--merge` flag:
+You can attach arbitrary metadata to pipeline data using the [`metadata set`](/commands/docs/metadata_set.md) command with the optional closure parameter:
 
 ```nu
 "data" | metadata set { merge {custom_key: "custom_value"} }

--- a/book/metadata.md
+++ b/book/metadata.md
@@ -43,7 +43,7 @@ The span "start" and "end" here refer to where the underline will be in the line
 You can attach arbitrary metadata to pipeline data using the [`metadata set`](/commands/docs/metadata_set.md) command with the `--merge` flag:
 
 ```nu
-"data" | metadata set --merge {custom_key: "custom_value"}
+"data" | metadata set { merge {custom_key: "custom_value"} }
 ```
 
 ## HTTP Response Metadata

--- a/book/special_variables.md
+++ b/book/special_variables.md
@@ -26,7 +26,7 @@ The `$nu` constant is a record containing several useful values:
 - `cache-dir`: A directory for non-essential (cached) data.
 - `vendor-autoload-dirs`: A list of directories where third-party applications should install configuration files that will be auto-loaded during startup.
 - `user-autoload-dirs`: A list of directories where the user may create additional configuration files which will be auto-loaded during startup.
-- `temp-dir`: A path for temporary files that should be writeable by the user.
+- `temp-dir`: A path for temporary files that should be writable by the user.
 - `pid`: The PID of the currently running Nushell process.
 - `os-info`: Information about the host operating system.
 - `startup-time`: The amount of time (in duration) that it took for Nushell to start and process all configuration files.


### PR DESCRIPTION
Also the commands page `metadata set` is also outdated. Not sure how to update them. Are they synced up using a script?