### PR TITLE
fix: keychain command

### DIFF
--- a/cookbook/ssh_agent.md
+++ b/cookbook/ssh_agent.md
@@ -58,10 +58,9 @@ do --env {
 keychain --eval --quiet <your ssh keys, eg. id_ed25519>
     | lines
     | where not ($it | is-empty)
-    | parse "{k}={v}; export {k2};"
-    | select k v
-    | transpose --header-row
-    | into record
+    | parse "{k}={v};{_}"
+    | transpose --header-row -d
+    | str trim -c "\""
     | load-env
 ```
 


### PR DESCRIPTION
The keychain command provided in the doc has a wrong pattern for matching environment variables output by "keychain --eval", there is an extra ";" at the end and the socket path was still in quotes.