### PR TITLE
support extracting nu code snippets into standalone .nu files for better downstream trackability

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -6,6 +6,7 @@ import { shikiPlugin } from '@vuepress/plugin-shiki';
 import { defaultTheme } from '@vuepress/theme-default';
 import { sitemapPlugin } from '@vuepress/plugin-sitemap';
 import { docsearchPlugin } from '@vuepress/plugin-docsearch';
+import { markdownIncludePlugin } from '@vuepress/plugin-markdown-include';
 
 import {
   navbarDe,
@@ -211,6 +212,7 @@ export default defineUserConfig({
   plugins: [
     // Note: gitPlugin, backToTopPlugin, mediumZoomPlugin, and copyCodePlugin
     // are already included in defaultTheme, so we don't need to add them here
+    markdownIncludePlugin({}),
     shikiPlugin({
       themes: {
         light: 'dark-plus',

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,8 @@ ls | where type == file | sort-by -r size | first 5
 
 The preferred form for consistency is `` ```nu ``.
 
+If the snippet is a reusable block that readers might want to source directly and track over time, save it as a sibling `.nu` file and include it inside the fence with `<!-- @include: ./example.nu -->` (see `cookbook/direnv.md` for an example).
+
 ## Translation Guide
 
 Follow the steps above for each group of translations.

--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -27,21 +27,7 @@ The direnv configuration below requires Nushell 0.104 or later.
 :::
 
 ```nu
-use std/config *
-
-# Initialize the PWD hook as an empty list if it doesn't exist
-$env.config.hooks.env_change.PWD = $env.config.hooks.env_change.PWD? | default []
-
-$env.config.hooks.env_change.PWD ++= [{||
-  if (which direnv | is-empty) {
-    # If direnv isn't installed, do nothing
-    return
-  }
-
-  direnv export json | from json | default {} | load-env
-  # If direnv changes the PATH, it will become a string and we need to re-convert it to a list
-  $env.PATH = do (env-conversions).path.from_string $env.PATH
-}]
+<!-- @include: ./direnv.nu -->
 ```
 
 As with other configuration changes, this can be made permanent by adding it to your startup [configuration](/book/configuration.md).

--- a/cookbook/direnv.nu
+++ b/cookbook/direnv.nu
@@ -1,0 +1,15 @@
+use std/config *
+
+# Initialize the PWD hook as an empty list if it doesn't exist
+$env.config.hooks.env_change.PWD = $env.config.hooks.env_change.PWD? | default []
+
+$env.config.hooks.env_change.PWD ++= [{||
+  if (which direnv | is-empty) {
+    # If direnv isn't installed, do nothing
+    return
+  }
+
+  direnv export json | from json | default {} | load-env
+  # If direnv changes the PATH, it will become a string and we need to re-convert it to a list
+  $env.PATH = do (env-conversions).path.from_string $env.PATH
+}]

--- a/cookbook/ssh_agent.md
+++ b/cookbook/ssh_agent.md
@@ -26,30 +26,7 @@ See the workarounds.
 You can work around this behavior by checking if a ssh-agent is already running on your user, and start one if none is:
 
 ```nu
-do --env {
-    let ssh_agent_file = (
-        $nu.temp-dir | path join $"ssh-agent-(whoami).nuon"
-    )
-
-    if ($ssh_agent_file | path exists) {
-        let ssh_agent_env = open ($ssh_agent_file)
-        if ($"/proc/($ssh_agent_env.SSH_AGENT_PID)" | path exists) {
-            load-env $ssh_agent_env
-            return
-        } else {
-            rm $ssh_agent_file
-        }
-    }
-
-    let ssh_agent_env = ^ssh-agent -c
-        | lines
-        | first 2
-        | parse "setenv {name} {value};"
-        | transpose --header-row
-        | into record
-    load-env $ssh_agent_env
-    $ssh_agent_env | save --force $ssh_agent_file
-}
+<!-- @include: ./ssh_agent_workaround.nu -->
 ```
 
 ### [Keychain](https://www.funtoo.org/Funtoo:Keychain)

--- a/cookbook/ssh_agent_workaround.nu
+++ b/cookbook/ssh_agent_workaround.nu
@@ -1,0 +1,24 @@
+do --env {
+    let ssh_agent_file = (
+        $nu.temp-dir | path join $"ssh-agent-(whoami).nuon"
+    )
+
+    if ($ssh_agent_file | path exists) {
+        let ssh_agent_env = open ($ssh_agent_file)
+        if ($"/proc/($ssh_agent_env.SSH_AGENT_PID)" | path exists) {
+            load-env $ssh_agent_env
+            return
+        } else {
+            rm $ssh_agent_file
+        }
+    }
+
+    let ssh_agent_env = ^ssh-agent -c
+        | lines
+        | first 2
+        | parse "setenv {name} {value};"
+        | transpose --header-row
+        | into record
+    load-env $ssh_agent_env
+    $ssh_agent_env | save --force $ssh_agent_file
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@vuepress/bundler-vite": "2.0.0-rc.26",
         "@vuepress/plugin-docsearch": "2.0.0-rc.118",
         "@vuepress/plugin-feed": "2.0.0-rc.118",
+        "@vuepress/plugin-markdown-include": "^2.0.0-rc.118",
         "@vuepress/plugin-shiki": "2.0.0-rc.118",
         "@vuepress/plugin-sitemap": "2.0.0-rc.118",
         "@vuepress/theme-default": "2.0.0-rc.118",
@@ -1108,6 +1109,47 @@
       "version": "0.22.2",
       "resolved": "https://registry.npmjs.org/@mdit/plugin-container/-/plugin-container-0.22.2.tgz",
       "integrity": "sha512-QBBti5EyQzVl/qzFAD9YAhiAB9S2zF/4MPAS4kwm7VkmeYrcj2HpZpA7snMjnWh3CtriDcaIMInhg0vDtDwyfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "markdown-it": "^14.1.0"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mdit/plugin-include": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-include/-/plugin-include-0.22.4.tgz",
+      "integrity": "sha512-nMzPD+Jc15DVRHewjE4wa7+XswM5Un6ku+OtWocmrcvgCfZO0NjGLf3dmnv9DoTVhTglZvBb9cPYGLTJkEmbzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "0.22.2",
+        "@types/markdown-it": "^14.1.2",
+        "upath": "^2.0.1"
+      },
+      "peerDependencies": {
+        "markdown-it": "^14.1.0"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mdit/plugin-include/node_modules/@mdit/helper": {
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-0.22.2.tgz",
+      "integrity": "sha512-i0mmN0S/BwR7zAKs9TnT9knmMVq3WGDJ3wO9PiETs0vUAwtcXIq5J0k8GAtGgKKTb7WTQuc19yt8uVQGVYfr2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2551,6 +2593,21 @@
         "@types/markdown-it": "^14.1.2",
         "@vuepress/helper": "2.0.0-rc.118",
         "@vueuse/core": "^14.0.0"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.26"
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-include": {
+      "version": "2.0.0-rc.118",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-include/-/plugin-markdown-include-2.0.0-rc.118.tgz",
+      "integrity": "sha512-YGd5mTMRYJQUoq/+pEU+736+fMOG3oQQB5juX+rlsup/w89B7Crk4o/jdJIvncMzoEWGkX1yaWNmAyZdk+AEAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/plugin-include": "^0.22.2",
+        "@types/markdown-it": "^14.1.2",
+        "@vuepress/helper": "2.0.0-rc.118"
       },
       "peerDependencies": {
         "vuepress": "2.0.0-rc.26"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@vuepress/bundler-vite": "2.0.0-rc.26",
     "@vuepress/plugin-docsearch": "2.0.0-rc.118",
     "@vuepress/plugin-feed": "2.0.0-rc.118",
+    "@vuepress/plugin-markdown-include": "2.0.0-rc.118",
     "@vuepress/plugin-shiki": "2.0.0-rc.118",
     "@vuepress/plugin-sitemap": "2.0.0-rc.118",
     "@vuepress/theme-default": "2.0.0-rc.118",


### PR DESCRIPTION
There are many useful recipes that exist in the cookbook and there is no way to track them directly in a script-friendly way (markdown file parsing is not ideal obviously).

This PR adds support for useful standalone code snippets (e.g. snippets that someone might want to put in their `autoload/` dir) to be extracted out into their own .nu files so it can remain the source of truth for the cookbook while also being programmatically fetch-able.

Note: this PR uses the lightweight @vuepress/plugin-markdown-include plugin which is an official VuePress plugin from the same @vuepress/* family already used in this repo