### PR TITLE
Document the percent sigil

### DIFF
--- a/book/aliases.md
+++ b/book/aliases.md
@@ -125,3 +125,12 @@ def ls [
     ) | sort-by type name -i
 }
 ```
+
+To call the underlying built-in command you can use a percent sigil `%`, e.g. 
+```nu
+def ls [] {
+    "something else"
+}
+
+%ls # <- calls the original ls
+```

--- a/lang-guide/chapters/strings_and_text.md
+++ b/lang-guide/chapters/strings_and_text.md
@@ -44,7 +44,10 @@ The percent sigin `%` can be used to call the built-in command (without argument
 
 ```nu
 let cmd = "ls"
+# call internal `ls` command
 %$cmd
+# call external `ls` command
+^$cmd
 ```
 
 ## String Quoting

--- a/lang-guide/chapters/strings_and_text.md
+++ b/lang-guide/chapters/strings_and_text.md
@@ -40,6 +40,13 @@ let arguments = ["arg1", "-a", "arg2"]
 
 The caret `^` before the string interpolation symbol `$` allows that external command to be executed.
 
+The percent sigin `%` can be used to call the built-in command (without arguments).
+
+```nu
+let cmd = "ls"
+%$cmd
+```
+
 ## String Quoting
 
 ### Double quotes


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell.github.io/issues/2166

Is the example too convoluted? Maybe just
```nu
let cmd = "is-empty"
[ 1 ] | %$cmd
```
?