### PR TITLE
Fix fileop anchor links

### DIFF
--- a/blog/2026-05-23-nushell_v0_113_0.md
+++ b/blog/2026-05-23-nushell_v0_113_0.md
@@ -62,7 +62,7 @@ mv -v before.txt after.txt | get 0.message
 rm -v missing.txt existing.txt | where deleted == false
 ```
 
-Read more about `mkdir`/`mv` [here](#mkdir--v-now-returns-a-table) and `rm` [here](#rm--v-returns-structured-data).
+Read more about `mkdir`/`mv` [here](#mkdir-v-now-returns-a-table) and `rm` [here](#rm-v-returns-structured-data).
 
 ## Markdown, now with less AST noise <JumpToc/>
 


### PR DESCRIPTION
The highlights section links to mkdir and rm had wrong anchor targets.