### PR TITLE
FIX: Nushell + Starship example updated to work with latest Nu syntax

### DIFF
--- a/cookbook/setup.md
+++ b/cookbook/setup.md
@@ -106,7 +106,7 @@ currently activated.
 ```nu
 # set NU_OVERLAYS with overlay list, useful for starship prompt
 $env.config.hooks.pre_prompt = ($env.config.hooks.pre_prompt | append {||
-  let overlays = overlay list | slice 1..
+  let overlays = overlay list | where ($it.active == true) | slice 1.. | each {|overlay| $overlay.name }
   if not ($overlays | is-empty) {
     $env.NU_OVERLAYS = $overlays | str join ", "
   } else {


### PR DESCRIPTION
The Nushell overlays + Starship prompt example required changes to work properly with the latest version of Nushell.

The recommended fix has been tested and now works properly.