### PR TITLE
Update 0.114 release notes for structured MCP output

### DIFF
--- a/blog/2026-07-04-nushell_v0_114_0.md
+++ b/blog/2026-07-04-nushell_v0_114_0.md
@@ -1474,7 +1474,6 @@ In addition, this globbing engine seems to perform faster than the existing engi
 - Fixed `plugin list --help` to show the correct output type and example for the `commands` column, which contains each plugin command's name and description. ([#18357](https://github.com/nushell/nushell/pull/18357))
 - Added some `@attr`s to the toolkit.nu commands so that they show up in category, search-terms, and examples. I also homogenized help casing and punctuation. ([#18350](https://github.com/nushell/nushell/pull/18350))
 - Added support for feature gating LSP functionality, specifically enable it via `--features lsp`. ([#18148](https://github.com/nushell/nushell/pull/18148))
-- Improved the MCP `evaluate` tool response: evaluation outputs NUON directly instead of wrapping everything as a string. Successful and error responses are also available as MCP `structuredContent` JSON for clients that support structured tool output. ([#18499](https://github.com/nushell/nushell/pull/18499))
 - `http post`/`put`/`patch`/`delete` now respects `--content-type` for JSON-variant MIME types like `application/json-patch+json`. ([#18496](https://github.com/nushell/nushell/pull/18496))
 
 ## Bug fixes <JumpToc/>
@@ -1673,9 +1672,9 @@ w:
 </div>
 </div>
 
-### Reduced escaping in `nu-mcp` evaluation output <JumpToc/> <PrBy :pr="18260" user="fdncred" />
+### Structured `nu-mcp` evaluation output <JumpToc/> <PrBy :pr="18499" user="Alb-O" />
 
-Reduce the amount of escaping that nu-mcp does by using raw-strings.
+The MCP `evaluate` tool keeps evaluated Nushell values structured in `output`, so output data is fully unescaped instead of a wrapped string. Successful and error responses are also mirrored as MCP `structuredContent` JSON for clients that support structured tool output.
 
 ```json :no-line-numbers title="Before"
 {
@@ -1701,9 +1700,18 @@ Reduce the amount of escaping that nu-mcp does by using raw-strings.
     "content": [
       {
         "type": "text",
-        "text": "{cwd:/Users/fdncred/src/nushell,history_index:0,timestamp:2026-05-21T15:20:18.004016+00:00,output:r#'[\n  {\n    \"name\": \"assets\",\n    \"type\": \"dir\",\n    \"size\": 160,\n    \"modified\": \"2024-09-14T07:06:47.316979108-05:00\"\n  },\n  {\n    \"name\": \"ast-grep\",\n    \"type\": \"dir\",\n    \"size\": 160,\n    \"modified\": \"2026-01-07T06:22:12.488582817-06:00\"\n  },\n  {\n    \"name\": \"benches\",\n    \"type\": \"dir\",\n    \"size\": 128,\n    \"modified\": \"2026-05-21T08:31:29.486599444-05:00\"\n  }\n]'#}"
+        "text": "{cwd:/Users/fdncred/src/nushell,history_index:0,timestamp:2026-06-30T06:52:27.000000+00:00,output:{a:1,b:[2,3]}}"
       }
     ],
+    "structuredContent": {
+      "cwd": "/Users/fdncred/src/nushell",
+      "history_index": 0,
+      "timestamp": "2026-06-30T06:52:27.000000+00:00",
+      "output": {
+        "a": 1,
+        "b": [2, 3]
+      }
+    },
     "isError": false
   }
 }


### PR DESCRIPTION
Replace the highlighted nu-mcp escaping note by fdncred with the structured evaluate output change from [#18499](https://github.com/nushell/nushell/pull/18499) which supersedes it