### PR TITLE
Improve v0.114.0 release post text

### DIFF
--- a/blog/2026-07-04-nushell_v0_114_0.md
+++ b/blog/2026-07-04-nushell_v0_114_0.md
@@ -91,7 +91,7 @@ foo bar      # valid
 foo sub baz  # invalid, `sub` is not implicitly imported
 ```
 
-To have your modules keep the old behavior, you will need to export the modules contents explicitly:
+To have your modules keep the old behavior, you will need to export the module's contents explicitly:
 
 ```nushell
 export module foo {
@@ -118,7 +118,7 @@ Thus, explicit `use`s as recommended above will not run `export-env` blocks, whi
 
 ### Type System Improvements <JumpToc/> <PrBy :pr="18430" user="Bahex" />
 
-This release comes with a handful of improvements to the type system, specifically the parse time type checking. But beware! Type annotations that previously seemed fine might raise errors, as they might have been passing only because typing information was insufficient to check it at parse time.
+This release comes with a handful of improvements to the type system, specifically the parse-time type checking. But beware! Type annotations that previously seemed fine might raise errors, as they might have been passing only because typing information was insufficient to check it at parse time.
 
 #### Commands' output types are now inferred based on pipeline input type.
 
@@ -197,16 +197,16 @@ let list = [["a" "b" "c"] [1 2 3]]
 let elem = $list.0
 ```
 
-Previously `$elem`'s type would be `list<oneof<int, string>>`, now `$elem`'s type is `oneof<list<int>, list<string>>`.
+Previously, `$elem`'s type would be `list<oneof<int, string>>`, now `$elem`'s type is `oneof<list<int>, list<string>>`.
 
-#### Operator type checking now accounts of `oneof` types
+#### Operator type checking now accounts for `oneof` types
 
-Nushell as language tries to strike a careful balance between correctness and convenience.
-One should be able to trust nu's type system will help them write correct and robust scripts, but nu shouldn't shouldn't get in the way of a nice REPL experience.
+Nushell as a language tries to strike a careful balance between correctness and convenience.
+One should be able to trust nu's type system will help them write correct and robust scripts, but nu shouldn't get in the way of a nice REPL experience.
 
 Because of that, some operations that might be invalid but aren't definitely so do not raise parse errors and such checks are delegated to runtime.
 
-For example `int`'s can only be added with `int`'s and `float`'s, yet the following code does not raise parse time error.
+For example, `int`'s can only be added with `int`'s and `float`'s, yet the following code does not raise a parse-time error.
 
 ```nushell
 def foo [anything: any] {
@@ -214,7 +214,7 @@ def foo [anything: any] {
 }
 ```
 
-But previously, despite being `oneof<int, nothing>` being specific than `any`, would be rejected by the type checker for addition to `int`s.
+But previously, despite `oneof<int, nothing>` being more specific than `any`, it would be rejected by the type checker for addition to `int`s.
 
 ```nushell
 def foo [maybe_int: oneof<int, nothing>] {
@@ -236,13 +236,13 @@ Error: [31mnu::parser::operator_unsupported_type
    ╰────[m
 ```
 
-Now, as long as the two operands have a possibility of being valid for an operation the parse time type checker will accept the expression, leaving errors to runtime type checking.
+Now, as long as the two operands have a possibility of being valid for an operation the parse-time type checker will accept the expression, leaving errors to runtime type checking.
 
 ### Promoted `enforce-runtime-annotations` to opt-out <JumpToc/> <PrBy :pr="18359" user="Bahex" />
 
 In Nushell 0.108.0, [`enforce-runtime-annotations`](https://www.nushell.sh/blog/2025-10-15-nushell_v0_108_0.html#enforce-assignment-type-annotations-at-runtime-16079-toc) experimental option was added. With this release `enforce-runtime-annotations` is promoted to being opt-out, meaning that by default this experimental option is enabled now.
 
-This option enforces type checking of let assignments at runtime, catching type errors that might have been missed in parse time type checking due to insufficient type information.
+This option enforces type checking of let assignments at runtime, catching type errors that might have been missed in parse-time type checking due to insufficient type information.
 
 If you experience any trouble with this, you can disable it via the command-line argument:
 
@@ -274,11 +274,11 @@ This release comes with various improvements to `from xlsx` and `from ods` comma
 These commands' signatures previously incorrectly indicated that they return tables.
 They return _records_ that contain _tables_, with a table for each sheet in the file.
 
-Also, signature of the `from ods` command previously had `string` as its input type rather than `binary`. This has been fixed.
+Also, the signature of the `from ods` command previously had `string` as its input type rather than `binary`. This has been fixed.
 
 #### Support for more data types
 
-Previously importing `datetime` values were supported only for `xlsx` files.
+Previously, importing `datetime` values were supported only for `xlsx` files.
 
 This release not only adds that for `ods` files as well, but also broadens the `datetime` formats that can be imported.
 
@@ -292,7 +292,7 @@ This release removes it.
 
 Don't worry! Instead of the `--header-row` flag, `from xlsx` _and_ `from ods` get two new flags that will provide finer control over how spreadsheets are imported:
 
-- `--noheaders`: What it says on the tin, identical to same flag on `from csv`, `from tsv` and `from ssv` commands.
+- `--noheaders`: What it says on the tin, identical to the same flag on `from csv`, `from tsv` and `from ssv` commands.
 - `--first-row`: This is where it gets a little interesting. `from xlsx` and `from ods` skip reading all leading empty rows. This is how it has worked for a long time.
   `--first-row=0` allows you to turn that off and keep those empty lines. It can also be used to start reading from an arbitrary row: `--first-row $n`
 
@@ -389,7 +389,7 @@ Error: [31mnu::parser::operator_incompatible_types[0m
 
 #### Better type inference of `let` bindings
 
-`let` bindings in the middle of a pipeline, or at the end of it, are now properly typed based ont the pipeline input type.
+`let` bindings in the middle of a pipeline, or at the end of it, are now properly typed based on the pipeline input type.
 
 You can observe this using `scope variables`:
 
@@ -564,18 +564,18 @@ Error: [31mnu::shell::error
 ╰─────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────╯[0m
 ```
 
-With these file relative spans, making external tools for reporting nushell errors should be much easier.
+With these file-relative spans, making external tools for reporting nushell errors should be much easier.
 
 ### Removed deprecated `grid` record input support <JumpToc/> <PrBy :pr="18276" user="Juhan280" />
 
-In the last release, `grid` command was modified to accept a column name argument rather than implicitly displaying the `name` column. The implicit assumption of `name` was deprecated, along with accepting a single record rather than a table.
-These deprecated behaviors of `grid` command is removed with this release.
+In the last release, the `grid` command was modified to accept a column name argument rather than implicitly displaying the `name` column. The implicit assumption of `name` was deprecated, along with accepting a single record rather than a table.
+These deprecated behaviors of the `grid` command are removed with this release.
 
 ```nushell
-# This will no longer work.
+# This will no longer work
 { name: test } | grid
 
-# And should be updated to receive tables and include the column name as an argument.
+# …and should be updated to receive tables and include the column name as an argument
 [{ name: test }] | grid name
 ```
 
@@ -593,7 +593,7 @@ This is a breaking change.
 
 Previously `iter scan` always needed an initial value to start off of (equivalent to `reduce`'s `--fold`), and to compensate for it a `--noinit` flag to remove that initial value from the output.
 
-Now it's signature is identical to `reduce`:
+Now its signature is identical to `reduce`:
 
 <div style="max-width: 100%; overflow: auto;">
 <div style="display: grid; grid-template-columns: auto 1fr 1fr; column-gap: 1rem; justify-items: stretch; align-items: center">
@@ -660,7 +660,7 @@ The following commands now stream:
   - `select column-slices`
   - `reject column-slices`
 
-These commands don't really "stream", in that they don't return a stream. Instead they now avoid eagerly collecting input streams:
+These commands don't really "stream", in that they don't return a stream. Instead, they now avoid eagerly collecting input streams:
 
 - `std-rfc/conversions`
   - `name-values`: strictly an internal change with possible performance benefits
@@ -945,9 +945,9 @@ Introducing polars bitwise commands:
 - `polars math bitwise-trailing-zeros` - Compute the number of trailing unset bits for each element in an integer column expression.
 - `polars math bitwise-xor` - Perform an aggregation of bitwise XORs over a column expression.
 
-### Add non UTF-8 text support for `url encode`/`url decode` <JumpToc/> <PrBy :pr="18314" user="Bahex" />
+### Add non-UTF-8 text support for `url encode`/`url decode` <JumpToc/> <PrBy :pr="18314" user="Bahex" />
 
-- `url encode` can now encode binary input too, adding support for encoding non UTF-8 texts
+- `url encode` can now encode binary input too, adding support for encoding non-UTF-8 texts
 
   ```ansi
   [38;5;14m> [32m'£ rates'[39m [1m[35m|[22m[39m [1m[36mencode[22m[39m [32miso-8859-1[39m [1m[35m|[22m[39m [1m[36murl encode[22m[39m
@@ -1355,7 +1355,7 @@ This has no effect on non-whole floats.
 - Added completions to `ansi gradient`'s `--fgnamed` and `--bgnamed` flags. ([#18342](https://github.com/nushell/nushell/pull/18342))
 - `nu-highlight` now clears `content_type` metadata ([#18266](https://github.com/nushell/nushell/pull/18266))
 - Keybinding `edit` events now support reedline's verb-based edit commands (`move`, `extend`, `cut`, `copy`, `change`, `erase`) combined with a `motion` and its parameters, enabling vi-style operator/motion keybindings to be expressed directly in config. The new commands and their fields are discoverable via `keybindings list`. ([#18396](https://github.com/nushell/nushell/pull/18396))
-- The http commands now use the response body as error message when getting an error response. ([#18387](https://github.com/nushell/nushell/pull/18387))
+- The `http` commands now use the response body as error message when getting an error response. ([#18387](https://github.com/nushell/nushell/pull/18387))
 - If the `NU_EXPERIMENTAL_OPTIONS` environment variable is set, it will be used when running nushell with the `--login` or `--execute` flags since they also load config. ([#18392](https://github.com/nushell/nushell/pull/18392))
 - Refactor commands that use sqlite pushdown so that it's easier to add other pushdown filters. ([#18398](https://github.com/nushell/nushell/pull/18398))
 - Added common navigation shortcuts to `explore config` command: `hl` to collapse/expand, and `jk`/`ctrl+p/n` to go up and down. ([#18440](https://github.com/nushell/nushell/pull/18440))
@@ -1372,7 +1372,7 @@ Deprecated `str downcase`, using it shows a warning recommending `str lowercase`
 
 ### Other deprecations <JumpToc/>
 
-- Removed the deprecated `use std/clip` `copy` and `paste` commands, they are now called `copy52` and `paste52` for the ones that use the terminal `OSC 52`, or you can use `clip copy` and `clip paste` from the experimental option `native-clip` that access the system clipboard directly. ([#18403](https://github.com/nushell/nushell/pull/18403))
+- Removed the deprecated `use std/clip` `copy` and `paste` commands; they are now called `copy52` and `paste52` for the ones that use the terminal `OSC 52`, or you can use `clip copy` and `clip paste` from the experimental option `native-clip` that access the system clipboard directly. ([#18403](https://github.com/nushell/nushell/pull/18403))
 
 ## Other changes <JumpToc/>
 
@@ -1455,7 +1455,7 @@ Providing the metadata will cause the `table` command to render the output diffe
 
 - `polar implode` now supports the flag `--maintain-order`
 - `polars is-in` now supports the flag `--maintain-order`
-- `polars pivot` not supports the flag `--always-combine-names`
+- `polars pivot` now supports the flag `--always-combine-names`
 - `polars replace` requires a `--default <value>` parameter when used with `--strict` and `--return-dtype` if the dtype has changed from the original dtype
 
 ### New experimental globbing engine <JumpToc/> <PrBy :pr="18109" user="fdncred" />
@@ -1463,16 +1463,16 @@ Providing the metadata will cause the `table` command to render the output diffe
 <ExperimentalOption option="dc-glob" />
 
 This release introduces a new experimental feature named `dc-glob` (named for Devyn Cairn's glob).
-Currently nushell has two separate globbing engines with varying features and platform support.
+Currently, Nushell has two separate globbing engines with varying features and platform support.
 
-This engine is intended to replace the existing globbing engines, and standardize on something that works well on all platforms.
+This engine is intended to replace the existing globbing engines and standardize on something that works well on all platforms.
 In addition, this globbing engine seems to perform faster than the existing engines.
 
 ### Additional changes <JumpToc/>
 
-- "Command not found" error messages will now suggest full command from a category if you type just its ending, for example `sqrt` will suggest `math sqrt`. ([#18498](https://github.com/nushell/nushell/pull/18498))
+- "Command not found" error messages will now suggest the full command from a category if you type just its ending; for example, `sqrt` will suggest `math sqrt`. ([#18498](https://github.com/nushell/nushell/pull/18498))
 - Fixed `plugin list --help` to show the correct output type and example for the `commands` column, which contains each plugin command's name and description. ([#18357](https://github.com/nushell/nushell/pull/18357))
-- Added some `@attr`s to the toolkit.nu commands so that they show up in category, search-terms, and examples. I also homogenized help casing and punctuation. ([#18350](https://github.com/nushell/nushell/pull/18350))
+- Added some `@attr`s to the `toolkit.nu` commands so that they show up in category, search terms, and examples. I also homogenized help casing and punctuation. ([#18350](https://github.com/nushell/nushell/pull/18350))
 - Added support for feature gating LSP functionality, specifically enable it via `--features lsp`. ([#18148](https://github.com/nushell/nushell/pull/18148))
 - `http post`/`put`/`patch`/`delete` now respects `--content-type` for JSON-variant MIME types like `application/json-patch+json`. ([#18496](https://github.com/nushell/nushell/pull/18496))
 
@@ -1495,7 +1495,7 @@ Update the `idx` fff-search dependency and fix bugs.
 - changed output to nushell values for commands that return tables
 - updated some help strings to be more helpful
 
-Files are ignored during indexing due to the use of the `ignore` crate. These are the rules for ignore https://docs.rs/ignore/latest/ignore/struct.WalkBuilder.html#ignore-rules. There's no way to override this in the current version.
+Files are ignored during indexing due to the use of the `ignore` crate. These are the rules for ignore <https://docs.rs/ignore/latest/ignore/struct.WalkBuilder.html#ignore-rules>. There's no way to override this in the current version.
 
 ### Subcommand completions are now wrapped in quotes for `which` <JumpToc/> <PrBy :pr="18295" user="Mrfiregem" />
 
@@ -1535,7 +1535,7 @@ Tab completions for `which` and `attr complete`/`@complete` commands will now pr
 
 ### Fix nested update closure for table columns <JumpToc/> <PrBy :pr="18205" user="fdncred" />
 
-This fixes a bug where update with a nested column path and closure (for example `rss_item.pubDate`) could evaluate the closure against a projected list and write the same result back to every row.
+This fixes a bug where `update` with a nested column path and closure (for example `rss_item.pubDate`) could evaluate the closure against a projected list and write the same result back to every row.
 
 <div style="max-width: 100%; overflow-x: auto;">
 <div style="display: grid; grid-template-columns: 1fr 1fr; column-gap: 2rem;">
@@ -1729,7 +1729,7 @@ Now Nushell reports clear messages such as "negative index is not supported in c
 
 #### `oneof<..., table>`
 
-In some specific cases the parser could reject values provided to `oneof` typed parameters, such as rejecting table literal syntax for `oneof<.., table>`:
+In some specific cases, the parser could reject values provided to `oneof` typed parameters, such as rejecting table literal syntax for `oneof<.., table>`:
 
 ```ansi :no-line-numbers
 [38;5;14m> [1m[36mdef[22m[39m [32mcmd[39m [1m[32m[--flag: oneof<record, table>][22m[39m [1m[32m{}[22m[38;5;14m
@@ -1749,7 +1749,7 @@ The parser no longer considers such code invalid.
 
 #### `oneof<..., closure>`
 
-Arguments of type `oneof<..., closure>`, could only be parsed as closures if they had a parameter list (`{|| }`).
+Arguments of type `oneof<..., closure>` could only be parsed as closures if they had a parameter list (`{|| }`).
 
 ```ansi :no-line-numbers
 [38;5;14m> [1m[36mdef[22m[39m [32mcmd[39m [1m[32m[--flag: oneof<list, closure>][22m[39m [1m[32m{}[22m[38;5;14m
@@ -1848,7 +1848,7 @@ Float ranges without an explicit step now use more natural fractional steps, so 
 
 ### Fixed stor open return type <JumpToc/> <PrBy :pr="18355" user="Bahex" />
 
-`stor open` returns the custom value `SQLiteDatabase`, yet it's signature had `sqlite-in-memory` as the return type. This causes problems with the `enforce-runtime-annotations` experimental option:
+`stor open` returns the custom value `SQLiteDatabase`, yet its signature had `sqlite-in-memory` as the return type. This causes problems with the `enforce-runtime-annotations` experimental option:
 
 ```ansi :no-line-numbers
 [38;5;14m> [1m[36mlet[22m[39m [35mdb[39m = [1m[36mstor open[22m[39m
@@ -1950,7 +1950,7 @@ Fixed a bug with how `--` was handled with `--wrapped` custom commands. Now you 
 
 ### Improved Ctrl-C handling in `from json` <JumpToc/> <PrBy :pr="18414" user="fdncred" />
 
-Ctrl+C is more responsive in `from json`, `from kdl`, and `from xml` now respond promptly to Ctrl+C when parsing large files. Pressing Ctrl+C during parsing will interrupt the command and return to the prompt. It will also produce better parse-error messages and should now show a focused snippet of the source around the error location instead of dumping the entire file content.
+Ctrl+C is more responsive in `from json`, `from kdl`, and `from xml`. They now respond promptly to Ctrl+C when parsing large files. Pressing Ctrl+C during parsing will interrupt the command and return to the prompt. It will also produce better parse-error messages and should now show a focused snippet of the source around the error location instead of dumping the entire file content.
 
 ### Improved conflicting column names in `flatten` <JumpToc/> <PrBy :pr="18407" user="WindSoilder" />
 


### PR DESCRIPTION
Various improvements; fixed typos, grammar, code fencing, etc

All small text adjustments that either do not change meaning or fix confusing wording.