### PR TITLE
Fix path type code demonstration

### DIFF
--- a/lang-guide/chapters/types/other_types/path.md
+++ b/lang-guide/chapters/types/other_types/path.md
@@ -12,7 +12,7 @@
 
 1. `path` is technically a "syntax shape" rather than a full "type".
    It is used for annotating strings that should be treated as a path to a filename or directory.
-   `~` and `.` characters in the string will automatically be expanded treated as a `path`.
+   `~` and `...` characters in the string will automatically be expanded treated as a `path`.
 
    Example:
 
@@ -27,9 +27,6 @@
 
    # Results
    cd ~/testing
-   show_difference . .
-   # => The path is expanded: /home/username/testing
-   # => The string is not: .
    show_difference ~ ~
    # => The path is expanded: /home/username
    # => The string is not: ~


### PR DESCRIPTION
`.` does not get expanded

tested in current 0.114.0 and reported in #2155 for 0.112.2

Resolves #2155

On Windows `...` gets expanded to `..\..`. I have not tested on Linux, so I leave the `...` example as-is.