### PR TITLE
Fix pubDate not being added to RSS entries

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -279,6 +279,9 @@ export default defineUserConfig({
           frontmatter.feed === true || filePathRelative?.indexOf('blog/') >= 0
         );
       },
+      getter: {
+        publishDate: (page) => new Date(page.date),
+      },
       sorter: (a, b) => {
         const pathDateA = new Date(
           a.path.replace('/blog/', '').substring(0, 10),


### PR DESCRIPTION
Resolves #2103. I went for the simplest possible fix which just uses the parsed date from the file name; since this lacks an actual time, the RSS feed shows new entries as being published at midnight. A more granular fix would be somewhat hacky (e.g. parsing the Git commit metadata on a per-file basis, or requiring that article writers specify `date` in the frontmatter), so I'd just leave it as-is for now.

Confirmed with:
```nu
def getTitlePubDate [] {
  $in | get content.content.0
      | where tag == "item"
      | each {|it|
          {
            title: ($it.content | where tag == "title" | first 1 | get content.0.content.0)
            pubDate: ($it.content | where tag == "pubDate" | first 1 | get content.0.content.0)
          }
        } | first 3 | to md 
}
```
Running `open .vuepress/dist/rss.xml | getTitlePubDate`:

| title | pubDate |
| --- | --- |
| Nushell 0.114.1 | Sat, 11 Jul 2026 00:00:00 GMT |
| Nushell 0.114.0 | Sat, 04 Jul 2026 00:00:00 GMT |
| This week in Nushell #356 | Fri, 19 Jun 2026 00:00:00 GMT |