### PR TITLE
Fix incorrect update date overriding publish date in Atom feed

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -281,6 +281,7 @@ export default defineUserConfig({
       },
       getter: {
         publishDate: (page) => new Date(page.date),
+        lastUpdateDate: (page) => new Date(page.date),
       },
       sorter: (a, b) => {
         const pathDateA = new Date(


### PR DESCRIPTION
Addendum to #2206. While that fix did correctly set `pubDate` in RSS feeds, it didn't set the `update` property for Atom entries, only `published`, which is not used by feeds for ordering.