### PR TITLE
convert the direnv export PATH to a list before loading it into env

### DIFF
--- a/cookbook/direnv.md
+++ b/cookbook/direnv.md
@@ -38,9 +38,10 @@ $env.config.hooks.env_change.PWD ++= [{||
     return
   }
 
-  direnv export json | from json | default {} | load-env
-  # If direnv changes the PATH, it will become a string and we need to re-convert it to a list
-  $env.PATH = do (env-conversions).path.from_string $env.PATH
+  direnv export json | from json | default {} | update cells --columns [ PATH ] {
+    # If direnv changes the PATH, it will become a string and we need to re-convert it to a list
+    do (env-conversions).path.from_string $in
+  } | load-env
 }]
 ```
 


### PR DESCRIPTION
I think it's cleaner to never load it into the env as a string in the first place