### PR TITLE
Fix to yaml examples 0115

### DIFF
--- a/blog/2026-08-15-nushell_v0_115_0.md
+++ b/blog/2026-08-15-nushell_v0_115_0.md
@@ -128,7 +128,7 @@ Tags also mean tags now. Previously, tagged scalars weren't really handled prope
 {|| $in } | to yaml
 # Error: closures are not round-trippable through YAML
 
-{|| $in } | to yaml --non-roundtrip null
+{|| $in } | to yaml --non-roundtrip "null"
 # => null
 
 {|| $in } | to yaml --serialize
@@ -251,7 +251,7 @@ For example, `--quote` and `--indent` can help when another tool expects a parti
 
 ```yaml
 outer:
-  inner: 'value'
+    inner: "value"
 ```
 
 ### Disallowed shadowing parser keywords <JumpToc/> <PrBy :pr="18662" user="fdncred" />


### PR DESCRIPTION
Fix two to yaml examples in the 0.115.0 release notes
Both snippets do not match what Nushell 0.115.0 actually does.

`--non-roundtrip` takes a string, so a bare `null` is parsed as the
`null` literal and the line fails to parse:

    Error: nu::parser::parse_mismatch_with_full_string_msg
      x Parse mismatch: expected string.

Quoting it makes the example run and print `null` as documented.

The `--indent 4 --quote double` example showed output with 2-space
indentation and single quotes. The real output on 0.115.0 is:

    outer:
        inner: "value"

which is also what the two flags are there to demonstrate.
