### PR TITLE
docs: refer to bashisms tutorial in blog

### DIFF
--- a/blog/2024-05-15-bashisms.md
+++ b/blog/2024-05-15-bashisms.md
@@ -29,3 +29,12 @@ In reedline we support these bashisms.
 #### How to invoke bang bang syntax
 
 In nushell when you type a bang command, it performs that functionality and places the result in the nushell command line buffer in the repl. It does not execute it.
+
+### Bashisms tutorial
+
+See the Bashisms tutorial for the supported bashisms and how to use them.
+You can access the tutorial directly in Nushell using:
+
+```nushell
+tutor bashisms
+```


### PR DESCRIPTION
## Description

Updates the Bashisms blog post to refer readers to the new Bashisms tutorial introduced in <https://github.com/nushell/nushell/pull/18903>.

<img width="899" height="784" alt="image" src="https://github.com/user-attachments/assets/c72f8bff-6e9f-482a-bd69-afc1bb2e6097" />

No other blog content has been changed.

## Validation

* Verified the Markdown formatting.

## Additional Notes

- related: <https://github.com/nushell/nushell/issues/7698>