### PR TITLE
docs: fix a/an article errors

### DIFF
--- a/book/background_jobs.md
+++ b/book/background_jobs.md
@@ -10,7 +10,7 @@ Nushell currently has experimental support for thread-based background jobs.
 ## Spawning Jobs
 
 Jobs can be spawned using [`job spawn`](/commands/docs/job_spawn.md), which receives a closure and starts its execution in a background thread, returning
-an unique integer id for the spawned job:
+a unique integer id for the spawned job:
 
 ```nu
 'i am' | save status.txt

--- a/book/dataframes.md
+++ b/book/dataframes.md
@@ -61,7 +61,7 @@ polars store-ls | select key type columns rows estimated_size
 ```
 
 ::: tip
-As of nushell 0.97, `polars open` will open as a lazy dataframe instead of a eager dataframe.
+As of nushell 0.97, `polars open` will open as a lazy dataframe instead of an eager dataframe.
 To open as an eager dataframe, use the `--eager` flag.
 :::
 
@@ -1119,7 +1119,7 @@ This list may be outdated. To get the up-to-date command list, see [Dataframe](/
 | polars drop-duplicates | dataframe             | Drops duplicate values in dataframe.                                                             |                         |
 | polars drop-nulls      | dataframe             | Drops null values in dataframe.                                                                  |                         |
 | polars dummies         | dataframe             | Creates a new dataframe with dummy variables.                                                    |                         |
-| polars explode         | expression, dataframe | Explodes a dataframe or creates a explode expression.                                            |                         |
+| polars explode         | expression, dataframe | Explodes a dataframe or creates an explode expression.                                            |                         |
 | polars expr-not        | expression            | Creates a not expression.                                                                        |                         |
 | polars fetch           | dataframe             | Collects the lazyframe to the selected rows.                                                     |                         |
 | polars fill-nan        | dataframe             | Replaces NaN values with the given expression.                                                   |                         |

--- a/cookbook/modules.md
+++ b/cookbook/modules.md
@@ -125,4 +125,4 @@ This kind of overlaying environments can be used to scope more elaborate virtual
 
 Tools like conda or Python virtualenv manage and isolate sets of environment variables.
 The [official virtualenv integration](https://github.com/pypa/virtualenv/blob/main/src/virtualenv/activation/nushell/activate.nu) makes use of these concepts.
-And our nu_scripts repository has a an [unofficial Conda module](https://github.com/nushell/nu_scripts/tree/main/modules/virtual_environments).
+And our nu_scripts repository has an [unofficial Conda module](https://github.com/nushell/nu_scripts/tree/main/modules/virtual_environments).

--- a/cookbook/ssh_agent.md
+++ b/cookbook/ssh_agent.md
@@ -66,7 +66,7 @@ keychain --eval --quiet <your ssh keys, eg. id_ed25519>
 
 ## Non-nushell workarounds
 
-However, the commonly recommended approach involves running an ssh-agent so it establishes an user-wide socket for processes to connect to.
+However, the commonly recommended approach involves running an ssh-agent so it establishes a user-wide socket for processes to connect to.
 
 Here are two common ways to achieve this.
 


### PR DESCRIPTION
This fixes five `a`/`an` article errors in hand-written pages. The auto-generated `commands/` pages and the translations are untouched.

| File | Before | After |
| --- | --- | --- |
| `book/dataframes.md` | instead of **a** eager dataframe | **an** eager dataframe |
| `book/dataframes.md` | creates **a** explode expression | creates **an** explode expression |
| `book/background_jobs.md` | returning **an** unique integer id | **a** unique integer id |
| `cookbook/ssh_agent.md` | establishes **an** user-wide socket | **a** user-wide socket |
| `cookbook/modules.md` | has **a an** unofficial Conda module | has **an** unofficial Conda module |

The edits are text-only, no links, headings, or code are touched. In `dataframes.md` the next line already reads "an eager dataframe", and "user"/"unique" take "a" because they begin with a consonant sound. The existing "an ssh-agent" on the same `ssh_agent.md` line is correct and left as is.
