### PR TITLE
docs: fix broken heading anchors

### DIFF
--- a/book/coming_from_bash.md
+++ b/book/coming_from_bash.md
@@ -97,7 +97,7 @@ $env.Path = ($env.Path | prepend 'C:\Program Files\Git\usr\bin')
 | (Emacs Mode) <kbd>Ctrl</kbd>+<kbd>X</kbd><kbd>Ctrl</kbd>+<kbd>E</kbd> | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd> | Edit the command-line in the editor defined by `$env.EDITOR`   |
 | (Vi Command Mode) <kbd>V</kbd>       | <kbd>Ctrl/Cmd</kbd>+<kbd>O</kbd>                              | Edit the command-line in the editor defined by `$env.EDITOR`       |
 
-Most common Emacs-mode and Vi-mode keybindings are also available. See the [Reedline Chapter](line_editor.html#editing-mode).
+Most common Emacs-mode and Vi-mode keybindings are also available. See the [Reedline Chapter](line_editor.html#setting-the-editing-mode).
 
 ::: tip
 In Bash, history substitution occurs immediately after pressing <kbd>Enter</kbd> 

--- a/book/control_flow.md
+++ b/book/control_flow.md
@@ -162,7 +162,7 @@ While it may be tempting to use loops if you're familiar with them in other lang
 
 The biggest downside of loops is that they are statements, unlike [`each`](/commands/docs/each.html) which is an expression. Expressions, like [`each`](/commands/docs/each.html) always result in some output value, however statements do not.
 
-This means that they don't work well with immutable variables and using immutable variables is considered a more [Nushell-style](/book/thinking_in_nu.html#variables-are-immutable). Without a mutable variable declared beforehand in the example in the previous section, it would be impossible to use [`for`](/commands/docs/each.html) to get the list of numbers with incremented numbers, or any value at all.
+This means that they don't work well with immutable variables and using immutable variables is considered a more [Nushell-style](/book/thinking_in_nu.html#variables-are-immutable-by-default). Without a mutable variable declared beforehand in the example in the previous section, it would be impossible to use [`for`](/commands/docs/each.html) to get the list of numbers with incremented numbers, or any value at all.
 
 Statements also don't work in Nushell pipelines which require some output. In fact Nushell will give an error if you try:
 

--- a/book/navigating_structured_data.md
+++ b/book/navigating_structured_data.md
@@ -17,7 +17,7 @@ Given Nushell's strong support for structured data, some of the more common task
   - Example - `get` vs. `select` with a Table Row
   - Example - `select` with multiple rows and columns
 - [Handling missing data using the optional operator](#the-optional-operator)
-- [Key/Column names with spaces](#keycolumn-names-with-spaces)
+- [Key/Column names with spaces](#key-column-names-with-spaces)
 - [Other commands for navigating structured data](#other-commands-for-accessing-structured-data)
 
 ## Background

--- a/lang-guide/chapters/types/basic_types/float.md
+++ b/lang-guide/chapters/types/basic_types/float.md
@@ -6,7 +6,7 @@
 | **_Annotation:_**     | `float`                                                                          |
 | **_Literal syntax:_** | A decimal numeric value including a decimal place. E.g., `1.5`, `2.0`, `-15.333` |
 | **_Casts:_**          | [`into float`](/commands/docs/into_float.md)                                     |
-| **_See also:_**       | [Types of Data - Floats](/book/types_of_data.md#floatsdecimals)                  |
+| **_See also:_**       | [Types of Data - Floats](/book/types_of_data.md#floats-decimals)                  |
 
 ## Additional language notes
 

--- a/lang-guide/chapters/types/basic_types/string.md
+++ b/lang-guide/chapters/types/basic_types/string.md
@@ -7,7 +7,7 @@
 | **_Literal Syntax:_** | See [Working with strings](/book/working_with_strings.md)    |
 | **_Casts:_**          | [`into string`](/commands/docs/into_string.md)               |
 | **_See also:_**       | [Handling Strings](/book/loading_data.md#handling-strings)   |
-|                       | [Types of Data - String](/book/types_of_data.md#textstrings) |
+|                       | [Types of Data - String](/book/types_of_data.md#text-strings) |
 
 ## Language Notes:
 


### PR DESCRIPTION
Five internal links point at heading anchors that do not exist, so they land at the top of the page instead of the intended section. Each target below was confirmed against the deployed site.

| File | Link anchor | Target heading | Correct anchor |
| --- | --- | --- | --- |
| `book/navigating_structured_data.md` | `#keycolumn-names-with-spaces` | `## Key/Column names with spaces` | `#key-column-names-with-spaces` |
| `lang-guide/.../basic_types/float.md` | `#floatsdecimals` | `### Floats/Decimals` | `#floats-decimals` |
| `lang-guide/.../basic_types/string.md` | `#textstrings` | `### Text/Strings` | `#text-strings` |
| `book/control_flow.md` | `#variables-are-immutable` | `## Variables are Immutable by Default` | `#variables-are-immutable-by-default` |
| `book/coming_from_bash.md` | `#editing-mode` | `## Setting the Editing Mode` | `#setting-the-editing-mode` |

The first three are slug mismatches: a heading with a `/` produces a `-` in the generated slug (for example `Key/Column` becomes `key-column`), but the link dropped that dash. The last two point at headings that were later renamed. Each target page has exactly one matching section, so the intended destination is unambiguous.
